### PR TITLE
docs(ui): add JSDoc to public methods (P1-05)

### DIFF
--- a/src/api/routes/pinboards.ts
+++ b/src/api/routes/pinboards.ts
@@ -5,6 +5,11 @@ import { handleRouteError } from '../../utils/errors';
 interface IdParams { id: string }
 interface ItemParams { id: string; itemId: string }
 
+/**
+ * Register pinboard and pinboard-item CRUD routes.
+ * @param router - Express router to attach routes to
+ * @param ctx - shared manager registry and main BrowserWindow
+ */
 export function registerPinboardRoutes(router: Router, ctx: RouteContext): void {
   // ═══════════════════════════════════════════════
   // PINBOARDS — Content Curation Boards

--- a/src/api/routes/sidebar.ts
+++ b/src/api/routes/sidebar.ts
@@ -2,6 +2,11 @@ import type { Router, Request, Response } from 'express';
 import type { RouteContext } from '../context';
 import { handleRouteError } from '../../utils/errors';
 
+/**
+ * Register sidebar layout and item management routes.
+ * @param router - Express router to attach routes to
+ * @param ctx - shared manager registry and main BrowserWindow
+ */
 export function registerSidebarRoutes(router: Router, ctx: RouteContext): void {
   // GET /sidebar/config
   router.get('/sidebar/config', (_req: Request, res: Response) => {

--- a/src/api/routes/workspaces.ts
+++ b/src/api/routes/workspaces.ts
@@ -16,6 +16,11 @@ function parseWorkspaceTabId(rawTabId: unknown): number | null {
   return null;
 }
 
+/**
+ * Register workspace CRUD, activation, and tab-move routes.
+ * @param router - Express router to attach routes to
+ * @param ctx - shared manager registry and main BrowserWindow
+ */
 export function registerWorkspaceRoutes(router: Router, ctx: RouteContext): void {
   // ═══════════════════════════════════════════════
   // WORKSPACES — Visual workspace management

--- a/src/pinboards/manager.ts
+++ b/src/pinboards/manager.ts
@@ -73,6 +73,7 @@ export class PinboardManager {
 
   // === 3. Dependency setters ===
 
+  /** Wire up sync manager and merge any newer shared pinboard data. */
   setSyncManager(sm: SyncManager): void {
     this.syncManager = sm;
     this.mergeFromSync();
@@ -82,6 +83,7 @@ export class PinboardManager {
 
   // --- Board CRUD ---
 
+  /** List all pinboards with summary info (no items included). */
   listBoards(): Array<{ id: string; name: string; emoji: string; itemCount: number; createdAt: string; updatedAt: string }> {
     return this.store.boards.map(b => ({
       id: b.id,
@@ -93,10 +95,16 @@ export class PinboardManager {
     }));
   }
 
+  /** Get a pinboard by ID, including all its items. */
   getBoard(boardId: string): Pinboard | null {
     return this.store.boards.find(b => b.id === boardId) || null;
   }
 
+  /**
+   * Create a new pinboard.
+   * @param name - board display name
+   * @param emoji - optional emoji icon (defaults to 📌)
+   */
   createBoard(name: string, emoji?: string): Pinboard {
     const now = new Date().toISOString();
     const board: Pinboard = {
@@ -112,6 +120,7 @@ export class PinboardManager {
     return board;
   }
 
+  /** Update a pinboard's name or emoji. Returns null if not found. */
   updateBoard(boardId: string, updates: { name?: string; emoji?: string }): Pinboard | null {
     const board = this.store.boards.find(b => b.id === boardId);
     if (!board) return null;
@@ -122,6 +131,7 @@ export class PinboardManager {
     return board;
   }
 
+  /** Delete a pinboard and all its items. Returns false if not found. */
   deleteBoard(boardId: string): boolean {
     const idx = this.store.boards.findIndex(b => b.id === boardId);
     if (idx === -1) return false;
@@ -130,6 +140,7 @@ export class PinboardManager {
     return true;
   }
 
+  /** Update a pinboard's visual settings (layout density and background). */
   updateBoardSettings(boardId: string, settings: { layout?: 'default' | 'spacious' | 'dense'; background?: 'dark' | 'light' }): Pinboard | null {
     const board = this.store.boards.find(b => b.id === boardId);
     if (!board) return null;
@@ -142,12 +153,14 @@ export class PinboardManager {
 
   // --- Item CRUD ---
 
+  /** Get all items for a pinboard, sorted by position. Returns null if board not found. */
   getItems(boardId: string): PinboardItem[] | null {
     const board = this.store.boards.find(b => b.id === boardId);
     if (!board) return null;
     return [...board.items].sort((a, b) => a.position - b.position);
   }
 
+  /** Add an item to a pinboard, auto-enriching link items with OG metadata. */
   async addItem(boardId: string, item: Omit<PinboardItem, 'id' | 'createdAt' | 'position'>): Promise<PinboardItem | null> {
     const board = this.store.boards.find(b => b.id === boardId);
     if (!board) return null;
@@ -170,6 +183,7 @@ export class PinboardManager {
     return newItem;
   }
 
+  /** Update an item's metadata (title, note, content, etc.). Returns null if not found. */
   updateItem(boardId: string, itemId: string, updates: { title?: string; note?: string; content?: string; description?: string; thumbnail?: string }): PinboardItem | null {
     const board = this.store.boards.find(b => b.id === boardId);
     if (!board) return null;
@@ -185,6 +199,7 @@ export class PinboardManager {
     return item;
   }
 
+  /** Remove an item from a pinboard and recalculate positions. */
   deleteItem(boardId: string, itemId: string): boolean {
     const board = this.store.boards.find(b => b.id === boardId);
     if (!board) return false;
@@ -198,6 +213,7 @@ export class PinboardManager {
     return true;
   }
 
+  /** Reorder items within a pinboard by assigning positions from the given ID sequence. */
   reorderItems(boardId: string, itemIds: string[]): boolean {
     const board = this.store.boards.find(b => b.id === boardId);
     if (!board) return false;
@@ -233,6 +249,7 @@ export class PinboardManager {
 
   // === 6. Cleanup ===
 
+  /** Clean up resources (currently a no-op). */
   destroy(): void {
     // Currently noop (no file watchers or timers)
   }

--- a/src/sidebar/manager.ts
+++ b/src/sidebar/manager.ts
@@ -69,14 +69,25 @@ export class SidebarManager {
 
   // === 4. Public methods ===
 
+  /** Get the current sidebar configuration. */
   getConfig(): SidebarConfig { return this.config; }
 
+  /**
+   * Merge partial updates into the sidebar configuration and persist.
+   * @param partial - fields to update (state, activeItemId, panelPinned, etc.)
+   * @returns the updated configuration
+   */
   updateConfig(partial: Partial<SidebarConfig>): SidebarConfig {
     this.config = { ...this.config, ...partial };
     this.save();
     return this.config;
   }
 
+  /**
+   * Toggle a sidebar item's enabled/disabled state.
+   * @param id - sidebar item ID
+   * @returns the toggled item, or undefined if not found
+   */
   toggleItem(id: string): SidebarItem | undefined {
     const item = this.config.items.find(i => i.id === id);
     if (!item) return undefined;
@@ -85,6 +96,10 @@ export class SidebarManager {
     return item;
   }
 
+  /**
+   * Reorder sidebar items by assigning new order values from the given ID sequence.
+   * @param orderedIds - item IDs in desired display order
+   */
   reorderItems(orderedIds: string[]): void {
     orderedIds.forEach((id, idx) => {
       const item = this.config.items.find(i => i.id === id);
@@ -94,11 +109,13 @@ export class SidebarManager {
     this.save();
   }
 
+  /** Set the sidebar visibility state (hidden, narrow, or wide). */
   setState(state: SidebarState): void {
     this.config.state = state;
     this.save();
   }
 
+  /** Set which sidebar item's panel is open, or null to close all panels. */
   setActiveItem(id: string | null): void {
     this.config.activeItemId = id;
     this.save();
@@ -109,6 +126,7 @@ export class SidebarManager {
 
   // === 6. Cleanup ===
 
+  /** Clean up resources (currently a no-op). */
   destroy(): void { /* nothing to clean up */ }
 
   // === 7. Private I/O ===

--- a/src/workspaces/manager.ts
+++ b/src/workspaces/manager.ts
@@ -63,10 +63,12 @@ export class WorkspaceManager {
 
   // === 3. Dependency setters ===
 
+  /** Set the main BrowserWindow for IPC workspace-switch notifications. */
   setMainWindow(win: BrowserWindow): void {
     this.mainWindow = win;
   }
 
+  /** Wire up sync manager and merge any newer shared workspace data. */
   setSyncManager(sm: SyncManager): void {
     this.syncManager = sm;
     this.mergeFromSync();
@@ -74,24 +76,33 @@ export class WorkspaceManager {
 
   // === 4. Public methods ===
 
+  /** List all workspaces sorted by display order. */
   list(): Workspace[] {
     return Array.from(this.workspaces.values()).sort((a, b) => a.order - b.order);
   }
 
+  /** Get a workspace by ID, or undefined if not found. */
   get(id: string): Workspace | undefined {
     return this.workspaces.get(id);
   }
 
+  /** Get the currently active workspace (falls back to default). */
   getActive(): Workspace {
     const ws = this.workspaces.get(this.activeId);
     if (!ws) return this.getDefaultWorkspace()!;
     return ws;
   }
 
+  /** Get the ID of the active workspace. */
   getActiveId(): string {
     return this.activeId;
   }
 
+  /**
+   * Look up which workspace a tab belongs to.
+   * @param tabId - webContentsId of the tab
+   * @returns workspace ID, or null if unassigned
+   */
   getWorkspaceIdForTab(tabId: number): string | null {
     for (const workspace of this.workspaces.values()) {
       if (workspace.tabIds.includes(tabId)) {
@@ -101,6 +112,12 @@ export class WorkspaceManager {
     return null;
   }
 
+  /**
+   * Create a new workspace.
+   * @param opts - name (required), icon, and color
+   * @returns the created workspace
+   * @throws if name is missing
+   */
   create(opts: { name: string; icon?: string; color?: string }): Workspace {
     if (!opts.name) throw new Error('name is required');
     // Pick a default color based on current count
@@ -120,6 +137,10 @@ export class WorkspaceManager {
     return ws;
   }
 
+  /**
+   * Update a workspace's name, icon, or color.
+   * @throws if the workspace is not found
+   */
   update(id: string, opts: Partial<Pick<Workspace, 'name' | 'icon' | 'color'>>): Workspace {
     const ws = this.workspaces.get(id);
     if (!ws) throw new Error(`Workspace ${id} not found`);
@@ -130,6 +151,10 @@ export class WorkspaceManager {
     return ws;
   }
 
+  /**
+   * Delete a workspace, moving its tabs to the default workspace.
+   * @throws if workspace not found or is the default workspace
+   */
   remove(id: string): void {
     const ws = this.workspaces.get(id);
     if (!ws) throw new Error(`Workspace ${id} not found`);
@@ -155,6 +180,10 @@ export class WorkspaceManager {
     log.info(`Removed workspace "${ws.name}" (${id})`);
   }
 
+  /**
+   * Switch the active workspace and notify the renderer.
+   * @throws if workspace not found
+   */
   switch(id: string): Workspace {
     const ws = this.workspaces.get(id);
     if (!ws) throw new Error(`Workspace ${id} not found`);
@@ -165,6 +194,7 @@ export class WorkspaceManager {
     return ws;
   }
 
+  /** Assign a tab (by webContentsId) to the currently active workspace. */
   assignTab(tabId: number): void {
     const active = this.getActive();
     for (const workspace of this.workspaces.values()) {
@@ -177,6 +207,7 @@ export class WorkspaceManager {
     this.saveToDisk();
   }
 
+  /** Remove a tab from whichever workspace it belongs to. */
   removeTab(tabId: number): void {
     for (const ws of this.workspaces.values()) {
       const idx = ws.tabIds.indexOf(tabId);
@@ -187,6 +218,10 @@ export class WorkspaceManager {
     this.saveToDisk();
   }
 
+  /**
+   * Move a tab to a specific workspace and refresh the tab bar.
+   * @throws if workspace not found
+   */
   moveTab(tabId: number, workspaceId: string): void {
     const target = this.workspaces.get(workspaceId);
     if (!target) throw new Error(`Workspace ${workspaceId} not found`);
@@ -205,6 +240,7 @@ export class WorkspaceManager {
     this.notifySwitch(this.getActive());
   }
 
+  /** Clear all tab assignments from every workspace. */
   resetTabAssignments(): void {
     for (const workspace of this.workspaces.values()) {
       workspace.tabIds = [];
@@ -241,6 +277,7 @@ export class WorkspaceManager {
 
   // === 6. Cleanup ===
 
+  /** Persist workspace state to disk on shutdown. */
   destroy(): void {
     this.saveToDisk();
   }


### PR DESCRIPTION
## Summary
- Add JSDoc to all public methods in `SidebarManager` (7 methods)
- Add JSDoc to all public methods in `WorkspaceManager` (16 methods)
- Add JSDoc to all public methods in `PinboardManager` (13 methods)
- Add JSDoc to route registration functions: `registerSidebarRoutes`, `registerWorkspaceRoutes`, `registerPinboardRoutes`
- `DownloadManager` and `PanelManager` already had full JSDoc coverage — no changes needed

## Scope
PR 2 of 5 — UI managers: `src/sidebar/`, `src/workspaces/`, `src/pinboards/`, `src/downloads/`, `src/panel/`

## Test plan
- [x] `npm run verify` passes (compile + lint + test)
- [x] No code logic changes — JSDoc comments only