### PR TITLE
docs: add API reference page + sponsor CTA (P2-02, P2-03)

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -1,0 +1,608 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>API Reference — Tandem Browser</title>
+<meta name="description" content="Complete HTTP API reference for Tandem Browser. 280+ endpoints across 19 route domains. Browse, click, type, extract, automate.">
+<meta property="og:title" content="Tandem Browser API Reference">
+<meta property="og:description" content="280+ HTTP endpoints for AI-human browser collaboration. Full programmatic control.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://tandembrowser.org/api">
+<link rel="canonical" href="https://tandembrowser.org/api">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,600;1,8..60,400&display=swap" rel="stylesheet">
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+:root{
+--bg:#0a0a0b;--bg2:#111113;--bg3:#1a1a1d;
+--text:#e8e6e0;--text2:#a8a6a0;--text3:#6a6862;
+--accent:#da7756;--accent2:#e89b7d;
+--green:#5DCAA5;--blue:#85B7EB;--red:#F09595;
+--mono:'JetBrains Mono',monospace;
+--serif:'Source Serif 4',Georgia,serif;
+--border:#2a2a2d;
+}
+html{scroll-behavior:smooth;font-size:16px}
+body{background:var(--bg);color:var(--text);font-family:var(--mono);line-height:1.7;overflow-x:hidden}
+a{color:var(--accent);text-decoration:none;transition:color .2s}
+a:hover{color:var(--accent2)}
+
+.grain{position:fixed;top:0;left:0;width:100%;height:100%;pointer-events:none;opacity:.03;z-index:9999;
+background-image:url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")}
+
+header{padding:2rem 0;border-bottom:1px solid var(--border)}
+.nav{max-width:960px;margin:0 auto;padding:0 2rem;display:flex;justify-content:space-between;align-items:center}
+.logo{font-size:1.1rem;font-weight:600;letter-spacing:-.02em;color:var(--text)}
+.logo span{color:var(--accent)}
+.nav-links{display:flex;gap:1.5rem;font-size:.8rem;color:var(--text2)}
+.nav-links a{color:var(--text2)}
+.nav-links a:hover{color:var(--text)}
+.nav-links a.active{color:var(--accent)}
+
+.hero{max-width:960px;margin:0 auto;padding:4rem 2rem 3rem}
+.hero-label{font-size:.75rem;color:var(--accent);letter-spacing:.15em;text-transform:uppercase;margin-bottom:1rem}
+.hero h1{font-family:var(--serif);font-size:clamp(1.6rem,4vw,2.4rem);font-weight:600;line-height:1.2;letter-spacing:-.03em;color:var(--text);margin-bottom:1rem}
+.hero p{font-size:.85rem;color:var(--text2);max-width:580px;line-height:1.8}
+.hero-stats{display:flex;gap:2.5rem;margin-top:1.5rem}
+.stat{display:flex;flex-direction:column}
+.stat-num{font-size:1.2rem;font-weight:600;color:var(--text)}
+.stat-label{font-size:.65rem;color:var(--text3);text-transform:uppercase;letter-spacing:.1em}
+
+section{max-width:960px;margin:0 auto;padding:3rem 2rem}
+.divider{max-width:960px;margin:0 auto;padding:0 2rem}
+.divider hr{border:none;border-top:1px solid var(--border)}
+
+.toc{display:grid;grid-template-columns:repeat(3,1fr);gap:.75rem;margin-top:1.5rem}
+.toc a{display:block;padding:.75rem 1rem;border:1px solid var(--border);border-radius:4px;background:var(--bg2);font-size:.75rem;color:var(--text2);transition:all .2s}
+.toc a:hover{border-color:var(--accent);color:var(--text)}
+.toc a .count{color:var(--text3);font-size:.65rem}
+
+.domain{margin-top:1rem}
+.domain-header{display:flex;align-items:baseline;gap:.75rem;margin-bottom:1rem;padding-top:2rem}
+.domain-name{font-family:var(--serif);font-size:1.3rem;font-weight:600;color:var(--text)}
+.domain-count{font-size:.7rem;color:var(--text3)}
+.domain-desc{font-size:.8rem;color:var(--text2);margin-bottom:1.25rem}
+
+.endpoint{display:grid;grid-template-columns:70px 1fr;gap:.75rem;padding:.5rem 0;border-bottom:1px solid rgba(42,42,45,.5);font-size:.78rem;align-items:baseline}
+.endpoint:last-child{border-bottom:none}
+.method{font-weight:600;font-size:.7rem;letter-spacing:.05em}
+.method.get{color:var(--green)}
+.method.post{color:var(--blue)}
+.method.put{color:var(--accent)}
+.method.patch{color:var(--accent2)}
+.method.delete{color:var(--red)}
+.path{color:var(--text)}
+.desc{color:var(--text3);font-size:.72rem;margin-left:.5rem}
+
+.info-box{margin-top:2rem;padding:1.25rem;background:var(--bg2);border:1px solid var(--border);border-radius:6px;font-size:.8rem}
+.info-box p{color:var(--text2);line-height:1.7}
+.info-box code{background:var(--bg3);padding:.15rem .4rem;border-radius:3px;font-size:.75rem;color:var(--green)}
+
+footer{max-width:960px;margin:0 auto;padding:3rem 2rem;border-top:1px solid var(--border);
+display:flex;justify-content:space-between;align-items:center;font-size:.75rem;color:var(--text3)}
+footer a{color:var(--text3)}
+footer a:hover{color:var(--text2)}
+
+@media(max-width:700px){
+.toc{grid-template-columns:1fr 1fr}
+.nav-links{display:none}
+.hero-stats{flex-wrap:wrap;gap:1.5rem}
+}
+@media(max-width:500px){
+.toc{grid-template-columns:1fr}
+}
+</style>
+</head>
+<body>
+<div class="grain"></div>
+
+<header>
+<nav class="nav">
+<div class="logo"><a href="/" style="color:var(--text)"><span>Tandem</span> Browser</a></div>
+<div class="nav-links">
+<a href="/">Home</a>
+<a href="/api" class="active">API</a>
+<a href="https://github.com/hydro13/tandem-browser">GitHub</a>
+<a href="https://github.com/sponsors/hydro13" style="color:var(--accent)">Sponsor</a>
+</div>
+</nav>
+</header>
+
+<div class="hero">
+<div class="hero-label">HTTP API Reference</div>
+<h1>Full programmatic control over a real browser</h1>
+<p>Every endpoint runs on <code style="background:var(--bg3);padding:.15rem .4rem;border-radius:3px;font-size:.8rem;color:var(--green)">localhost:8765</code>. All responses return <code style="background:var(--bg3);padding:.15rem .4rem;border-radius:3px;font-size:.8rem;color:var(--green)">{ ok: true, data }</code> on success.</p>
+<div class="hero-stats">
+<div class="stat"><span class="stat-num">280+</span><span class="stat-label">Endpoints</span></div>
+<div class="stat"><span class="stat-num">19</span><span class="stat-label">Domains</span></div>
+<div class="stat"><span class="stat-num">236</span><span class="stat-label">MCP tools</span></div>
+</div>
+</div>
+
+<div class="divider"><hr></div>
+
+<section>
+<div class="toc">
+<a href="#browser">Browser <span class="count">16</span></a>
+<a href="#tabs">Tabs <span class="count">8</span></a>
+<a href="#snapshots">Snapshots <span class="count">8</span></a>
+<a href="#content">Content <span class="count">17</span></a>
+<a href="#devtools">DevTools <span class="count">16</span></a>
+<a href="#network">Network <span class="count">11</span></a>
+<a href="#agents">Agents <span class="count">16</span></a>
+<a href="#sessions">Sessions <span class="count">13</span></a>
+<a href="#workspaces">Workspaces <span class="count">8</span></a>
+<a href="#pinboards">Pinboards <span class="count">11</span></a>
+<a href="#sidebar">Sidebar <span class="count">6</span></a>
+<a href="#data">Data <span class="count">36</span></a>
+<a href="#extensions">Extensions <span class="count">18</span></a>
+<a href="#clipboard">Clipboard <span class="count">4</span></a>
+<a href="#awareness">Awareness <span class="count">2</span></a>
+<a href="#media">Media <span class="count">24</span></a>
+<a href="#previews">Previews <span class="count">7</span></a>
+<a href="#sync">Sync <span class="count">4</span></a>
+<a href="#misc">Misc <span class="count">60+</span></a>
+</div>
+</section>
+
+<div class="divider"><hr></div>
+
+<!-- Browser -->
+<section>
+<div class="domain" id="browser">
+<div class="domain-header"><span class="domain-name">Browser</span><span class="domain-count">browser.ts</span></div>
+<div class="domain-desc">Core browsing actions — navigate, click, type, scroll, screenshot, execute JavaScript.</div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/navigate <span class="desc">Navigate to URL</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/page-content <span class="desc">Get page content as markdown</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/page-html <span class="desc">Get raw page HTML</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/click <span class="desc">Click element</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/type <span class="desc">Type text into element</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/execute-js <span class="desc">Execute JavaScript in page</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/screenshot <span class="desc">Take screenshot</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/cookies <span class="desc">Get cookies for current page</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/cookies/clear <span class="desc">Clear cookies</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/scroll <span class="desc">Scroll page</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/press-key <span class="desc">Press keyboard key</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/press-key-combo <span class="desc">Press key combination</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/wingman-alert <span class="desc">Show alert dialog</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/wait <span class="desc">Wait for element or page load</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/links <span class="desc">Get all links on page</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/forms <span class="desc">Get all forms on page</span></span></div>
+</div>
+</section>
+
+<div class="divider"><hr></div>
+
+<!-- Tabs -->
+<section>
+<div class="domain" id="tabs">
+<div class="domain-header"><span class="domain-name">Tabs</span><span class="domain-count">tabs.ts</span></div>
+<div class="domain-desc">Tab lifecycle — open, close, focus, group, and manage tabs.</div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/tabs/open <span class="desc">Open new tab</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/tabs/close <span class="desc">Close tab</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/tabs/list <span class="desc">List all open tabs</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/tabs/focus <span class="desc">Focus/switch to tab</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/tabs/group <span class="desc">Group tabs together</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/tabs/source <span class="desc">Set tab source (agent owner)</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/tabs/reconcile <span class="desc">Reconcile tabs with renderer</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/tabs/cleanup <span class="desc">Cleanup zombie tabs</span></span></div>
+</div>
+</section>
+
+<div class="divider"><hr></div>
+
+<!-- Snapshots -->
+<section>
+<div class="domain" id="snapshots">
+<div class="domain-header"><span class="domain-name">Snapshots</span><span class="domain-count">snapshots.ts</span></div>
+<div class="domain-desc">Accessibility tree snapshots — the universal API for AI to read and interact with any website.</div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/snapshot <span class="desc">Get accessibility tree with @ref IDs</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/snapshot/click <span class="desc">Click element by @ref</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/snapshot/fill <span class="desc">Fill input by @ref</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/snapshot/text <span class="desc">Get text content by @ref</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/find <span class="desc">Find element by label/text/role</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/find/click <span class="desc">Find and click element</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/find/fill <span class="desc">Find and fill element</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/find/all <span class="desc">Find all matching elements</span></span></div>
+</div>
+</section>
+
+<div class="divider"><hr></div>
+
+<!-- Content -->
+<section>
+<div class="domain" id="content">
+<div class="domain-header"><span class="domain-name">Content</span><span class="domain-count">content.ts</span></div>
+<div class="domain-desc">Page content extraction, context search, user scripts and styles.</div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/content/extract <span class="desc">Extract page as markdown</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/content/extract/url <span class="desc">Extract content from URL</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/context/recent <span class="desc">Get recently visited pages</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/context/search <span class="desc">Search browsing context</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/context/page <span class="desc">Get page details</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/context/summary <span class="desc">Get context summary</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/context/note <span class="desc">Add note to page</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/scripts <span class="desc">List user scripts</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/scripts/add <span class="desc">Add user script</span></span></div>
+<div class="endpoint"><span class="method delete">DELETE</span><span class="path">/scripts/remove <span class="desc">Remove script</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/scripts/enable <span class="desc">Enable script</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/scripts/disable <span class="desc">Disable script</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/styles <span class="desc">List user styles</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/styles/add <span class="desc">Add CSS style</span></span></div>
+<div class="endpoint"><span class="method delete">DELETE</span><span class="path">/styles/remove <span class="desc">Remove style</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/styles/enable <span class="desc">Enable style</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/styles/disable <span class="desc">Disable style</span></span></div>
+</div>
+</section>
+
+<div class="divider"><hr></div>
+
+<!-- DevTools -->
+<section>
+<div class="domain" id="devtools">
+<div class="domain-header"><span class="domain-name">DevTools</span><span class="domain-count">devtools.ts</span></div>
+<div class="domain-desc">Chrome DevTools Protocol bridge — console, network, DOM, storage, performance.</div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/devtools/status <span class="desc">Get DevTools status</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/devtools/console <span class="desc">Get console entries</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/devtools/console/errors <span class="desc">Get console errors only</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/devtools/console/clear <span class="desc">Clear console</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/devtools/network <span class="desc">Get network entries</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/devtools/network/:requestId/body <span class="desc">Get response body</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/devtools/network/clear <span class="desc">Clear network log</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/devtools/dom/query <span class="desc">Query DOM with CSS selector</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/devtools/dom/xpath <span class="desc">Query DOM with XPath</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/devtools/storage <span class="desc">Get storage data</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/devtools/performance <span class="desc">Get performance metrics</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/devtools/evaluate <span class="desc">Evaluate JavaScript via CDP</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/devtools/cdp <span class="desc">Send raw CDP command</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/devtools/screenshot/element <span class="desc">Screenshot specific element</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/devtools/shell <span class="desc">Toggle shell DevTools</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/devtools/toggle <span class="desc">Toggle page DevTools</span></span></div>
+</div>
+</section>
+
+<div class="divider"><hr></div>
+
+<!-- Network -->
+<section>
+<div class="domain" id="network">
+<div class="domain-header"><span class="domain-name">Network</span><span class="domain-count">network.ts</span></div>
+<div class="domain-desc">Network inspection, HAR export, request mocking.</div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/network/log <span class="desc">Get network log</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/network/apis <span class="desc">List detected API endpoints</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/network/domains <span class="desc">List contacted domains</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/network/har <span class="desc">Export as HAR file</span></span></div>
+<div class="endpoint"><span class="method delete">DELETE</span><span class="path">/network/clear <span class="desc">Clear network log</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/network/mock <span class="desc">Add mock rule</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/network/route <span class="desc">Add route (alias for mock)</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/network/mocks <span class="desc">List active mocks</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/network/unmock <span class="desc">Remove mock rule</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/network/unroute <span class="desc">Remove route (alias)</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/network/mock-clear <span class="desc">Clear all mocks</span></span></div>
+</div>
+</section>
+
+<div class="divider"><hr></div>
+
+<!-- Agents -->
+<section>
+<div class="domain" id="agents">
+<div class="domain-header"><span class="domain-name">Agents</span><span class="domain-count">agents.ts</span></div>
+<div class="domain-desc">Multi-agent coordination — tasks, tab locks, autonomy, emergency stop.</div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/tasks <span class="desc">List all tasks</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/tasks/:id <span class="desc">Get task by ID</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/tasks <span class="desc">Create new task</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/tasks/:id/approve <span class="desc">Approve task step</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/tasks/:id/reject <span class="desc">Reject task step</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/tasks/:id/status <span class="desc">Update task status</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/emergency-stop <span class="desc">Stop all agent tasks</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/execute-js/confirm <span class="desc">Execute JS with approval</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/tasks/check-approval <span class="desc">Check if approval needed</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/autonomy <span class="desc">Get autonomy settings</span></span></div>
+<div class="endpoint"><span class="method patch">PATCH</span><span class="path">/autonomy <span class="desc">Update autonomy level</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/activity-log/agent <span class="desc">Get agent activity log</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/tab-locks <span class="desc">List all tab locks</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/tab-locks/acquire <span class="desc">Acquire tab lock</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/tab-locks/release <span class="desc">Release tab lock</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/tab-locks/:tabId <span class="desc">Get lock status for tab</span></span></div>
+</div>
+</section>
+
+<div class="divider"><hr></div>
+
+<!-- Sessions -->
+<section>
+<div class="domain" id="sessions">
+<div class="domain-header"><span class="domain-name">Sessions</span><span class="domain-count">sessions.ts</span></div>
+<div class="domain-desc">Isolated browser sessions, device emulation, session state persistence.</div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/sessions/list <span class="desc">List all sessions</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/sessions/create <span class="desc">Create new session</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/sessions/switch <span class="desc">Switch active session</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/sessions/destroy <span class="desc">Destroy session</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/sessions/state/save <span class="desc">Save session state</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/sessions/state/load <span class="desc">Load session state</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/sessions/state/list <span class="desc">List saved states</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/sessions/fetch <span class="desc">Fetch URL in session context</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/sessions/auth-headers <span class="desc">Get auth headers</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/device/profiles <span class="desc">List device profiles</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/device/status <span class="desc">Get emulation status</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/device/emulate <span class="desc">Start device emulation</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/device/reset <span class="desc">Reset to desktop</span></span></div>
+</div>
+</section>
+
+<div class="divider"><hr></div>
+
+<!-- Workspaces -->
+<section>
+<div class="domain" id="workspaces">
+<div class="domain-header"><span class="domain-name">Workspaces</span><span class="domain-count">workspaces.ts</span></div>
+<div class="domain-desc">Named tab groups with icons and persistence — one workspace per agent.</div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/workspaces <span class="desc">List all workspaces</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/workspaces <span class="desc">Create workspace</span></span></div>
+<div class="endpoint"><span class="method delete">DELETE</span><span class="path">/workspaces/:id <span class="desc">Delete workspace</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/workspaces/:id/activate <span class="desc">Activate workspace</span></span></div>
+<div class="endpoint"><span class="method put">PUT</span><span class="path">/workspaces/:id <span class="desc">Update workspace</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/workspaces/:id/tabs <span class="desc">Move tab to workspace</span></span></div>
+</div>
+</section>
+
+<div class="divider"><hr></div>
+
+<!-- Pinboards -->
+<section>
+<div class="domain" id="pinboards">
+<div class="domain-header"><span class="domain-name">Pinboards</span><span class="domain-count">pinboards.ts</span></div>
+<div class="domain-desc">Visual boards for saving and organizing content — links, notes, images.</div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/pinboards <span class="desc">List all pinboards</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/pinboards <span class="desc">Create pinboard</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/pinboards/:id <span class="desc">Get pinboard with items</span></span></div>
+<div class="endpoint"><span class="method put">PUT</span><span class="path">/pinboards/:id <span class="desc">Update pinboard</span></span></div>
+<div class="endpoint"><span class="method put">PUT</span><span class="path">/pinboards/:id/settings <span class="desc">Update board appearance</span></span></div>
+<div class="endpoint"><span class="method delete">DELETE</span><span class="path">/pinboards/:id <span class="desc">Delete pinboard</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/pinboards/:id/items <span class="desc">Get board items</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/pinboards/:id/items <span class="desc">Add item to board</span></span></div>
+<div class="endpoint"><span class="method put">PUT</span><span class="path">/pinboards/:id/items/:itemId <span class="desc">Update item</span></span></div>
+<div class="endpoint"><span class="method delete">DELETE</span><span class="path">/pinboards/:id/items/:itemId <span class="desc">Delete item</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/pinboards/:id/items/reorder <span class="desc">Reorder items</span></span></div>
+</div>
+</section>
+
+<div class="divider"><hr></div>
+
+<!-- Sidebar -->
+<section>
+<div class="domain" id="sidebar">
+<div class="domain-header"><span class="domain-name">Sidebar</span><span class="domain-count">sidebar.ts</span></div>
+<div class="domain-desc">Left sidebar configuration, panel routing, item management.</div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/sidebar/config <span class="desc">Get sidebar config</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/sidebar/config <span class="desc">Update sidebar config</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/sidebar/items/:id/toggle <span class="desc">Toggle sidebar item</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/sidebar/items/:id/activate <span class="desc">Activate sidebar item</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/sidebar/reorder <span class="desc">Reorder sidebar items</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/sidebar/state <span class="desc">Set sidebar open/closed state</span></span></div>
+</div>
+</section>
+
+<div class="divider"><hr></div>
+
+<!-- Data -->
+<section>
+<div class="domain" id="data">
+<div class="domain-header"><span class="domain-name">Data</span><span class="domain-count">data.ts</span></div>
+<div class="domain-desc">Bookmarks, history, downloads, configuration, Chrome import, data export.</div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/bookmarks <span class="desc">List all bookmarks</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/bookmarks/add <span class="desc">Create bookmark</span></span></div>
+<div class="endpoint"><span class="method delete">DELETE</span><span class="path">/bookmarks/remove <span class="desc">Remove bookmark</span></span></div>
+<div class="endpoint"><span class="method put">PUT</span><span class="path">/bookmarks/update <span class="desc">Update bookmark</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/bookmarks/add-folder <span class="desc">Create folder</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/bookmarks/move <span class="desc">Move bookmark</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/bookmarks/search <span class="desc">Search bookmarks</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/bookmarks/check <span class="desc">Check if URL bookmarked</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/history <span class="desc">List history entries</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/history/search <span class="desc">Search history</span></span></div>
+<div class="endpoint"><span class="method delete">DELETE</span><span class="path">/history/clear <span class="desc">Clear all history</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/downloads <span class="desc">List downloads</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/downloads/active <span class="desc">List active downloads</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/config <span class="desc">Get app configuration</span></span></div>
+<div class="endpoint"><span class="method patch">PATCH</span><span class="path">/config <span class="desc">Update configuration</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/data/export <span class="desc">Export all user data</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/data/import <span class="desc">Import user data</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/import/chrome/status <span class="desc">Chrome import status</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/import/chrome/bookmarks <span class="desc">Import Chrome bookmarks</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/import/chrome/history <span class="desc">Import Chrome history</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/import/chrome/cookies <span class="desc">Import Chrome cookies</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/import/chrome/profiles <span class="desc">List Chrome profiles</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/import/chrome/sync/start <span class="desc">Start Chrome sync</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/import/chrome/sync/stop <span class="desc">Stop Chrome sync</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/import/chrome/sync/status <span class="desc">Chrome sync status</span></span></div>
+</div>
+</section>
+
+<div class="divider"><hr></div>
+
+<!-- Extensions -->
+<section>
+<div class="domain" id="extensions">
+<div class="domain-header"><span class="domain-name">Extensions</span><span class="domain-count">extensions.ts</span></div>
+<div class="domain-desc">Chrome extension management — install, load, import from Chrome, update.</div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/extensions/list <span class="desc">List installed extensions</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/extensions/load <span class="desc">Load from path</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/extensions/install <span class="desc">Install from Chrome Web Store</span></span></div>
+<div class="endpoint"><span class="method delete">DELETE</span><span class="path">/extensions/uninstall/:id <span class="desc">Uninstall extension</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/extensions/chrome/list <span class="desc">List Chrome extensions</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/extensions/chrome/import <span class="desc">Import from Chrome</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/extensions/gallery <span class="desc">Get extension gallery</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/extensions/native-messaging/status <span class="desc">Native messaging status</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/extensions/updates/check <span class="desc">Check for updates</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/extensions/updates/status <span class="desc">Get update status</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/extensions/updates/apply <span class="desc">Apply updates</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/extensions/disk-usage <span class="desc">Get disk usage</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/extensions/conflicts <span class="desc">Get conflicts</span></span></div>
+</div>
+</section>
+
+<div class="divider"><hr></div>
+
+<!-- Clipboard -->
+<section>
+<div class="domain" id="clipboard">
+<div class="domain-header"><span class="domain-name">Clipboard</span><span class="domain-count">clipboard.ts</span></div>
+<div class="domain-desc">Read and write the system clipboard.</div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/clipboard <span class="desc">Read clipboard contents</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/clipboard/text <span class="desc">Write text to clipboard</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/clipboard/image <span class="desc">Write image to clipboard</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/clipboard/save <span class="desc">Save clipboard as file</span></span></div>
+</div>
+</section>
+
+<div class="divider"><hr></div>
+
+<!-- Awareness -->
+<section>
+<div class="domain" id="awareness">
+<div class="domain-header"><span class="domain-name">Awareness</span><span class="domain-count">awareness.ts</span></div>
+<div class="domain-desc">AI awareness of human browsing activity.</div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/awareness/digest <span class="desc">Get activity digest</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/awareness/focus <span class="desc">Get current focus activity</span></span></div>
+</div>
+</section>
+
+<div class="divider"><hr></div>
+
+<!-- Media -->
+<section>
+<div class="domain" id="media">
+<div class="domain-header"><span class="domain-name">Media</span><span class="domain-count">media.ts</span></div>
+<div class="domain-desc">Voice, audio, video, screenshots, annotations, Wingman panel, chat.</div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/panel/toggle <span class="desc">Toggle Wingman panel</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/chat <span class="desc">Get chat messages</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/chat <span class="desc">Send chat message</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/voice/start <span class="desc">Start voice recognition</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/voice/stop <span class="desc">Stop voice recognition</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/voice/status <span class="desc">Get voice status</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/audio/start <span class="desc">Start audio recording</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/audio/stop <span class="desc">Stop audio recording</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/audio/status <span class="desc">Recording status</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/audio/recordings <span class="desc">List recordings</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/screenshot/annotated <span class="desc">Get annotated screenshot</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/screenshot/annotated <span class="desc">Capture annotated screenshot</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/draw/toggle <span class="desc">Toggle draw mode</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/screenshots <span class="desc">List all screenshots</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/wingman-stream/toggle <span class="desc">Toggle activity stream</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/wingman-stream/status <span class="desc">Stream status</span></span></div>
+</div>
+</section>
+
+<div class="divider"><hr></div>
+
+<!-- Previews -->
+<section>
+<div class="domain" id="previews">
+<div class="domain-header"><span class="domain-name">Previews</span><span class="domain-count">previews.ts</span></div>
+<div class="domain-desc">Live HTML previews created by agents — auto-refreshing in browser tabs.</div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/previews <span class="desc">List all previews</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/preview <span class="desc">Create preview</span></span></div>
+<div class="endpoint"><span class="method put">PUT</span><span class="path">/preview/:id <span class="desc">Update preview</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/preview/:id/meta <span class="desc">Get preview metadata</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/preview/:id <span class="desc">Serve preview HTML</span></span></div>
+<div class="endpoint"><span class="method delete">DELETE</span><span class="path">/preview/:id <span class="desc">Delete preview</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/previews/index <span class="desc">Preview index page</span></span></div>
+</div>
+</section>
+
+<div class="divider"><hr></div>
+
+<!-- Sync -->
+<section>
+<div class="domain" id="sync">
+<div class="domain-header"><span class="domain-name">Sync</span><span class="domain-count">sync.ts</span></div>
+<div class="domain-desc">Local sync and data export across devices.</div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/sync/status <span class="desc">Get sync status</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/sync/devices <span class="desc">List remote devices</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/sync/config <span class="desc">Configure sync</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/sync/trigger <span class="desc">Trigger sync</span></span></div>
+</div>
+</section>
+
+<div class="divider"><hr></div>
+
+<!-- Misc -->
+<section>
+<div class="domain" id="misc">
+<div class="domain-header"><span class="domain-name">Misc</span><span class="domain-count">misc.ts</span></div>
+<div class="domain-desc">Status, events, passwords, memory, watches, headless, workflows, auth, forms, and more.</div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/status <span class="desc">Get browser status</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/active-tab/context <span class="desc">Get active tab context for agents</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/events/stream <span class="desc">SSE event stream</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/events/recent <span class="desc">Get recent events</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/activity-log <span class="desc">Get activity log</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/live/status <span class="desc">Live mode status</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/live/toggle <span class="desc">Toggle live mode</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/security/injection-override <span class="desc">Override injection scanner</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/passwords/status <span class="desc">Password vault status</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/passwords/unlock <span class="desc">Unlock vault</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/passwords/lock <span class="desc">Lock vault</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/passwords/suggest <span class="desc">Get saved passwords</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/passwords/save <span class="desc">Save password</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/passwords/generate <span class="desc">Generate password</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/memory/sites <span class="desc">List sites with memory</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/memory/site/:domain <span class="desc">Get site memory</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/memory/site/:domain/diff <span class="desc">Get memory diffs</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/memory/search <span class="desc">Search memory</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/watch/add <span class="desc">Add page watch</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/watch/list <span class="desc">List watches</span></span></div>
+<div class="endpoint"><span class="method delete">DELETE</span><span class="path">/watch/remove <span class="desc">Remove watch</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/watch/check <span class="desc">Trigger watch check</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/headless/open <span class="desc">Open headless browser</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/headless/content <span class="desc">Get headless page content</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/headless/status <span class="desc">Headless browser status</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/headless/show <span class="desc">Show headless window</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/headless/hide <span class="desc">Hide headless window</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/headless/close <span class="desc">Close headless browser</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/forms/memory <span class="desc">List form memory</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/forms/memory/:domain <span class="desc">Get form data for domain</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/forms/fill <span class="desc">Get auto-fill data</span></span></div>
+<div class="endpoint"><span class="method delete">DELETE</span><span class="path">/forms/memory/:domain <span class="desc">Delete form memory</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/behavior/stats <span class="desc">Get behavior stats</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/behavior/clear <span class="desc">Clear behavior data</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/workflows <span class="desc">List workflows</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/workflows <span class="desc">Create workflow</span></span></div>
+<div class="endpoint"><span class="method delete">DELETE</span><span class="path">/workflows/:id <span class="desc">Delete workflow</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/workflow/run <span class="desc">Run workflow</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/workflow/status/:executionId <span class="desc">Get execution status</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/workflow/stop <span class="desc">Stop workflow</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/workflow/running <span class="desc">Get running workflows</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/auth/states <span class="desc">Get all auth states</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/auth/state/:domain <span class="desc">Get auth state for domain</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/auth/check <span class="desc">Check current page auth</span></span></div>
+<div class="endpoint"><span class="method get">GET</span><span class="path">/auth/is-login-page <span class="desc">Check if login page</span></span></div>
+<div class="endpoint"><span class="method post">POST</span><span class="path">/auth/update <span class="desc">Update auth state</span></span></div>
+<div class="endpoint"><span class="method delete">DELETE</span><span class="path">/auth/state/:domain <span class="desc">Delete auth state</span></span></div>
+</div>
+</section>
+
+<div class="divider"><hr></div>
+
+<!-- Info boxes -->
+<section>
+<div class="info-box">
+<p><strong>Base URL:</strong> <code>http://localhost:8765</code></p>
+<p style="margin-top:.5rem"><strong>Response format:</strong> All endpoints return <code>{ ok: true, data: ... }</code> on success and <code>{ ok: false, error: "message" }</code> on failure.</p>
+<p style="margin-top:.5rem"><strong>Tab targeting:</strong> Use the <code>X-Tab-Id</code> header to target a specific background tab without focusing it.</p>
+<p style="margin-top:.5rem"><strong>MCP alternative:</strong> Every HTTP endpoint has a corresponding MCP tool. See <a href="https://github.com/hydro13/tandem-browser/blob/main/skill/SKILL.md">skill/SKILL.md</a> for the MCP tool reference.</p>
+</div>
+</section>
+
+<footer>
+<div>&copy; 2026 Tandem Browser &middot; MIT License &middot; tandembrowser.org</div>
+<div>
+<a href="https://github.com/hydro13/tandem-browser">GitHub</a> &middot;
+<a href="https://github.com/sponsors/hydro13">Sponsor</a> &middot;
+<a href="https://github.com/hydro13/tandem-browser/issues">Issues</a>
+</div>
+</footer>
+
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -119,6 +119,7 @@ footer a:hover{color:var(--text2)}
 <div class="nav-links">
 <a href="#how">How it works</a>
 <a href="#security">Security</a>
+<a href="/api">API</a>
 <a href="#start">Get started</a>
 <a href="https://github.com/hydro13/tandem-browser">GitHub</a>
 <a href="https://github.com/sponsors/hydro13" style="color:var(--accent)">Sponsor</a>


### PR DESCRIPTION
## Summary
- **docs/api.html** — New full API reference page for tandembrowser.org with 280+ endpoints across 19 domains, matching existing site style
- **docs/index.html** — Added "API" nav link and sponsor CTA (nav badge, hero button, sponsor section, footer link)
- **SPONSORS.md** — Aligned tier prices with GitHub Sponsors: $15→$14, $30→$29, $50→$49, $150→$149, $500→$499

## Test plan
- [ ] Verify `npm run verify` passes (compile + lint + test) — confirmed locally
- [ ] Check API page renders correctly and navigation links work
- [ ] Confirm sponsor CTA elements display properly on index page
- [ ] Validate SPONSORS.md tier prices match GitHub Sponsors config