### PR TITLE
docs(core): add JSDoc to public methods (P1-05)

### DIFF
--- a/src/api/routes/sessions.ts
+++ b/src/api/routes/sessions.ts
@@ -13,6 +13,11 @@ const FORBIDDEN_SESSION_FETCH_HEADERS = new Set([
   'referer',
 ]);
 
+/**
+ * Register session, device emulation, session-fetch relay, and auth-header routes.
+ * @param router - Express router to attach routes to
+ * @param ctx - shared manager registry and main BrowserWindow
+ */
 export function registerSessionRoutes(router: Router, ctx: RouteContext): void {
   // ═══════════════════════════════════════════════
   // DEVICE EMULATION

--- a/src/api/routes/tabs.ts
+++ b/src/api/routes/tabs.ts
@@ -3,6 +3,11 @@ import { webContents } from 'electron';
 import type { RouteContext } from '../context';
 import { handleRouteError } from '../../utils/errors';
 
+/**
+ * Register all tab-related API routes (open, close, list, focus, group, source, reconcile, cleanup).
+ * @param router - Express router to attach routes to
+ * @param ctx - shared manager registry and main BrowserWindow
+ */
 export function registerTabRoutes(router: Router, ctx: RouteContext): void {
   router.post('/tabs/open', async (req: Request, res: Response) => {
     const {

--- a/src/tabs/manager.ts
+++ b/src/tabs/manager.ts
@@ -73,14 +73,20 @@ export class TabManager {
 
   // === 3. Dependency setters ===
 
+  /** Wire up the sync manager for cross-device tab publishing. */
   setSyncManager(sm: SyncManager): void {
     this.syncManager = sm;
   }
 
+  /** Wire up the session restore manager for crash-safe tab persistence. */
   setSessionRestore(sr: SessionRestoreManager): void {
     this.sessionRestore = sr;
   }
 
+  /**
+   * Set the callback used to look up which workspace a tab belongs to.
+   * @param resolver - maps a webContentsId to its workspace ID, or null to clear
+   */
   setWorkspaceIdResolver(resolver: ((webContentsId: number) => string | null) | null): void {
     this.workspaceIdResolver = resolver;
   }


### PR DESCRIPTION
## Summary
- Add JSDoc to `TabManager` dependency setters (`setSyncManager`, `setSessionRestore`, `setWorkspaceIdResolver`)
- Add JSDoc to `registerTabRoutes` and `registerSessionRoutes` route registration functions
- Core managers (`SessionManager`, `StateManager`, `SessionRestoreManager`) already had full JSDoc coverage — no changes needed

## Scope
PR 1 of 5 — Core managers: `src/tabs/`, `src/sessions/`, `src/session/`, and related route files.

## Test plan
- [x] `npm run verify` passes (compile + lint + test)
- [x] No code logic changes — JSDoc comments only