### PR TITLE
feat: add test coverage reporting and badge (P3-05)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -25,3 +25,12 @@ jobs:
 
       - name: Run repository verification
         run: npm run verify
+
+      - name: Generate coverage report
+        run: npx vitest run --coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage/coverage-summary.json
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![CodeQL](https://github.com/hydro13/tandem-browser/actions/workflows/codeql.yml/badge.svg)](https://github.com/hydro13/tandem-browser/actions/workflows/codeql.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Version](https://img.shields.io/github/package-json/v/hydro13/tandem-browser)](package.json)
+[![Coverage](https://codecov.io/gh/hydro13/tandem-browser/branch/main/graph/badge.svg)](https://codecov.io/gh/hydro13/tandem-browser)
 
 **236 MCP tools. Plug in any AI. No scraping. No API wrangling.**
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     ],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'html'],
+      reporter: ['text', 'html', 'json-summary'],
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/**/tests/**', 'node_modules'],
       reportOnFailure: true,


### PR DESCRIPTION
## Summary
- Add `json-summary` reporter to vitest coverage config
- Add coverage generation + Codecov upload step to `verify.yml` workflow
- Add Codecov badge to README (after Version badge)

Current overall line coverage: ~28% (unit tests cover API routes, tabs, config, security utils — many managers are untested as they require Electron runtime).

## Test plan
- [x] `npm run verify` passes locally (compile + lint + 1146 tests + consistency check)
- [ ] CI verify workflow runs coverage step successfully
- [ ] Codecov receives the upload (may need repo activation on codecov.io for the badge to render)