### PR TITLE
docs(browser): add JSDoc to public methods (P1-05)

### DIFF
--- a/src/api/routes/browser.ts
+++ b/src/api/routes/browser.ts
@@ -79,6 +79,11 @@ function buildPageContentScript(settleMs: number, maxWait: number, targetLength:
   `;
 }
 
+/**
+ * Register core browser action routes (navigate, click, type, scroll, key press, screenshots, etc.).
+ * @param router - Express router to attach routes to
+ * @param ctx - shared manager registry and main BrowserWindow
+ */
 export function registerBrowserRoutes(router: Router, ctx: RouteContext): void {
   // ═══════════════════════════════════════════════
   // NAVIGATE

--- a/src/api/routes/content.ts
+++ b/src/api/routes/content.ts
@@ -3,6 +3,11 @@ import type { RouteContext} from '../context';
 import { getActiveWC, getSessionWC } from '../context';
 import { handleRouteError } from '../../utils/errors';
 
+/**
+ * Register content extraction and URL-fetch routes.
+ * @param router - Express router to attach routes to
+ * @param ctx - shared manager registry and main BrowserWindow
+ */
 export function registerContentRoutes(router: Router, ctx: RouteContext): void {
   // ═══════════════════════════════════════════════
   // CONTENT EXTRACTION

--- a/src/history/manager.ts
+++ b/src/history/manager.ts
@@ -44,6 +44,7 @@ export class HistoryManager {
     this.store = this.load();
   }
 
+  /** Wire up sync manager for cross-device history publishing. */
   setSyncManager(sm: SyncManager): void {
     this.syncManager = sm;
   }
@@ -72,6 +73,7 @@ export class HistoryManager {
     }, 2000);
   }
 
+  /** Flush pending history writes to disk on shutdown. */
   destroy(): void {
     if (this.saveTimer) {
       clearTimeout(this.saveTimer);


### PR DESCRIPTION
## Summary
- Add JSDoc to `HistoryManager.setSyncManager()` and `HistoryManager.destroy()`
- Add JSDoc to `registerBrowserRoutes()` and `registerContentRoutes()` route registration functions
- `BookmarkManager`, `FormMemoryManager`, `SiteMemoryManager` already had full JSDoc coverage

## Scope
PR 4 of 5 — Browser features: `src/history/`, `src/bookmarks/`, `src/memory/`, and related route files.

## Test plan
- [x] `npm run verify` passes (compile + lint + test)
- [x] No code logic changes — JSDoc comments only