### PR TITLE
feat: add clipboard awareness — read, write, and save

### DIFF
--- a/src/api/routes/awareness.ts
+++ b/src/api/routes/awareness.ts
@@ -86,7 +86,7 @@ export function registerAwarenessRoutes(router: Router, ctx: RouteContext): void
 
       const clickCount = activityEntries.filter(e => e.type === 'click').length;
       const formEvents = streamEvents.filter(e => e.type === 'form-submit');
-      const inputEvents = activityEntries.filter(e => e.type === 'input');
+      const _inputEvents = activityEntries.filter(e => e.type === 'input');
 
       // Text selections from activity
       const textSelections = activityEntries

--- a/src/api/routes/clipboard.ts
+++ b/src/api/routes/clipboard.ts
@@ -63,11 +63,7 @@ export function registerClipboardRoutes(router: Router, ctx: RouteContext): void
       const quality = typeof rawQuality === 'number' && rawQuality >= 1 && rawQuality <= 100
         ? rawQuality
         : undefined;
-      // Validate directory — must be string, sanitization happens in ClipboardManager via resolvePathInAllowedRoots
-      const rawDir = req.body.directory;
-      const directory = typeof rawDir === 'string' && rawDir.length > 0 ? rawDir : undefined;
-
-      const result = ctx.clipboardManager.saveAs({ filename, format, quality, directory });
+      const result = ctx.clipboardManager.saveAs({ filename, format, quality });
       res.json({ ok: true, path: result.path, size: result.size });
     } catch (e) {
       handleRouteError(res, e);

--- a/src/api/routes/clipboard.ts
+++ b/src/api/routes/clipboard.ts
@@ -47,11 +47,26 @@ export function registerClipboardRoutes(router: Router, ctx: RouteContext): void
   // ═══ POST /clipboard/save — Save clipboard content as file ═══
   router.post('/clipboard/save', (req: Request, res: Response) => {
     try {
-      const { filename, format, quality, directory } = req.body;
+      const { filename } = req.body;
       if (typeof filename !== 'string' || !filename) {
         res.status(400).json({ error: 'filename is required (string)' });
         return;
       }
+      // Validate format — only allow known safe values
+      const VALID_FORMATS = ['png', 'jpg', 'txt'] as const;
+      const rawFormat = req.body.format;
+      const format = typeof rawFormat === 'string' && VALID_FORMATS.includes(rawFormat as typeof VALID_FORMATS[number])
+        ? rawFormat as 'png' | 'jpg' | 'txt'
+        : undefined;
+      // Validate quality — must be number in range
+      const rawQuality = req.body.quality;
+      const quality = typeof rawQuality === 'number' && rawQuality >= 1 && rawQuality <= 100
+        ? rawQuality
+        : undefined;
+      // Validate directory — must be string, sanitization happens in ClipboardManager via resolvePathInAllowedRoots
+      const rawDir = req.body.directory;
+      const directory = typeof rawDir === 'string' && rawDir.length > 0 ? rawDir : undefined;
+
       const result = ctx.clipboardManager.saveAs({ filename, format, quality, directory });
       res.json({ ok: true, path: result.path, size: result.size });
     } catch (e) {

--- a/src/api/routes/clipboard.ts
+++ b/src/api/routes/clipboard.ts
@@ -1,0 +1,61 @@
+import type { Router, Request, Response } from 'express';
+import type { RouteContext } from '../context';
+import { handleRouteError } from '../../utils/errors';
+
+export function registerClipboardRoutes(router: Router, ctx: RouteContext): void {
+
+  // ═══ GET /clipboard — Read clipboard content ═══
+  router.get('/clipboard', (_req: Request, res: Response) => {
+    try {
+      const content = ctx.clipboardManager.read();
+      res.json(content);
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+
+  // ═══ POST /clipboard/text — Write text to clipboard ═══
+  router.post('/clipboard/text', (req: Request, res: Response) => {
+    try {
+      const { text } = req.body;
+      if (typeof text !== 'string') {
+        res.status(400).json({ error: 'text is required (string)' });
+        return;
+      }
+      ctx.clipboardManager.writeText(text);
+      res.json({ ok: true });
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+
+  // ═══ POST /clipboard/image — Write image to clipboard ═══
+  router.post('/clipboard/image', (req: Request, res: Response) => {
+    try {
+      const { base64 } = req.body;
+      if (typeof base64 !== 'string') {
+        res.status(400).json({ error: 'base64 is required (string)' });
+        return;
+      }
+      ctx.clipboardManager.writeImage(base64);
+      res.json({ ok: true });
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+
+  // ═══ POST /clipboard/save — Save clipboard content as file ═══
+  router.post('/clipboard/save', (req: Request, res: Response) => {
+    try {
+      const { filename, format, quality, directory } = req.body;
+      if (typeof filename !== 'string' || !filename) {
+        res.status(400).json({ error: 'filename is required (string)' });
+        return;
+      }
+      const result = ctx.clipboardManager.saveAs({ filename, format, quality, directory });
+      res.json({ ok: true, path: result.path, size: result.size });
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+}

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -28,6 +28,7 @@ import { registerSyncRoutes } from './routes/sync';
 import { registerPinboardRoutes } from './routes/pinboards';
 import { registerPreviewRoutes } from './routes/previews';
 import { registerAwarenessRoutes } from './routes/awareness';
+import { registerClipboardRoutes } from './routes/clipboard';
 import { registerSecurityRoutes } from '../security/routes';
 import { nmProxy, TRUSTED_EXTENSION_PROXY_PATHS } from '../extensions/nm-proxy';
 import type { ExtensionRouteAccessDecision } from '../extensions/manager';
@@ -429,6 +430,7 @@ export class TandemAPI {
     registerPinboardRoutes(router, ctx);
     registerPreviewRoutes(router, ctx);
     registerAwarenessRoutes(router, ctx);
+    registerClipboardRoutes(router, ctx);
 
     // Native messaging proxy: route extension connectNative/sendNativeMessage
     // through Tandem's API since Electron 40 doesn't support them natively.

--- a/src/api/tests/helpers.ts
+++ b/src/api/tests/helpers.ts
@@ -526,6 +526,14 @@ export function createMockContext(): RouteContext {
       reorderItems: vi.fn().mockReturnValue(true),
       destroy: vi.fn(),
     } as any,
+
+    // ── clipboardManager ────────────────────────
+    clipboardManager: {
+      read: vi.fn().mockReturnValue({ hasText: false, hasImage: false, hasHTML: false, formats: [] }),
+      writeText: vi.fn(),
+      writeImage: vi.fn(),
+      saveAs: vi.fn().mockReturnValue({ path: '/tmp/test.png', size: 1024 }),
+    } as any,
   };
 
   return ctx;

--- a/src/bootstrap/runtime.ts
+++ b/src/bootstrap/runtime.ts
@@ -50,6 +50,7 @@ import { HeadlessManager } from '../headless/manager';
 import { BehaviorObserver } from '../behavior/observer';
 import { WorkflowEngine } from '../workflow/engine';
 import { WorkspaceManager } from '../workspaces/manager';
+import { ClipboardManager } from '../clipboard/manager';
 import { DEFAULT_PARTITION } from '../utils/constants';
 import type { RuntimeManagers } from './types';
 
@@ -174,6 +175,7 @@ export async function initializeRuntimeManagers(opts: InitializeRuntimeOptions):
   runtime.contentExtractor = new ContentExtractor();
   runtime.workflowEngine = new WorkflowEngine();
   runtime.loginManager = new LoginManager();
+  runtime.clipboardManager = new ClipboardManager();
   runtime.sessionRestoreManager = new SessionRestoreManager(runtime.syncManager);
 
   runtime.workspaceManager.setMainWindow(win);
@@ -315,6 +317,7 @@ export function createManagerRegistry(runtime: RuntimeManagers): ManagerRegistry
     syncManager: runtime.syncManager,
     pinboardManager: runtime.pinboardManager,
     googlePhotosManager: runtime.googlePhotosManager,
+    clipboardManager: runtime.clipboardManager,
   };
 }
 

--- a/src/bootstrap/types.ts
+++ b/src/bootstrap/types.ts
@@ -43,6 +43,7 @@ import type { SessionRestoreManager } from '../session/restore';
 import type { ContentExtractor } from '../content/extractor';
 import type { WorkflowEngine } from '../workflow/engine';
 import type { LoginManager } from '../auth/login-manager';
+import type { ClipboardManager } from '../clipboard/manager';
 import type { GooglePhotosManager } from '../integrations/google-photos';
 
 export interface RuntimeManagers {
@@ -92,6 +93,7 @@ export interface RuntimeManagers {
   workflowEngine: WorkflowEngine;
   loginManager: LoginManager;
   googlePhotosManager: GooglePhotosManager;
+  clipboardManager: ClipboardManager;
 }
 
 export interface PendingTabRegister {

--- a/src/clipboard/manager.ts
+++ b/src/clipboard/manager.ts
@@ -2,19 +2,14 @@ import path from 'path';
 import os from 'os';
 import fs from 'fs';
 import { clipboard, nativeImage } from 'electron';
-import { resolvePathInAllowedRoots } from '../utils/security';
+// No user-controlled paths — save directory is a compile-time constant
 import { createLogger } from '../utils/logger';
 
 const log = createLogger('ClipboardManager');
 
 const MAX_IMAGE_BYTES = 10 * 1024 * 1024; // 10 MB
 
-const ALLOWED_SAVE_ROOTS = [
-  path.join(os.homedir(), 'Desktop'),
-  path.join(os.homedir(), 'Downloads'),
-  path.join(os.homedir(), '.tandem'),
-  path.join(os.homedir(), 'Pictures', 'Tandem'),
-];
+// Save directory is fixed — no user-controlled paths to prevent path injection
 
 const DEFAULT_SAVE_DIR = path.join(os.homedir(), 'Pictures', 'Tandem', 'clipboard');
 
@@ -39,7 +34,6 @@ export interface ClipboardSaveOptions {
   filename: string;
   format?: 'png' | 'jpg' | 'txt';
   quality?: number;
-  directory?: string;
 }
 
 export interface ClipboardSaveResult {
@@ -114,18 +108,13 @@ export class ClipboardManager {
       throw new Error('Invalid filename: must be a simple filename without path separators');
     }
 
-    // Sanitize directory — resolve to an allowed root, default to safe location
-    const rawDir = typeof options.directory === 'string' ? options.directory : DEFAULT_SAVE_DIR;
-    const safePath = resolvePathInAllowedRoots(
-      path.join(path.resolve(rawDir), filename),
-      ALLOWED_SAVE_ROOTS,
-    );
-
-    // Only create directories under allowed roots (safePath already validated)
-    const safeDir = path.dirname(safePath);
-    if (!fs.existsSync(safeDir)) {
-      fs.mkdirSync(safeDir, { recursive: true });
+    // Always save to the fixed safe directory — no user-controlled directory input.
+    // This eliminates path injection entirely: the directory is a compile-time constant.
+    const saveDir = DEFAULT_SAVE_DIR;
+    if (!fs.existsSync(saveDir)) {
+      fs.mkdirSync(saveDir, { recursive: true });
     }
+    const safePath = path.join(saveDir, filename);
 
     // Detect format from filename extension if not specified
     const ext = path.extname(filename).toLowerCase().replace('.', '');

--- a/src/clipboard/manager.ts
+++ b/src/clipboard/manager.ts
@@ -2,7 +2,6 @@ import path from 'path';
 import os from 'os';
 import fs from 'fs';
 import { clipboard, nativeImage } from 'electron';
-import { ensureDir } from '../utils/paths';
 import { resolvePathInAllowedRoots } from '../utils/security';
 import { createLogger } from '../utils/logger';
 
@@ -107,16 +106,26 @@ export class ClipboardManager {
   }
 
   saveAs(options: ClipboardSaveOptions): ClipboardSaveResult {
-    const { filename, quality = 90 } = options;
+    const { quality = 90 } = options;
 
-    // Validate filename — no path separators allowed
-    if (!filename || filename.includes('/') || filename.includes('\\') || filename.includes('..')) {
-      throw new Error('Invalid filename: must not contain path separators or ".."');
+    // Sanitize filename — only allow simple filenames, no path traversal
+    const filename = path.basename(String(options.filename || ''));
+    if (!filename || filename.startsWith('.')) {
+      throw new Error('Invalid filename: must be a simple filename without path separators');
     }
 
-    const dir = options.directory || DEFAULT_SAVE_DIR;
-    const fullPath = resolvePathInAllowedRoots(path.join(dir, filename), ALLOWED_SAVE_ROOTS);
-    ensureDir(path.dirname(fullPath));
+    // Sanitize directory — resolve to an allowed root, default to safe location
+    const rawDir = typeof options.directory === 'string' ? options.directory : DEFAULT_SAVE_DIR;
+    const safePath = resolvePathInAllowedRoots(
+      path.join(path.resolve(rawDir), filename),
+      ALLOWED_SAVE_ROOTS,
+    );
+
+    // Only create directories under allowed roots (safePath already validated)
+    const safeDir = path.dirname(safePath);
+    if (!fs.existsSync(safeDir)) {
+      fs.mkdirSync(safeDir, { recursive: true });
+    }
 
     // Detect format from filename extension if not specified
     const ext = path.extname(filename).toLowerCase().replace('.', '');
@@ -138,9 +147,9 @@ export class ClipboardManager {
       buffer = format === 'jpg' ? img.toJPEG(quality) : img.toPNG();
     }
 
-    fs.writeFileSync(fullPath, buffer);
-    log.info(`Saved clipboard to ${fullPath} (${buffer.length} bytes)`);
+    fs.writeFileSync(safePath, buffer);
+    log.info(`Saved clipboard to ${safePath} (${buffer.length} bytes)`);
 
-    return { path: fullPath, size: buffer.length };
+    return { path: safePath, size: buffer.length };
   }
 }

--- a/src/clipboard/manager.ts
+++ b/src/clipboard/manager.ts
@@ -1,0 +1,146 @@
+import path from 'path';
+import os from 'os';
+import fs from 'fs';
+import { clipboard, nativeImage } from 'electron';
+import { ensureDir } from '../utils/paths';
+import { resolvePathInAllowedRoots } from '../utils/security';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('ClipboardManager');
+
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024; // 10 MB
+
+const ALLOWED_SAVE_ROOTS = [
+  path.join(os.homedir(), 'Desktop'),
+  path.join(os.homedir(), 'Downloads'),
+  path.join(os.homedir(), '.tandem'),
+  path.join(os.homedir(), 'Pictures', 'Tandem'),
+];
+
+const DEFAULT_SAVE_DIR = path.join(os.homedir(), 'Pictures', 'Tandem', 'clipboard');
+
+export interface ClipboardImageInfo {
+  width: number;
+  height: number;
+  base64: string;
+  sizeBytes: number;
+}
+
+export interface ClipboardContent {
+  hasText: boolean;
+  hasImage: boolean;
+  hasHTML: boolean;
+  formats: string[];
+  text?: string;
+  html?: string;
+  image?: ClipboardImageInfo;
+}
+
+export interface ClipboardSaveOptions {
+  filename: string;
+  format?: 'png' | 'jpg' | 'txt';
+  quality?: number;
+  directory?: string;
+}
+
+export interface ClipboardSaveResult {
+  path: string;
+  size: number;
+}
+
+export class ClipboardManager {
+
+  read(): ClipboardContent {
+    const formats = clipboard.availableFormats();
+    const hasText = formats.some(f => f.includes('text/plain') || f.includes('text/uri-list'));
+    const hasHTML = formats.some(f => f.includes('text/html'));
+    const hasImage = formats.some(f => f.includes('image/'));
+
+    const result: ClipboardContent = { hasText, hasImage, hasHTML, formats };
+
+    if (hasText) {
+      result.text = clipboard.readText();
+    }
+    if (hasHTML) {
+      result.html = clipboard.readHTML();
+    }
+    if (hasImage) {
+      const img = clipboard.readImage();
+      if (!img.isEmpty()) {
+        const pngBuffer = img.toPNG();
+        if (pngBuffer.length <= MAX_IMAGE_BYTES) {
+          const size = img.getSize();
+          result.image = {
+            width: size.width,
+            height: size.height,
+            base64: `data:image/png;base64,${pngBuffer.toString('base64')}`,
+            sizeBytes: pngBuffer.length,
+          };
+        } else {
+          log.warn(`Clipboard image too large (${pngBuffer.length} bytes), skipping base64`);
+          const size = img.getSize();
+          result.image = {
+            width: size.width,
+            height: size.height,
+            base64: '',
+            sizeBytes: pngBuffer.length,
+          };
+        }
+      }
+    }
+
+    return result;
+  }
+
+  writeText(text: string): void {
+    clipboard.writeText(text);
+  }
+
+  writeImage(base64Data: string): void {
+    const raw = base64Data.replace(/^data:image\/\w+;base64,/, '');
+    const buffer = Buffer.from(raw, 'base64');
+    const img = nativeImage.createFromBuffer(buffer);
+    if (img.isEmpty()) {
+      throw new Error('Invalid image data');
+    }
+    clipboard.writeImage(img);
+  }
+
+  saveAs(options: ClipboardSaveOptions): ClipboardSaveResult {
+    const { filename, quality = 90 } = options;
+
+    // Validate filename — no path separators allowed
+    if (!filename || filename.includes('/') || filename.includes('\\') || filename.includes('..')) {
+      throw new Error('Invalid filename: must not contain path separators or ".."');
+    }
+
+    const dir = options.directory || DEFAULT_SAVE_DIR;
+    const fullPath = resolvePathInAllowedRoots(path.join(dir, filename), ALLOWED_SAVE_ROOTS);
+    ensureDir(path.dirname(fullPath));
+
+    // Detect format from filename extension if not specified
+    const ext = path.extname(filename).toLowerCase().replace('.', '');
+    const format = options.format || (ext === 'jpg' || ext === 'jpeg' ? 'jpg' : ext === 'txt' ? 'txt' : 'png');
+
+    let buffer: Buffer;
+
+    if (format === 'txt') {
+      const text = clipboard.readText();
+      if (!text) {
+        throw new Error('No text on clipboard to save');
+      }
+      buffer = Buffer.from(text, 'utf-8');
+    } else {
+      const img = clipboard.readImage();
+      if (img.isEmpty()) {
+        throw new Error('No image on clipboard to save');
+      }
+      buffer = format === 'jpg' ? img.toJPEG(quality) : img.toPNG();
+    }
+
+    fs.writeFileSync(fullPath, buffer);
+    log.info(`Saved clipboard to ${fullPath} (${buffer.length} bytes)`);
+
+    return { path: fullPath, size: buffer.length };
+  }
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -43,12 +43,13 @@ import { registerMediaTools } from './tools/media.js';
 import { registerEventTools } from './tools/events.js';
 import { registerSystemTools } from './tools/system.js';
 import { registerAwarenessTools } from './tools/awareness.js';
+import { registerClipboardTools } from './tools/clipboard.js';
 
 // log is defined above — stderr-only for MCP stdio safety
 
 const server = new McpServer({
   name: 'tandem-browser',
-  version: '0.70.0',  // 233 tools — full API parity + awareness
+  version: '0.70.0',  // 236 tools — full API parity + awareness + clipboard
 });
 
 // ═══════════════════════════════════════════════
@@ -86,6 +87,7 @@ registerMediaTools(server);
 registerEventTools(server);
 registerSystemTools(server);
 registerAwarenessTools(server);
+registerClipboardTools(server);
 
 // ═══════════════════════════════════════════════
 // MCP Resources

--- a/src/mcp/tools/clipboard.ts
+++ b/src/mcp/tools/clipboard.ts
@@ -1,0 +1,93 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { apiCall, logActivity } from '../api-client.js';
+
+export function registerClipboardTools(server: McpServer): void {
+
+  server.tool(
+    'tandem_clipboard_read',
+    'Read what is on the clipboard. Returns text and/or image. Use this to see what the user has copied — if there is an image you will receive it visually.',
+    {},
+    {
+      readOnlyHint: true,
+      openWorldHint: false,
+    },
+    async () => {
+      const data = await apiCall('GET', '/clipboard');
+      const content: Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }> = [];
+
+      if (data.text) {
+        content.push({ type: 'text' as const, text: data.text });
+      }
+
+      if (data.image && data.image.base64) {
+        // Strip data URI prefix for MCP image transport
+        const raw = (data.image.base64 as string).replace(/^data:image\/\w+;base64,/, '');
+        content.push({ type: 'image' as const, data: raw, mimeType: 'image/png' });
+      }
+
+      if (data.html && !data.text) {
+        content.push({ type: 'text' as const, text: data.html });
+      }
+
+      if (content.length === 0) {
+        content.push({ type: 'text' as const, text: `Clipboard is empty. Formats: ${JSON.stringify(data.formats)}` });
+      }
+
+      await logActivity('clipboard_read', data.hasImage ? 'image' : data.text ? data.text.slice(0, 60) : 'empty');
+      return { content };
+    }
+  );
+
+  server.tool(
+    'tandem_clipboard_write',
+    'Write text or an image to the clipboard so the user can paste it somewhere. For images, provide base64-encoded image data.',
+    {
+      text: z.string().optional().describe('Text to place on the clipboard'),
+      image_base64: z.string().optional().describe('Base64-encoded image data (with or without data URI prefix)'),
+    },
+    async ({ text, image_base64 }) => {
+      if (!text && !image_base64) {
+        return { content: [{ type: 'text', text: 'Error: provide text or image_base64 (or both)' }] };
+      }
+
+      const results: string[] = [];
+
+      if (text) {
+        await apiCall('POST', '/clipboard/text', { text });
+        results.push('text');
+      }
+      if (image_base64) {
+        await apiCall('POST', '/clipboard/image', { base64: image_base64 });
+        results.push('image');
+      }
+
+      const summary = `Copied ${results.join(' and ')} to clipboard`;
+      await logActivity('clipboard_write', summary);
+      return { content: [{ type: 'text', text: summary }] };
+    }
+  );
+
+  server.tool(
+    'tandem_clipboard_save',
+    'Save the current clipboard content as a file. Choose a descriptive filename that reflects the content. Use jpg for photos/screenshots, png for graphics with transparency, txt for text.',
+    {
+      filename: z.string().describe('Descriptive filename, e.g. "vercel-503-error.png" or "meeting-notes.txt"'),
+      format: z.enum(['png', 'jpg', 'txt']).optional().describe('File format — auto-detected from filename extension if omitted'),
+      quality: z.number().min(1).max(100).optional().describe('JPEG quality (1-100, default 90). Only applies to jpg format'),
+      directory: z.string().optional().describe('Save directory (default: ~/Pictures/Tandem/clipboard/)'),
+    },
+    async ({ filename, format, quality, directory }) => {
+      const data = await apiCall('POST', '/clipboard/save', { filename, format, quality, directory });
+      const summary = `Saved to ${data.path} (${formatBytes(data.size)})`;
+      await logActivity('clipboard_save', summary);
+      return { content: [{ type: 'text', text: summary }] };
+    }
+  );
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/src/mcp/tools/clipboard.ts
+++ b/src/mcp/tools/clipboard.ts
@@ -75,10 +75,9 @@ export function registerClipboardTools(server: McpServer): void {
       filename: z.string().describe('Descriptive filename, e.g. "vercel-503-error.png" or "meeting-notes.txt"'),
       format: z.enum(['png', 'jpg', 'txt']).optional().describe('File format — auto-detected from filename extension if omitted'),
       quality: z.number().min(1).max(100).optional().describe('JPEG quality (1-100, default 90). Only applies to jpg format'),
-      directory: z.string().optional().describe('Save directory (default: ~/Pictures/Tandem/clipboard/)'),
     },
-    async ({ filename, format, quality, directory }) => {
-      const data = await apiCall('POST', '/clipboard/save', { filename, format, quality, directory });
+    async ({ filename, format, quality }) => {
+      const data = await apiCall('POST', '/clipboard/save', { filename, format, quality });
       const summary = `Saved to ${data.path} (${formatBytes(data.size)})`;
       await logActivity('clipboard_save', summary);
       return { content: [{ type: 'text', text: summary }] };

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -46,6 +46,7 @@ import type { SidebarManager } from './sidebar/manager';
 import type { WorkspaceManager } from './workspaces/manager';
 import type { SyncManager } from './sync/manager';
 import type { PinboardManager } from './pinboards/manager';
+import type { ClipboardManager } from './clipboard/manager';
 import type { GooglePhotosManager } from './integrations/google-photos';
 
 export interface ManagerRegistry {
@@ -92,4 +93,5 @@ export interface ManagerRegistry {
   syncManager: SyncManager;
   pinboardManager: PinboardManager;
   googlePhotosManager: GooglePhotosManager;
+  clipboardManager: ClipboardManager;
 }

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -144,9 +144,18 @@ export function resolvePathInAllowedRoots(candidatePath: string, allowedRoots: s
   }
 
   const resolvedCandidate = path.resolve(trimmed);
+  const candidateDir = path.dirname(resolvedCandidate);
+  const candidateBase = path.basename(resolvedCandidate);
+
+  // Canonicalize candidate parent (if it exists) to prevent symlink-based escapes.
+  const canonicalCandidateDir = fs.existsSync(candidateDir) ? fs.realpathSync(candidateDir) : candidateDir;
+  const canonicalCandidate = path.join(canonicalCandidateDir, candidateBase);
+
   for (const root of allowedRoots) {
     try {
-      return assertPathWithinRoot(root, resolvedCandidate);
+      const resolvedRoot = path.resolve(root);
+      const canonicalRoot = fs.existsSync(resolvedRoot) ? fs.realpathSync(resolvedRoot) : resolvedRoot;
+      return assertPathWithinRoot(canonicalRoot, canonicalCandidate);
     } catch {
       continue;
     }

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -144,18 +144,9 @@ export function resolvePathInAllowedRoots(candidatePath: string, allowedRoots: s
   }
 
   const resolvedCandidate = path.resolve(trimmed);
-  const candidateDir = path.dirname(resolvedCandidate);
-  const candidateBase = path.basename(resolvedCandidate);
-
-  // Canonicalize candidate parent (if it exists) to prevent symlink-based escapes.
-  const canonicalCandidateDir = fs.existsSync(candidateDir) ? fs.realpathSync(candidateDir) : candidateDir;
-  const canonicalCandidate = path.join(canonicalCandidateDir, candidateBase);
-
   for (const root of allowedRoots) {
     try {
-      const resolvedRoot = path.resolve(root);
-      const canonicalRoot = fs.existsSync(resolvedRoot) ? fs.realpathSync(resolvedRoot) : resolvedRoot;
-      return assertPathWithinRoot(canonicalRoot, canonicalCandidate);
+      return assertPathWithinRoot(root, resolvedCandidate);
     } catch {
       continue;
     }


### PR DESCRIPTION
## Summary

The AI can now see, write, and save clipboard content:

- `tandem_clipboard_read` — see what the user copied (text and/or image, displayed visually)
- `tandem_clipboard_write` — put text or image on clipboard for the user to paste
- `tandem_clipboard_save` — save clipboard content as a file

New: ClipboardManager, 4 HTTP endpoints, 3 MCP tools. 233 → 236 tools.

## Test plan

- [x] `npm run compile` — zero errors
- [x] Read clipboard with image — image displayed visually
- [x] Write text to clipboard — verified by reading back
- [x] Read clipboard with text — correct content returned