### PR TITLE
docs(security): add JSDoc to public methods (P1-05)

### DIFF
--- a/src/api/routes/network.ts
+++ b/src/api/routes/network.ts
@@ -2,6 +2,11 @@ import type { Router, Request, Response } from 'express';
 import type { RouteContext } from '../context';
 import { handleRouteError } from '../../utils/errors';
 
+/**
+ * Register network inspector and mock/intercept routes.
+ * @param router - Express router to attach routes to
+ * @param ctx - shared manager registry and main BrowserWindow
+ */
 export function registerNetworkRoutes(router: Router, ctx: RouteContext): void {
   // ═══════════════════════════════════════════════
   // NETWORK INSPECTOR — Phase 3.8

--- a/src/network/inspector.ts
+++ b/src/network/inspector.ts
@@ -333,6 +333,11 @@ export class NetworkInspector {
     })).sort((a, b) => b.requests - a.requests);
   }
 
+  /**
+   * Export logged requests as a HAR 1.2 archive.
+   * @param limit - max entries to include (default 100)
+   * @param domain - optional domain filter
+   */
   toHar(limit: number = 100, domain?: string): HarExport {
     const entries = this.getLog(limit, domain).map((request) => this.toHarEntry(request));
     const startedDateTime = entries[0]?.startedDateTime ?? new Date().toISOString();

--- a/src/security/security-manager.ts
+++ b/src/security/security-manager.ts
@@ -185,6 +185,7 @@ export class SecurityManager {
     this.setupPermissionHandler(deps.session);
   }
 
+  /** Register the Guardian's request interceptors with the network dispatcher. */
   registerWith(dispatcher: RequestDispatcher): void {
     this.guardian.registerWith(dispatcher);
   }
@@ -449,20 +450,34 @@ export class SecurityManager {
 
   // --- Public accessors for route handlers (src/security/routes.ts) ---
 
+  /** Get the security event/domain database. */
   getDb(): SecurityDB { return this.db; }
+  /** Get the domain/URL blocklist shield. */
   getShield(): NetworkShield { return this.shield; }
+  /** Get the request guardian (mode enforcement, blocking). */
   getGuardian(): Guardian { return this.guardian; }
+  /** Get the outbound data exfiltration guard. */
   getOutboundGuard(): OutboundGuard { return this.outboundGuard; }
+  /** Get the CDP-based script analysis guard (null until DevTools attached). */
   getScriptGuard(): ScriptGuard | null { return this.scriptGuard; }
+  /** Get the page content analyzer (null until DevTools attached). */
   getContentAnalyzer(): ContentAnalyzer | null { return this.contentAnalyzer; }
+  /** Get the runtime behavior monitor (null until DevTools attached). */
   getBehaviorMonitor(): BehaviorMonitor | null { return this.behaviorMonitor; }
+  /** Get the DevTools CDP manager reference. */
   getDevToolsManager(): DevToolsManager | null { return this.devToolsManager; }
+  /** Get the Gatekeeper WebSocket server (null until HTTP server starts). */
   getGatekeeperWs(): GatekeeperWebSocket | null { return this.gatekeeperWs; }
+  /** Get the threat intelligence correlation engine. */
   getThreatIntel(): ThreatIntel { return this.threatIntel; }
+  /** Get the blocklist source updater. */
   getBlocklistUpdater(): BlocklistUpdater { return this.blocklistUpdater; }
+  /** Get the analyzer plugin manager. */
   getAnalyzerManager(): AnalyzerManager { return this.analyzerManager; }
+  /** Get a snapshot of all containment incidents (most recent first). */
   getContainmentIncidents(): SecurityContainmentIncident[] { return [...this.containmentIncidents]; }
 
+  /** Tear down all security subsystems, clear timers, and close the database. */
   destroy(): void {
     if (this.correlationInterval) clearInterval(this.correlationInterval);
     if (this.blocklistInterval) clearInterval(this.blocklistInterval);

--- a/src/stealth/manager.ts
+++ b/src/stealth/manager.ts
@@ -37,6 +37,7 @@ export class StealthManager {
       `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${chromeVersion} Safari/537.36`;
   }
 
+  /** Apply stealth patches to the Electron session (User-Agent override). */
   async apply(): Promise<void> {
     // Set realistic User-Agent globally (LinkedIn etc. block "Electron" UA)
     // Google auth is excluded via the onBeforeSendHeaders handler in registerWith()


### PR DESCRIPTION
## Summary
- Add JSDoc to `SecurityManager` — 15 public accessors and `destroy()`
- Add JSDoc to `StealthManager.apply()`
- Add JSDoc to `NetworkInspector.toHar()`
- Add JSDoc to `registerNetworkRoutes()` route registration function
- `NetworkMocker` and `security/routes.ts` already had full JSDoc coverage

## Scope
PR 3 of 5 — Security managers: `src/security/`, `src/stealth/`, `src/network/`

## Test plan
- [x] `npm run verify` passes (compile + lint + test)
- [x] No code logic changes — JSDoc comments only