### PR TITLE
fix(tests): resolve flaky API route tests (IPv6/IPv4 port collision)

### DIFF
--- a/src/api/tests/setup.ts
+++ b/src/api/tests/setup.ts
@@ -1,0 +1,34 @@
+/**
+ * Fix sporadic test failures caused by IPv4/IPv6 port collisions.
+ *
+ * Root cause: Node.js `server.listen(0)` binds to `::` (IPv6 dual-stack) by
+ * default, but supertest always connects to `127.0.0.1` (IPv4). On macOS,
+ * when another process (Tailscale, OpenClaw, etc.) holds the same port on
+ * IPv4, the OS routes the IPv4 connection to that process instead of the
+ * test server — producing sporadic 404s, 401s, or socket hang-ups.
+ *
+ * Fix: monkey-patch supertest's Test.serverAddress to use the address the
+ * server actually bound to (`[::1]` for IPv6) instead of hardcoded
+ * `127.0.0.1`.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { Server: TlsServer } = require('tls');
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Test = require('supertest/lib/test');
+
+Test.prototype.serverAddress = function (app: any, path: string) {
+  const addr = app.address();
+  if (!addr) {
+    this._server = app.listen(0);
+  }
+
+  const resolved = app.address();
+  const port = resolved.port;
+  const protocol = app instanceof TlsServer ? 'https' : 'http';
+
+  // Use the actual bound address instead of always 127.0.0.1
+  const host = resolved.family === 'IPv6' ? `[::1]` : '127.0.0.1';
+  return `${protocol}://${host}:${port}${path}`;
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
     include: [
       'src/**/tests/**/*.test.ts',
     ],
+    setupFiles: [
+      'src/api/tests/setup.ts',
+    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html'],


### PR DESCRIPTION
## Summary
- Fix sporadic test failures (~30% failure rate) in API route tests
- Root cause: Node.js `server.listen(0)` binds to `::` (IPv6), but supertest connects to `127.0.0.1` (IPv4). When another local process (Tailscale, OpenClaw) holds the same port on IPv4, requests hit the wrong server
- Fix: vitest setup file patches supertest's `serverAddress` to use the actual bound address (`[::1]` for IPv6)

## Root cause analysis
1. `server.listen(0)` → OS assigns port 49296 on IPv6 `[::]`
2. Tailscale/OpenClaw holds port 49296 on IPv4 `127.0.0.1`
3. Supertest connects to `http://127.0.0.1:49296/test` → hits Tailscale (401) or OpenClaw (404)
4. Test fails with unexpected status code

## Verification
- Before: 21/30 full-suite runs pass (~30% flake rate)
- After: **30/30 full-suite runs pass** (0% flake rate)

## Test plan
- [x] `npm run verify` passes
- [x] 30 consecutive full-suite runs all pass
- [x] Minimal reproduction (200 rapid supertest requests) passes 30/30