### PR TITLE
docs(remaining): add JSDoc to public methods (P1-05)

### DIFF
--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -5,6 +5,11 @@ import { handleRouteError } from '../../utils/errors';
 import { DEFAULT_TIMEOUT_MS } from '../../utils/constants';
 import type { TaskStatus } from '../../agents/task-manager';
 
+/**
+ * Register agent task management, tab-lock, workflow, and watch routes.
+ * @param router - Express router to attach routes to
+ * @param ctx - shared manager registry and main BrowserWindow
+ */
 export function registerAgentRoutes(router: Router, ctx: RouteContext): void {
   // ═══════════════════════════════════════════════
   // TASKS — Agent task management (Phase 5)

--- a/src/api/routes/awareness.ts
+++ b/src/api/routes/awareness.ts
@@ -2,6 +2,11 @@ import type { Router, Request, Response } from 'express';
 import type { RouteContext } from '../context';
 import { handleRouteError } from '../../utils/errors';
 
+/**
+ * Register AI awareness routes (activity digest, focus context).
+ * @param router - Express router to attach routes to
+ * @param ctx - shared manager registry and main BrowserWindow
+ */
 export function registerAwarenessRoutes(router: Router, ctx: RouteContext): void {
 
   // ═══ GET /awareness/digest — Smart activity digest ═══

--- a/src/api/routes/clipboard.ts
+++ b/src/api/routes/clipboard.ts
@@ -2,6 +2,11 @@ import type { Router, Request, Response } from 'express';
 import type { RouteContext } from '../context';
 import { handleRouteError } from '../../utils/errors';
 
+/**
+ * Register clipboard read, write, and saved-clips management routes.
+ * @param router - Express router to attach routes to
+ * @param ctx - shared manager registry and main BrowserWindow
+ */
 export function registerClipboardRoutes(router: Router, ctx: RouteContext): void {
 
   // ═══ GET /clipboard — Read clipboard content ═══

--- a/src/api/routes/data.ts
+++ b/src/api/routes/data.ts
@@ -27,6 +27,11 @@ const openClawConnectRateLimit = expressRateLimit({
   message: { error: 'Too many OpenClaw connect requests. Retry shortly.' },
 });
 
+/**
+ * Register data management routes (bookmarks, history, forms, site memory, cookies, import/export).
+ * @param router - Express router to attach routes to
+ * @param ctx - shared manager registry and main BrowserWindow
+ */
 export function registerDataRoutes(router: Router, ctx: RouteContext): void {
   // ═══════════════════════════════════════════════
   // BOOKMARKS — Phase 4.2

--- a/src/api/routes/devtools.ts
+++ b/src/api/routes/devtools.ts
@@ -6,6 +6,11 @@ import { DEFAULT_TIMEOUT_MS } from '../../utils/constants';
 /** Maximum allowed expression length for evaluation endpoints (1 MB) */
 const MAX_CODE_LENGTH = 1_048_576;
 
+/**
+ * Register DevTools CDP bridge routes (console, DOM, evaluate, storage, performance).
+ * @param router - Express router to attach routes to
+ * @param ctx - shared manager registry and main BrowserWindow
+ */
 export function registerDevtoolsRoutes(router: Router, ctx: RouteContext): void {
   // ═══════════════════════════════════════════════
   // DEVTOOLS — CDP Bridge for Wingman

--- a/src/api/routes/extensions.ts
+++ b/src/api/routes/extensions.ts
@@ -55,6 +55,11 @@ function getExtensionFramesForWebContents(tabId: number): ExtensionFrameInfo[] {
     }));
 }
 
+/**
+ * Register browser extension management routes (list, install, uninstall, Chrome import).
+ * @param router - Express router to attach routes to
+ * @param ctx - shared manager registry and main BrowserWindow
+ */
 export function registerExtensionRoutes(router: Router, ctx: RouteContext): void {
   // ═══════════════════════════════════════════════
   // EXTENSIONS — Phase 5.7 + Phase 2 API Routes

--- a/src/api/routes/media.ts
+++ b/src/api/routes/media.ts
@@ -35,6 +35,11 @@ function renderGooglePhotosAuthPage(opts: { ok: boolean; title: string; message:
 </html>`;
 }
 
+/**
+ * Register Wingman panel, chat, activity log, audio recording, and draw overlay routes.
+ * @param router - Express router to attach routes to
+ * @param ctx - shared manager registry and main BrowserWindow
+ */
 export function registerMediaRoutes(router: Router, ctx: RouteContext): void {
   // ═══════════════════════════════════════════════
   // PANEL — Wingman side panel

--- a/src/api/routes/misc.ts
+++ b/src/api/routes/misc.ts
@@ -17,6 +17,11 @@ export function resetMiscRouteStateForTests(): void {
   liveMode = false;
 }
 
+/**
+ * Register miscellaneous routes (status, config, live mode, voice, password vault, etc.).
+ * @param router - Express router to attach routes to
+ * @param ctx - shared manager registry and main BrowserWindow
+ */
 export function registerMiscRoutes(router: Router, ctx: RouteContext): void {
 
   // ═══════════════════════════════════════════════

--- a/src/api/routes/previews.ts
+++ b/src/api/routes/previews.ts
@@ -126,6 +126,11 @@ function injectLiveReload(html: string, id: string, version: number): string {
 
 // ─── Routes ─────────────────────────────────────────────────────────────────
 
+/**
+ * Register headless preview CRUD and content routes.
+ * @param router - Express router to attach routes to
+ * @param ctx - shared manager registry and main BrowserWindow
+ */
 export function registerPreviewRoutes(router: Router, ctx: RouteContext): void {
 
   // List all previews

--- a/src/api/routes/snapshots.ts
+++ b/src/api/routes/snapshots.ts
@@ -5,6 +5,11 @@ import type { LocatorQuery } from '../../locators/finder';
 import { handleRouteError } from '../../utils/errors';
 import { injectionScannerMiddleware } from '../middleware/injection-scanner';
 
+/**
+ * Register accessibility-tree snapshot and locator-based interaction routes.
+ * @param router - Express router to attach routes to
+ * @param ctx - shared manager registry and main BrowserWindow
+ */
 export function registerSnapshotRoutes(router: Router, ctx: RouteContext): void {
   // ═══════════════════════════════════════════════
   // SNAPSHOTS — Accessibility-tree based interaction

--- a/src/api/routes/sync.ts
+++ b/src/api/routes/sync.ts
@@ -3,6 +3,11 @@ import type { RouteContext } from '../context';
 import { createRateLimitMiddleware } from '../rate-limit';
 import { normalizeExistingDirectoryPath } from '../../utils/security';
 
+/**
+ * Register cross-device sync routes (config, remote devices, tabs).
+ * @param router - Express router to attach routes to
+ * @param ctx - shared manager registry and main BrowserWindow
+ */
 export function registerSyncRoutes(router: Router, ctx: RouteContext): void {
   // ═══════════════════════════════════════════════
   // SYNC — Cross-device sync via shared folder

--- a/src/claronote/manager.ts
+++ b/src/claronote/manager.ts
@@ -45,6 +45,7 @@ export class ClaroNoteManager {
 
   // ═══ Authentication ═══
 
+  /** Authenticate with ClaroNote and persist the token to disk. */
   async login(email: string, password: string): Promise<{ success: boolean; error?: string }> {
     try {
       const response = await this.apiRequest('POST', '/auth/login', {
@@ -72,12 +73,14 @@ export class ClaroNoteManager {
     }
   }
 
+  /** Remove the stored ClaroNote auth token. */
   async logout(): Promise<void> {
     if (fs.existsSync(this.authFile)) {
       fs.unlinkSync(this.authFile);
     }
   }
 
+  /** Load and validate the persisted auth token, returning null if expired. */
   getAuth(): ClaroNoteAuth | null {
     try {
       if (!fs.existsSync(this.authFile)) return null;
@@ -96,6 +99,7 @@ export class ClaroNoteManager {
     }
   }
 
+  /** Fetch the authenticated user's profile from ClaroNote. */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- upstream auth payload is not versioned yet
   async getMe(): Promise<any> {
     const auth = this.getAuth();
@@ -104,12 +108,14 @@ export class ClaroNoteManager {
     return await this.apiRequest('GET', '/auth/me', null, auth.token);
   }
 
+  /** Check whether a valid (non-expired) auth token exists. */
   isAuthenticated(): boolean {
     return this.getAuth() !== null;
   }
 
   // ═══ Recording ═══
 
+  /** Start tracking a recording session (actual MediaRecorder lives in renderer). */
   async startRecording(): Promise<{ success: boolean; error?: string }> {
     try {
       if (this.isRecording) {
@@ -130,6 +136,7 @@ export class ClaroNoteManager {
     }
   }
 
+  /** Stop the current recording session. */
   async stopRecording(): Promise<{ success: boolean; noteId?: string; error?: string }> {
     try {
       if (!this.isRecording) {
@@ -158,6 +165,7 @@ export class ClaroNoteManager {
     }
   }
 
+  /** Get the current recording state, including elapsed duration. */
   getRecordingStatus(): { 
     isRecording: boolean; 
     duration?: number; 
@@ -172,6 +180,7 @@ export class ClaroNoteManager {
 
   // ═══ Notes Management ═══
 
+  /** Fetch recent notes from ClaroNote, sorted newest first. */
   async getNotes(limit: number = 10): Promise<ClaroNote[]> {
     const auth = this.getAuth();
     if (!auth) throw new Error('Not authenticated');
@@ -180,6 +189,7 @@ export class ClaroNoteManager {
     return response.data || response;
   }
 
+  /** Fetch a single note by ID from ClaroNote. */
   async getNote(noteId: string): Promise<ClaroNote> {
     const auth = this.getAuth();
     if (!auth) throw new Error('Not authenticated');
@@ -189,6 +199,10 @@ export class ClaroNoteManager {
 
   // ═══ Public Methods for Audio Upload ═══
 
+  /**
+   * Upload an audio recording buffer to ClaroNote for transcription.
+   * @returns the created note ID
+   */
   async uploadRecording(audioBuffer: Buffer, duration: number): Promise<string> {
     const auth = this.getAuth();
     if (!auth) throw new Error('Not authenticated');

--- a/src/integrations/google-photos.ts
+++ b/src/integrations/google-photos.ts
@@ -84,6 +84,7 @@ export class GooglePhotosManager {
     this.authPath = path.join(baseDir, 'google-photos-auth.json');
   }
 
+  /** Get the current connection and configuration status. */
   getStatus(): GooglePhotosStatus {
     const config = this.configManager.getConfig();
     const auth = this.loadAuth();
@@ -96,10 +97,12 @@ export class GooglePhotosManager {
     };
   }
 
+  /** Get the configured Google OAuth client ID. */
   getClientId(): string {
     return parseJsonFile<GooglePhotosConfig>(this.configPath)?.clientId?.trim() ?? '';
   }
 
+  /** Set or clear the Google OAuth client ID. */
   setClientId(clientId: string): GooglePhotosStatus {
     const trimmed = clientId.trim();
     if (!trimmed) {
@@ -117,6 +120,7 @@ export class GooglePhotosManager {
     };
   }
 
+  /** Start the OAuth PKCE flow and return the authorization URL for the browser. */
   beginAuth(): string {
     const clientId = this.getClientId();
     if (!clientId) {
@@ -143,6 +147,7 @@ export class GooglePhotosManager {
     return `${GOOGLE_AUTH_URL}?${params.toString()}`;
   }
 
+  /** Complete the OAuth flow by exchanging the authorization code for tokens. */
   async completeAuth(opts: { code?: string; state?: string; error?: string }): Promise<void> {
     if (opts.error) {
       throw new Error(`Google OAuth failed: ${opts.error}`);
@@ -185,6 +190,7 @@ export class GooglePhotosManager {
     });
   }
 
+  /** Disconnect from Google Photos by deleting stored auth tokens. */
   disconnect(): GooglePhotosStatus {
     this.pendingAuth = null;
     if (fs.existsSync(this.authPath)) {
@@ -193,6 +199,7 @@ export class GooglePhotosManager {
     return this.getStatus();
   }
 
+  /** Upload a screenshot file to Google Photos, returning null if not configured. */
   async uploadScreenshot(filePath: string): Promise<GooglePhotosUploadResult | null> {
     const config = this.configManager.getConfig();
     if (!config.screenshots.googlePhotos) {

--- a/src/passwords/manager.ts
+++ b/src/passwords/manager.ts
@@ -83,11 +83,13 @@ export class PasswordManager {
         }
     }
 
+    /** Lock the vault and wipe the in-memory key. */
     public lock() {
         this.vaultKey = null;
         this.isUnlocked = false;
     }
 
+    /** Whether the vault is currently unlocked. */
     public get isVaultUnlocked() {
         return this.isUnlocked;
     }
@@ -162,6 +164,7 @@ export class PasswordManager {
 }
 let _instance: PasswordManager | null = null;
 
+/** Get or create the singleton PasswordManager instance. */
 export function getPasswordManager(): PasswordManager {
   if (!_instance) {
     _instance = new PasswordManager();

--- a/src/sync/manager.ts
+++ b/src/sync/manager.ts
@@ -47,6 +47,7 @@ export class SyncManager {
     return SyncManager.sanitizeDeviceName(os.hostname());
   }
 
+  /** Initialize sync with the given config, creating the directory structure on disk. */
   init(config: SyncConfig): void {
     this.config = config;
     if (!this.isConfigured()) {
@@ -68,6 +69,7 @@ export class SyncManager {
     log.info(`Sync initialized: ${config.syncRoot} (device: ${config.deviceName})`);
   }
 
+  /** Check whether sync is enabled, configured, and the sync root exists. */
   isConfigured(): boolean {
     return !!(this.config && this.config.enabled && this.config.syncRoot && fs.existsSync(this.config.syncRoot));
   }
@@ -170,6 +172,7 @@ export class SyncManager {
     }
   }
 
+  /** Clean up resources (currently a no-op). */
   destroy(): void {
     // nothing to clean up
   }


### PR DESCRIPTION
## Summary
- Add JSDoc to `SyncManager` — init, isConfigured, destroy (3 methods)
- Add JSDoc to `PasswordManager` — lock, isVaultUnlocked, getPasswordManager (3 methods)
- Add JSDoc to `ClaroNoteManager` — all 11 public methods
- Add JSDoc to `GooglePhotosManager` — all 7 public methods
- Add JSDoc to 11 route registration functions: sync, snapshots, previews, devtools, clipboard, agents, misc, awareness, media, extensions, data
- All other remaining managers (config, pip, headless, extensions, devtools, snapshot, clipboard, context-menu, draw, activity, voice, behavior, watch, bridge, chrome-importer, video, content, workflow, auth, events, task, tab-lock, wingman-stream, scripts, locators, device) already had full JSDoc coverage

## Scope
PR 5 of 5 — Everything remaining.

## Test plan
- [x] `npm run verify` passes (compile + lint + test)
- [x] No code logic changes — JSDoc comments only