### PR TITLE
test(mcp): add unit tests for core MCP tools (P3-04c)

### DIFF
--- a/src/mcp/tests/bookmarks.test.ts
+++ b/src/mcp/tests/bookmarks.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn(),
+  logActivity: vi.fn(),
+}));
+
+import { apiCall, logActivity } from '../api-client.js';
+import { registerBookmarkTools } from '../tools/bookmarks.js';
+import { createMockServer, getHandler, expectTextContent } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+const mockLogActivity = vi.mocked(logActivity);
+
+describe('MCP bookmark tools', () => {
+  const { server, tools } = createMockServer();
+  registerBookmarkTools(server);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── tandem_bookmarks_list ─────────────────────────────────────────
+  describe('tandem_bookmarks_list', () => {
+    const handler = getHandler(tools, 'tandem_bookmarks_list');
+
+    it('returns the full bookmark tree', async () => {
+      const tree = { children: [{ name: 'GitHub', url: 'https://github.com' }] };
+      mockApiCall.mockResolvedValueOnce(tree);
+
+      const result = await handler({});
+      const text = expectTextContent(result);
+      expect(JSON.parse(text)).toEqual(tree);
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/bookmarks');
+    });
+  });
+
+  // ── tandem_bookmark_add ───────────────────────────────────────────
+  describe('tandem_bookmark_add', () => {
+    const handler = getHandler(tools, 'tandem_bookmark_add');
+
+    it('adds a bookmark with title', async () => {
+      mockApiCall.mockResolvedValueOnce({ bookmark: { name: 'My Site' } });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ url: 'https://my.site', title: 'My Site' });
+      expectTextContent(result, 'Bookmark added: My Site');
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/bookmarks/add', {
+        name: 'My Site', url: 'https://my.site', parentId: undefined,
+      });
+    });
+
+    it('uses URL as fallback title', async () => {
+      mockApiCall.mockResolvedValueOnce({ bookmark: { name: 'https://x.com' } });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      await handler({ url: 'https://x.com' });
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/bookmarks/add', {
+        name: 'https://x.com', url: 'https://x.com', parentId: undefined,
+      });
+    });
+
+    it('passes folderId as parentId', async () => {
+      mockApiCall.mockResolvedValueOnce({ bookmark: { name: 'A' } });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      await handler({ url: 'https://a.com', folderId: 'f1' });
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/bookmarks/add', {
+        name: 'https://a.com', url: 'https://a.com', parentId: 'f1',
+      });
+    });
+  });
+
+  // ── tandem_bookmark_delete ────────────────────────────────────────
+  describe('tandem_bookmark_delete', () => {
+    const handler = getHandler(tools, 'tandem_bookmark_delete');
+
+    it('deletes a bookmark', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: true });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ id: 'bm1' });
+      expectTextContent(result, 'Deleted bookmark: bm1');
+    });
+
+    it('reports when bookmark not found', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: false });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ id: 'missing' });
+      expectTextContent(result, 'Bookmark not found: missing');
+    });
+  });
+
+  // ── tandem_bookmark_update ────────────────────────────────────────
+  describe('tandem_bookmark_update', () => {
+    const handler = getHandler(tools, 'tandem_bookmark_update');
+
+    it('updates a bookmark', async () => {
+      mockApiCall.mockResolvedValueOnce({ bookmark: { name: 'Updated' } });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ id: 'bm1', title: 'Updated', url: 'https://new.url' });
+      expectTextContent(result, 'Updated bookmark: Updated');
+      expect(mockApiCall).toHaveBeenCalledWith('PUT', '/bookmarks/update', {
+        id: 'bm1', name: 'Updated', url: 'https://new.url',
+      });
+    });
+  });
+
+  // ── tandem_bookmark_folder_add ────────────────────────────────────
+  describe('tandem_bookmark_folder_add', () => {
+    const handler = getHandler(tools, 'tandem_bookmark_folder_add');
+
+    it('creates a folder', async () => {
+      mockApiCall.mockResolvedValueOnce({ folder: { name: 'Work' } });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ name: 'Work' });
+      expectTextContent(result, 'Created folder: Work');
+    });
+  });
+
+  // ── tandem_bookmark_move ──────────────────────────────────────────
+  describe('tandem_bookmark_move', () => {
+    const handler = getHandler(tools, 'tandem_bookmark_move');
+
+    it('moves a bookmark to a folder', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: true });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ id: 'bm1', folderId: 'f2' });
+      expectTextContent(result, 'Moved bm1 to folder f2');
+    });
+
+    it('reports failure', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: false });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ id: 'bm1', folderId: 'f2' });
+      expectTextContent(result, 'Failed to move bookmark bm1');
+    });
+  });
+
+  // ── tandem_bookmark_check ─────────────────────────────────────────
+  describe('tandem_bookmark_check', () => {
+    const handler = getHandler(tools, 'tandem_bookmark_check');
+
+    it('reports bookmarked URL', async () => {
+      mockApiCall.mockResolvedValueOnce({ bookmarked: true, bookmark: { name: 'GH' } });
+
+      const result = await handler({ url: 'https://github.com' });
+      expectTextContent(result, 'Yes');
+    });
+
+    it('reports non-bookmarked URL', async () => {
+      mockApiCall.mockResolvedValueOnce({ bookmarked: false });
+
+      const result = await handler({ url: 'https://unknown.com' });
+      expectTextContent(result, 'No');
+    });
+  });
+
+  // ── tandem_search_bookmarks ───────────────────────────────────────
+  describe('tandem_search_bookmarks', () => {
+    const handler = getHandler(tools, 'tandem_search_bookmarks');
+
+    it('returns search results', async () => {
+      mockApiCall.mockResolvedValueOnce({
+        results: [{ name: 'GitHub', url: 'https://github.com' }],
+      });
+
+      const result = await handler({ query: 'git' });
+      const text = expectTextContent(result, 'Bookmark results for "git"');
+      expect(text).toContain('[GitHub](https://github.com)');
+    });
+
+    it('handles empty results', async () => {
+      mockApiCall.mockResolvedValueOnce({ results: [] });
+
+      const result = await handler({ query: 'nope' });
+      expectTextContent(result, '(0)');
+    });
+  });
+});

--- a/src/mcp/tests/devtools.test.ts
+++ b/src/mcp/tests/devtools.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn((tabId?: string) => (tabId ? { 'X-Tab-Id': tabId } : undefined)),
+  logActivity: vi.fn(),
+}));
+
+vi.mock('../coerce.js', async (importOriginal) => importOriginal());
+
+import { apiCall, tabHeaders, logActivity } from '../api-client.js';
+import { registerDevtoolsTools } from '../tools/devtools.js';
+import { createMockServer, getHandler, expectTextContent, expectImageContent } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+const mockLogActivity = vi.mocked(logActivity);
+
+describe('MCP devtools tools', () => {
+  const { server, tools } = createMockServer();
+  registerDevtoolsTools(server);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── tandem_devtools_console ───────────────────────────────────────
+  describe('tandem_devtools_console', () => {
+    const handler = getHandler(tools, 'tandem_devtools_console');
+
+    it('returns console entries as JSON', async () => {
+      const data = { entries: [{ level: 'log', text: 'hello' }] };
+      mockApiCall.mockResolvedValueOnce(data);
+
+      const result = await handler({});
+      const text = expectTextContent(result);
+      expect(JSON.parse(text)).toEqual(data);
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/devtools/console', undefined, undefined);
+    });
+
+    it('builds query string with filters', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+
+      await handler({ level: 'error', search: 'TypeError', limit: 20, tabId: 't1' });
+      const endpoint = mockApiCall.mock.calls[0][1] as string;
+      expect(endpoint).toContain('level=error');
+      expect(endpoint).toContain('search=TypeError');
+      expect(endpoint).toContain('limit=20');
+      expect(vi.mocked(tabHeaders)).toHaveBeenCalledWith('t1');
+    });
+  });
+
+  // ── tandem_devtools_console_errors ────────────────────────────────
+  describe('tandem_devtools_console_errors', () => {
+    const handler = getHandler(tools, 'tandem_devtools_console_errors');
+
+    it('returns errors from console', async () => {
+      mockApiCall.mockResolvedValueOnce({ entries: [] });
+
+      const result = await handler({});
+      expectTextContent(result);
+    });
+
+    it('applies limit filter', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+
+      await handler({ limit: 5 });
+      const endpoint = mockApiCall.mock.calls[0][1] as string;
+      expect(endpoint).toContain('limit=5');
+    });
+  });
+
+  // ── tandem_devtools_console_clear ─────────────────────────────────
+  describe('tandem_devtools_console_clear', () => {
+    const handler = getHandler(tools, 'tandem_devtools_console_clear');
+
+    it('clears console buffer', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: true });
+      const result = await handler({});
+      expectTextContent(result);
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/devtools/console/clear');
+    });
+  });
+
+  // ── tandem_devtools_evaluate ──────────────────────────────────────
+  describe('tandem_devtools_evaluate', () => {
+    const handler = getHandler(tools, 'tandem_devtools_evaluate');
+
+    it('evaluates JS expression', async () => {
+      mockApiCall.mockResolvedValueOnce({ result: { value: 42 } });
+
+      const result = await handler({ expression: '1 + 1' });
+      expectTextContent(result);
+      expect(mockApiCall).toHaveBeenCalledWith(
+        'POST', '/devtools/evaluate',
+        { expression: '1 + 1' },
+        undefined,
+      );
+    });
+
+    it('targets specific tab', async () => {
+      mockApiCall.mockResolvedValueOnce({ result: {} });
+
+      await handler({ expression: 'document.title', tabId: 't2' });
+      expect(vi.mocked(tabHeaders)).toHaveBeenCalledWith('t2');
+    });
+  });
+
+  // ── tandem_devtools_dom_query ─────────────────────────────────────
+  describe('tandem_devtools_dom_query', () => {
+    const handler = getHandler(tools, 'tandem_devtools_dom_query');
+
+    it('queries DOM by CSS selector', async () => {
+      mockApiCall.mockResolvedValueOnce({ nodes: [{ tag: 'div' }] });
+
+      const result = await handler({ selector: '.app' });
+      expectTextContent(result);
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/devtools/dom/query', { selector: '.app' }, undefined);
+    });
+  });
+
+  // ── tandem_devtools_dom_xpath ──────────────────────────────────────
+  describe('tandem_devtools_dom_xpath', () => {
+    const handler = getHandler(tools, 'tandem_devtools_dom_xpath');
+
+    it('queries DOM by XPath', async () => {
+      mockApiCall.mockResolvedValueOnce({ nodes: [] });
+
+      const result = await handler({ expression: '//div[@class="app"]' });
+      expectTextContent(result);
+    });
+  });
+
+  // ── tandem_devtools_screenshot_element ─────────────────────────────
+  describe('tandem_devtools_screenshot_element', () => {
+    const handler = getHandler(tools, 'tandem_devtools_screenshot_element');
+
+    it('returns an image response', async () => {
+      mockApiCall.mockResolvedValueOnce('iVBORw0KGgo=');
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ selector: '#hero' });
+      const data = expectImageContent(result);
+      expect(data).toBe('iVBORw0KGgo=');
+      expect(mockApiCall).toHaveBeenCalledWith(
+        'POST', '/devtools/screenshot/element',
+        { selector: '#hero' },
+        undefined,
+      );
+    });
+  });
+
+  // ── tandem_devtools_cdp ───────────────────────────────────────────
+  describe('tandem_devtools_cdp', () => {
+    const handler = getHandler(tools, 'tandem_devtools_cdp');
+
+    it('sends a raw CDP command', async () => {
+      mockApiCall.mockResolvedValueOnce({ result: {} });
+
+      const result = await handler({ method: 'Page.reload', params: { ignoreCache: true } });
+      expectTextContent(result);
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/devtools/cdp', {
+        method: 'Page.reload', params: { ignoreCache: true },
+      });
+    });
+  });
+
+  // ── tandem_devtools_status ────────────────────────────────────────
+  describe('tandem_devtools_status', () => {
+    const handler = getHandler(tools, 'tandem_devtools_status');
+
+    it('returns devtools status', async () => {
+      mockApiCall.mockResolvedValueOnce({ connected: true });
+      const result = await handler({});
+      expectTextContent(result);
+    });
+  });
+
+  // ── tandem_devtools_toggle ────────────────────────────────────────
+  describe('tandem_devtools_toggle', () => {
+    const handler = getHandler(tools, 'tandem_devtools_toggle');
+
+    it('toggles devtools', async () => {
+      mockApiCall.mockResolvedValueOnce({ open: true });
+      const result = await handler({});
+      expectTextContent(result);
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/devtools/toggle');
+    });
+  });
+});

--- a/src/mcp/tests/mcp-test-helper.ts
+++ b/src/mcp/tests/mcp-test-helper.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared test helper for MCP tool tests.
+ *
+ * Creates a mock McpServer that captures tool registrations so handlers
+ * can be invoked directly in tests without spinning up a real server.
+ */
+import { vi, expect } from 'vitest';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+export interface RegisteredTool {
+  name: string;
+  description: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  handler: (params: any) => Promise<any>;
+}
+
+/**
+ * Build a mock McpServer whose `.tool()` captures every registration.
+ * Returns the mock and a map from tool-name → handler.
+ */
+export function createMockServer() {
+  const tools = new Map<string, RegisteredTool>();
+
+  const server = {
+    tool: vi.fn((...args: unknown[]) => {
+      const name = args[0] as string;
+      const description = args[1] as string;
+      // The handler is always the last argument
+      const handler = args[args.length - 1] as RegisteredTool['handler'];
+      tools.set(name, { name, description, handler });
+    }),
+  } as unknown as McpServer;
+
+  return { server, tools };
+}
+
+/** Retrieve a handler by name or throw if missing. */
+export function getHandler(tools: Map<string, RegisteredTool>, name: string) {
+  const tool = tools.get(name);
+  if (!tool) throw new Error(`Tool "${name}" not registered`);
+  return tool.handler;
+}
+
+/** Assert the standard MCP text response shape. */
+export function expectTextContent(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  result: any,
+  substring?: string,
+) {
+  expect(result).toHaveProperty('content');
+  expect(Array.isArray(result.content)).toBe(true);
+  expect(result.content[0]).toHaveProperty('type', 'text');
+  expect(result.content[0]).toHaveProperty('text');
+  if (substring) {
+    expect(result.content[0].text).toContain(substring);
+  }
+  return result.content[0].text as string;
+}
+
+/** Assert the standard MCP image response shape. */
+export function expectImageContent(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  result: any,
+  mimeType = 'image/png',
+) {
+  expect(result).toHaveProperty('content');
+  expect(result.content[0]).toHaveProperty('type', 'image');
+  expect(result.content[0]).toHaveProperty('data');
+  expect(result.content[0]).toHaveProperty('mimeType', mimeType);
+  return result.content[0].data as string;
+}

--- a/src/mcp/tests/navigation.test.ts
+++ b/src/mcp/tests/navigation.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn((tabId?: string) => (tabId ? { 'X-Tab-Id': tabId } : undefined)),
+  logActivity: vi.fn(),
+}));
+
+vi.mock('../coerce.js', async (importOriginal) => importOriginal());
+
+import { apiCall, tabHeaders, logActivity } from '../api-client.js';
+import { registerNavigationTools } from '../tools/navigation.js';
+import { createMockServer, getHandler, expectTextContent } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+const mockLogActivity = vi.mocked(logActivity);
+
+describe('MCP navigation tools', () => {
+  const { server, tools } = createMockServer();
+  registerNavigationTools(server);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── tandem_navigate ───────────────────────────────────────────────
+  describe('tandem_navigate', () => {
+    const handler = getHandler(tools, 'tandem_navigate');
+
+    it('navigates to a URL', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ url: 'https://example.com' });
+      expectTextContent(result, 'Navigated to https://example.com');
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/navigate', { url: 'https://example.com' }, undefined);
+      expect(mockLogActivity).toHaveBeenCalledWith('navigate', 'https://example.com');
+    });
+
+    it('targets a specific tab via tabId', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      await handler({ url: 'https://a.com', tabId: 't1' });
+      expect(vi.mocked(tabHeaders)).toHaveBeenCalledWith('t1');
+    });
+  });
+
+  // ── tandem_go_back ────────────────────────────────────────────────
+  describe('tandem_go_back', () => {
+    const handler = getHandler(tools, 'tandem_go_back');
+
+    it('calls history.back()', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({});
+      expectTextContent(result, 'Navigated back');
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/execute-js', { code: 'window.history.back()' });
+    });
+  });
+
+  // ── tandem_go_forward ─────────────────────────────────────────────
+  describe('tandem_go_forward', () => {
+    const handler = getHandler(tools, 'tandem_go_forward');
+
+    it('calls history.forward()', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({});
+      expectTextContent(result, 'Navigated forward');
+    });
+  });
+
+  // ── tandem_reload ─────────────────────────────────────────────────
+  describe('tandem_reload', () => {
+    const handler = getHandler(tools, 'tandem_reload');
+
+    it('reloads the page', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({});
+      expectTextContent(result, 'Page reloaded');
+    });
+  });
+
+  // ── tandem_click ──────────────────────────────────────────────────
+  describe('tandem_click', () => {
+    const handler = getHandler(tools, 'tandem_click');
+
+    it('clicks an element by selector', async () => {
+      mockApiCall.mockResolvedValueOnce({ clicked: true });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ selector: '#btn' });
+      expectTextContent(result, 'Clicked: #btn');
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/click', { selector: '#btn' }, undefined);
+    });
+  });
+
+  // ── tandem_type ───────────────────────────────────────────────────
+  describe('tandem_type', () => {
+    const handler = getHandler(tools, 'tandem_type');
+
+    it('types text into an input', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ selector: '#email', text: 'test@mail.com', clear: false });
+      expectTextContent(result, 'Typed "test@mail.com" into #email');
+      expect(mockApiCall).toHaveBeenCalledWith(
+        'POST', '/type',
+        { selector: '#email', text: 'test@mail.com', clear: false },
+        undefined,
+      );
+    });
+  });
+
+  // ── tandem_scroll ─────────────────────────────────────────────────
+  describe('tandem_scroll', () => {
+    const handler = getHandler(tools, 'tandem_scroll');
+
+    it('scrolls down by pixels', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ direction: 'down', amount: 300 });
+      expectTextContent(result, 'Scrolled down 300px');
+    });
+
+    it('scrolls to bottom', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ direction: 'down', amount: 500, target: 'bottom' });
+      expectTextContent(result, 'Scrolled bottom');
+    });
+  });
+
+  // ── tandem_press_key ──────────────────────────────────────────────
+  describe('tandem_press_key', () => {
+    const handler = getHandler(tools, 'tandem_press_key');
+
+    it('presses a key without modifiers', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: true });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ key: 'Enter' });
+      expectTextContent(result, 'Pressed key: Enter');
+    });
+
+    it('presses a key with modifiers', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: true });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ key: 'c', modifiers: ['control'] });
+      expectTextContent(result, 'control+c');
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/press-key', { key: 'c', modifiers: ['control'] }, undefined);
+    });
+  });
+
+  // ── tandem_wait_for_load ──────────────────────────────────────────
+  describe('tandem_wait_for_load', () => {
+    const handler = getHandler(tools, 'tandem_wait_for_load');
+
+    it('reports success when page loads', async () => {
+      mockApiCall.mockResolvedValueOnce({ timeout: false });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ timeout: 10000 });
+      expectTextContent(result, 'Page loaded successfully');
+    });
+
+    it('reports timeout', async () => {
+      mockApiCall.mockResolvedValueOnce({ timeout: true });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ timeout: 5000 });
+      expectTextContent(result, 'timed out');
+    });
+  });
+});

--- a/src/mcp/tests/network.test.ts
+++ b/src/mcp/tests/network.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn((tabId?: string) => (tabId ? { 'X-Tab-Id': tabId } : undefined)),
+  logActivity: vi.fn(),
+}));
+
+vi.mock('../coerce.js', async (importOriginal) => importOriginal());
+
+import { apiCall, tabHeaders } from '../api-client.js';
+import { registerNetworkTools } from '../tools/network.js';
+import { createMockServer, getHandler, expectTextContent } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+
+describe('MCP network tools', () => {
+  const { server, tools } = createMockServer();
+  registerNetworkTools(server);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── tandem_network_log ────────────────────────────────────────────
+  describe('tandem_network_log', () => {
+    const handler = getHandler(tools, 'tandem_network_log');
+
+    it('returns network log as JSON', async () => {
+      const data = { entries: [{ url: 'https://api.com/data' }] };
+      mockApiCall.mockResolvedValueOnce(data);
+
+      const result = await handler({});
+      const text = expectTextContent(result);
+      expect(JSON.parse(text)).toEqual(data);
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/network/log', undefined, undefined);
+    });
+
+    it('builds query string with filters', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+
+      await handler({ domain: 'api.com', type: 'xhr', limit: 10 });
+      const endpoint = mockApiCall.mock.calls[0][1] as string;
+      expect(endpoint).toContain('domain=api.com');
+      expect(endpoint).toContain('type=xhr');
+      expect(endpoint).toContain('limit=10');
+    });
+
+    it('passes tabId as header', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+
+      await handler({ tabId: 't1' });
+      expect(vi.mocked(tabHeaders)).toHaveBeenCalledWith('t1');
+    });
+  });
+
+  // ── tandem_network_apis ───────────────────────────────────────────
+  describe('tandem_network_apis', () => {
+    const handler = getHandler(tools, 'tandem_network_apis');
+
+    it('returns API summary', async () => {
+      mockApiCall.mockResolvedValueOnce({ apis: ['/v1/users'] });
+
+      const result = await handler({});
+      expectTextContent(result);
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/network/apis');
+    });
+  });
+
+  // ── tandem_network_domains ────────────────────────────────────────
+  describe('tandem_network_domains', () => {
+    const handler = getHandler(tools, 'tandem_network_domains');
+
+    it('returns domain list', async () => {
+      mockApiCall.mockResolvedValueOnce({ domains: { 'api.com': 15 } });
+      const result = await handler({});
+      expectTextContent(result);
+    });
+  });
+
+  // ── tandem_network_mock ───────────────────────────────────────────
+  describe('tandem_network_mock', () => {
+    const handler = getHandler(tools, 'tandem_network_mock');
+
+    it('creates a mock rule', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: true });
+
+      const result = await handler({
+        url: 'https://api.com/*',
+        method: 'GET',
+        status: 200,
+        body: '{"mock": true}',
+      });
+      expectTextContent(result);
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/network/mock', {
+        pattern: 'https://api.com/*',
+        method: 'GET',
+        status: 200,
+        body: '{"mock": true}',
+      });
+    });
+
+    it('sends only required fields when optionals omitted', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: true });
+
+      await handler({ url: 'https://x.com' });
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/network/mock', {
+        pattern: 'https://x.com',
+      });
+    });
+  });
+
+  // ── tandem_network_unmock ─────────────────────────────────────────
+  describe('tandem_network_unmock', () => {
+    const handler = getHandler(tools, 'tandem_network_unmock');
+
+    it('removes a mock rule', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: true });
+
+      await handler({ url: 'https://api.com/*' });
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/network/unmock', { pattern: 'https://api.com/*' });
+    });
+  });
+
+  // ── tandem_network_clear ──────────────────────────────────────────
+  describe('tandem_network_clear', () => {
+    const handler = getHandler(tools, 'tandem_network_clear');
+
+    it('clears the network log', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: true });
+
+      const result = await handler({});
+      expectTextContent(result);
+      expect(mockApiCall).toHaveBeenCalledWith('DELETE', '/network/clear');
+    });
+  });
+
+  // ── tandem_network_mock_clear ─────────────────────────────────────
+  describe('tandem_network_mock_clear', () => {
+    const handler = getHandler(tools, 'tandem_network_mock_clear');
+
+    it('clears all mock rules', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: true });
+
+      const result = await handler({});
+      expectTextContent(result);
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/network/mock-clear');
+    });
+  });
+
+  // ── error propagation ─────────────────────────────────────────────
+  describe('error propagation', () => {
+    it('propagates errors from apiCall', async () => {
+      mockApiCall.mockRejectedValueOnce(new Error('server error'));
+      const handler = getHandler(tools, 'tandem_network_har');
+      await expect(handler({})).rejects.toThrow('server error');
+    });
+  });
+});

--- a/src/mcp/tests/sessions.test.ts
+++ b/src/mcp/tests/sessions.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn(),
+  logActivity: vi.fn(),
+}));
+
+import { apiCall, logActivity } from '../api-client.js';
+import { registerSessionTools } from '../tools/sessions.js';
+import { createMockServer, getHandler, expectTextContent } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+const mockLogActivity = vi.mocked(logActivity);
+
+describe('MCP session tools', () => {
+  const { server, tools } = createMockServer();
+  registerSessionTools(server);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── tandem_session_list ───────────────────────────────────────────
+  describe('tandem_session_list', () => {
+    const handler = getHandler(tools, 'tandem_session_list');
+
+    it('lists sessions as JSON', async () => {
+      const data = { sessions: [{ name: 'default', tabs: 3 }] };
+      mockApiCall.mockResolvedValueOnce(data);
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({});
+      const text = expectTextContent(result);
+      expect(JSON.parse(text)).toEqual(data);
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/sessions/list');
+    });
+  });
+
+  // ── tandem_session_create ─────────────────────────────────────────
+  describe('tandem_session_create', () => {
+    const handler = getHandler(tools, 'tandem_session_create');
+
+    it('creates a session with name', async () => {
+      mockApiCall.mockResolvedValueOnce({ name: 'test', partition: 'persist:test' });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ name: 'test' });
+      expectTextContent(result, 'Created session: test');
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/sessions/create', { name: 'test' });
+    });
+
+    it('includes partition when provided', async () => {
+      mockApiCall.mockResolvedValueOnce({ name: 'dev', partition: 'custom' });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      await handler({ name: 'dev', partition: 'custom' });
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/sessions/create', {
+        name: 'dev', partition: 'custom',
+      });
+    });
+  });
+
+  // ── tandem_session_switch ─────────────────────────────────────────
+  describe('tandem_session_switch', () => {
+    const handler = getHandler(tools, 'tandem_session_switch');
+
+    it('switches to a session', async () => {
+      mockApiCall.mockResolvedValueOnce({ active: 'work' });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ name: 'work' });
+      expectTextContent(result, 'Switched to session: work');
+    });
+  });
+
+  // ── tandem_session_destroy ────────────────────────────────────────
+  describe('tandem_session_destroy', () => {
+    const handler = getHandler(tools, 'tandem_session_destroy');
+
+    it('destroys a session', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ name: 'old' });
+      expectTextContent(result, 'Destroyed session: old');
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/sessions/destroy', { name: 'old' });
+    });
+  });
+
+  // ── tandem_session_fetch ──────────────────────────────────────────
+  describe('tandem_session_fetch', () => {
+    const handler = getHandler(tools, 'tandem_session_fetch');
+
+    it('fetches within session context', async () => {
+      mockApiCall.mockResolvedValueOnce({ status: 200, body: '{}' });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ url: 'https://api.com/me' });
+      expectTextContent(result);
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/sessions/fetch', {
+        url: 'https://api.com/me',
+      }, undefined);
+    });
+
+    it('passes method and body', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      await handler({ url: 'https://api.com/data', method: 'POST', body: '{"a":1}' });
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/sessions/fetch', {
+        url: 'https://api.com/data', method: 'POST', body: '{"a":1}',
+      }, undefined);
+    });
+
+    it('passes sessionName as X-Session header', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      await handler({ url: 'https://x.com', sessionName: 'work' });
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/sessions/fetch', {
+        url: 'https://x.com',
+      }, { 'X-Session': 'work' });
+    });
+  });
+
+  // ── tandem_session_state_save ─────────────────────────────────────
+  describe('tandem_session_state_save', () => {
+    const handler = getHandler(tools, 'tandem_session_state_save');
+
+    it('saves session state', async () => {
+      mockApiCall.mockResolvedValueOnce({ path: '/tmp/state.json' });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ name: 'checkpoint' });
+      expectTextContent(result, 'Saved session state "checkpoint"');
+    });
+  });
+
+  // ── tandem_session_state_load ─────────────────────────────────────
+  describe('tandem_session_state_load', () => {
+    const handler = getHandler(tools, 'tandem_session_state_load');
+
+    it('loads session state', async () => {
+      mockApiCall.mockResolvedValueOnce({ cookiesRestored: 12 });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ name: 'checkpoint' });
+      expectTextContent(result, 'cookies restored: 12');
+    });
+  });
+
+  // ── tandem_session_state_list ─────────────────────────────────────
+  describe('tandem_session_state_list', () => {
+    const handler = getHandler(tools, 'tandem_session_state_list');
+
+    it('lists saved states', async () => {
+      mockApiCall.mockResolvedValueOnce({ states: ['checkpoint', 'backup'] });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({});
+      expectTextContent(result);
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/sessions/state/list');
+    });
+  });
+
+  // ── error propagation ─────────────────────────────────────────────
+  describe('error propagation', () => {
+    it('propagates API errors', async () => {
+      mockApiCall.mockRejectedValueOnce(new Error('session not found'));
+      const handler = getHandler(tools, 'tandem_session_switch');
+      await expect(handler({ name: 'nope' })).rejects.toThrow('session not found');
+    });
+  });
+});

--- a/src/mcp/tests/snapshots.test.ts
+++ b/src/mcp/tests/snapshots.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn((tabId?: string) => (tabId ? { 'X-Tab-Id': tabId } : undefined)),
+  logActivity: vi.fn(),
+}));
+
+vi.mock('../coerce.js', async (importOriginal) => importOriginal());
+
+import { apiCall, tabHeaders, logActivity } from '../api-client.js';
+import { registerSnapshotTools } from '../tools/snapshots.js';
+import { createMockServer, getHandler, expectTextContent } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+const mockLogActivity = vi.mocked(logActivity);
+
+describe('MCP snapshot tools', () => {
+  const { server, tools } = createMockServer();
+  registerSnapshotTools(server);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── tandem_snapshot ───────────────────────────────────────────────
+  describe('tandem_snapshot', () => {
+    const handler = getHandler(tools, 'tandem_snapshot');
+
+    it('returns the accessibility tree', async () => {
+      mockApiCall.mockResolvedValueOnce({ snapshot: '<tree>...</tree>', count: 42 });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({});
+      expectTextContent(result, '<tree>...</tree>');
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/snapshot', undefined, undefined);
+      expect(mockLogActivity).toHaveBeenCalledWith('snapshot', '42 nodes');
+    });
+
+    it('builds query string for compact and interactive', async () => {
+      mockApiCall.mockResolvedValueOnce({ snapshot: '...', count: 5 });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      await handler({ compact: true, interactive: true, selector: '#app' });
+      expect(mockApiCall).toHaveBeenCalledWith(
+        'GET',
+        expect.stringContaining('compact=true'),
+        undefined,
+        undefined,
+      );
+    });
+
+    it('passes tabId as header', async () => {
+      mockApiCall.mockResolvedValueOnce({ snapshot: '', count: 0 });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      await handler({ tabId: 't1' });
+      expect(vi.mocked(tabHeaders)).toHaveBeenCalledWith('t1');
+    });
+
+    it('returns empty string when snapshot is missing', async () => {
+      mockApiCall.mockResolvedValueOnce({ count: 0 });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({});
+      const text = expectTextContent(result);
+      expect(text).toBe('');
+    });
+  });
+
+  // ── tandem_snapshot_click ─────────────────────────────────────────
+  describe('tandem_snapshot_click', () => {
+    const handler = getHandler(tools, 'tandem_snapshot_click');
+
+    it('clicks an element by ref', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ ref: '@e1' });
+      expectTextContent(result, 'Clicked element @e1');
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/snapshot/click', { ref: '@e1' }, undefined);
+    });
+  });
+
+  // ── tandem_snapshot_fill ──────────────────────────────────────────
+  describe('tandem_snapshot_fill', () => {
+    const handler = getHandler(tools, 'tandem_snapshot_fill');
+
+    it('fills an input by ref', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ ref: '@e3', value: 'hello' });
+      expectTextContent(result, 'Filled element @e3 with "hello"');
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/snapshot/fill', { ref: '@e3', value: 'hello' }, undefined);
+    });
+  });
+
+  // ── tandem_snapshot_text ──────────────────────────────────────────
+  describe('tandem_snapshot_text', () => {
+    const handler = getHandler(tools, 'tandem_snapshot_text');
+
+    it('returns text content of element', async () => {
+      mockApiCall.mockResolvedValueOnce({ text: 'Hello World' });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ ref: '@e1' });
+      expectTextContent(result, 'Hello World');
+    });
+  });
+
+  // ── tandem_find ───────────────────────────────────────────────────
+  describe('tandem_find', () => {
+    const handler = getHandler(tools, 'tandem_find');
+
+    it('finds elements by semantic locator', async () => {
+      mockApiCall.mockResolvedValueOnce({ ref: '@e5', tag: 'button' });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ by: 'role', value: 'button' });
+      expectTextContent(result);
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/find', { by: 'role', value: 'button' }, undefined);
+    });
+  });
+
+  // ── tandem_find_click ─────────────────────────────────────────────
+  describe('tandem_find_click', () => {
+    const handler = getHandler(tools, 'tandem_find_click');
+
+    it('finds and clicks an element', async () => {
+      mockApiCall.mockResolvedValueOnce({ ref: '@e7' });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ by: 'text', value: 'Submit' });
+      expectTextContent(result, 'Clicked element found by text="Submit"');
+    });
+  });
+
+  // ── tandem_find_fill ──────────────────────────────────────────────
+  describe('tandem_find_fill', () => {
+    const handler = getHandler(tools, 'tandem_find_fill');
+
+    it('finds and fills an input', async () => {
+      mockApiCall.mockResolvedValueOnce({ ref: '@e8' });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ by: 'placeholder', value: 'Email', text: 'a@b.com' });
+      expectTextContent(result, 'Filled element found by placeholder="Email"');
+      expect(mockApiCall).toHaveBeenCalledWith(
+        'POST', '/find/fill',
+        { by: 'placeholder', value: 'Email', fillValue: 'a@b.com' },
+        undefined,
+      );
+    });
+  });
+
+  // ── tandem_find_all ───────────────────────────────────────────────
+  describe('tandem_find_all', () => {
+    const handler = getHandler(tools, 'tandem_find_all');
+
+    it('finds all matching elements', async () => {
+      mockApiCall.mockResolvedValueOnce({ matches: [{ ref: '@e1' }, { ref: '@e2' }] });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ by: 'role', value: 'link' });
+      expectTextContent(result);
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/find/all', { by: 'role', value: 'link' }, undefined);
+    });
+  });
+});

--- a/src/mcp/tests/tabs.test.ts
+++ b/src/mcp/tests/tabs.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn((tabId?: string) => (tabId ? { 'X-Tab-Id': tabId } : undefined)),
+  logActivity: vi.fn(),
+}));
+
+import { apiCall, logActivity } from '../api-client.js';
+import { registerTabTools } from '../tools/tabs.js';
+import { createMockServer, getHandler, expectTextContent } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+const mockLogActivity = vi.mocked(logActivity);
+
+describe('MCP tab tools', () => {
+  const { server, tools } = createMockServer();
+  registerTabTools(server);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── tandem_list_tabs ──────────────────────────────────────────────
+  describe('tandem_list_tabs', () => {
+    const handler = getHandler(tools, 'tandem_list_tabs');
+
+    it('lists open tabs with formatted text', async () => {
+      mockApiCall.mockResolvedValueOnce({
+        tabs: [
+          { id: 't1', title: 'Google', url: 'https://google.com', active: true },
+          { id: 't2', title: 'GitHub', url: 'https://github.com', active: false },
+        ],
+      });
+
+      const result = await handler({});
+      const text = expectTextContent(result, 'Open tabs (2)');
+      expect(text).toContain('→ [t1] Google');
+      expect(text).toContain('  [t2] GitHub');
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/tabs/list');
+    });
+
+    it('handles empty tab list', async () => {
+      mockApiCall.mockResolvedValueOnce({ tabs: [] });
+      const result = await handler({});
+      expectTextContent(result, 'Open tabs (0)');
+    });
+
+    it('handles tabs with missing title', async () => {
+      mockApiCall.mockResolvedValueOnce({
+        tabs: [{ id: 't1', title: '', url: 'about:blank', active: false }],
+      });
+      const result = await handler({});
+      expectTextContent(result, '(untitled)');
+    });
+
+    it('propagates API errors', async () => {
+      mockApiCall.mockRejectedValueOnce(new Error('connection refused'));
+      await expect(handler({})).rejects.toThrow('connection refused');
+    });
+  });
+
+  // ── tandem_open_tab ───────────────────────────────────────────────
+  describe('tandem_open_tab', () => {
+    const handler = getHandler(tools, 'tandem_open_tab');
+
+    it('opens a tab with URL', async () => {
+      mockApiCall.mockResolvedValueOnce({ tab: { id: 't3' } });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ url: 'https://example.com' });
+      expectTextContent(result, 'Opened tab');
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/tabs/open', {
+        url: 'https://example.com',
+        source: 'wingman',
+      });
+      expect(mockLogActivity).toHaveBeenCalledWith('open_tab', 'https://example.com');
+    });
+
+    it('opens a tab without URL', async () => {
+      mockApiCall.mockResolvedValueOnce({ tab: { id: 't4' } });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({});
+      expectTextContent(result, 'new tab');
+    });
+
+    it('passes workspaceId when provided', async () => {
+      mockApiCall.mockResolvedValueOnce({ tab: { id: 't5' } });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      await handler({ url: 'https://a.com', workspaceId: 'w1' });
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/tabs/open', {
+        url: 'https://a.com',
+        source: 'wingman',
+        workspaceId: 'w1',
+      });
+    });
+  });
+
+  // ── tandem_close_tab ──────────────────────────────────────────────
+  describe('tandem_close_tab', () => {
+    const handler = getHandler(tools, 'tandem_close_tab');
+
+    it('closes a tab by ID', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ tabId: 't1' });
+      expectTextContent(result, 'Closed tab: t1');
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/tabs/close', { tabId: 't1' });
+      expect(mockLogActivity).toHaveBeenCalledWith('close_tab', 't1');
+    });
+  });
+
+  // ── tandem_focus_tab ──────────────────────────────────────────────
+  describe('tandem_focus_tab', () => {
+    const handler = getHandler(tools, 'tandem_focus_tab');
+
+    it('focuses a tab by ID', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ tabId: 't2' });
+      expectTextContent(result, 'Focused tab: t2');
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/tabs/focus', { tabId: 't2' });
+    });
+
+    it('propagates API errors', async () => {
+      mockApiCall.mockRejectedValueOnce(new Error('tab not found'));
+      await expect(handler({ tabId: 'bad' })).rejects.toThrow('tab not found');
+    });
+  });
+});

--- a/src/mcp/tests/workspaces.test.ts
+++ b/src/mcp/tests/workspaces.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn(),
+  logActivity: vi.fn(),
+}));
+
+import { apiCall, logActivity } from '../api-client.js';
+import { registerWorkspaceTools } from '../tools/workspaces.js';
+import { createMockServer, getHandler, expectTextContent } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+const mockLogActivity = vi.mocked(logActivity);
+
+describe('MCP workspace tools', () => {
+  const { server, tools } = createMockServer();
+  registerWorkspaceTools(server);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── tandem_workspace_list ─────────────────────────────────────────
+  describe('tandem_workspace_list', () => {
+    const handler = getHandler(tools, 'tandem_workspace_list');
+
+    it('returns workspace data as JSON', async () => {
+      const data = { workspaces: [{ id: 'w1', name: 'Default' }], active: 'w1' };
+      mockApiCall.mockResolvedValueOnce(data);
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({});
+      const text = expectTextContent(result);
+      expect(JSON.parse(text)).toEqual(data);
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/workspaces');
+    });
+  });
+
+  // ── tandem_workspace_create ───────────────────────────────────────
+  describe('tandem_workspace_create', () => {
+    const handler = getHandler(tools, 'tandem_workspace_create');
+
+    it('creates a workspace with name only', async () => {
+      mockApiCall.mockResolvedValueOnce({ workspace: { id: 'w2', name: 'Dev' } });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ name: 'Dev' });
+      expectTextContent(result, 'Created workspace');
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/workspaces', { name: 'Dev' });
+    });
+
+    it('includes icon and color when provided', async () => {
+      mockApiCall.mockResolvedValueOnce({ workspace: { id: 'w3', name: 'Work' } });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      await handler({ name: 'Work', icon: '💼', color: '#ff0000' });
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/workspaces', {
+        name: 'Work', icon: '💼', color: '#ff0000',
+      });
+    });
+  });
+
+  // ── tandem_workspace_activate ─────────────────────────────────────
+  describe('tandem_workspace_activate', () => {
+    const handler = getHandler(tools, 'tandem_workspace_activate');
+
+    it('activates a workspace', async () => {
+      mockApiCall.mockResolvedValueOnce({ workspace: { id: 'w1', name: 'Dev' } });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ id: 'w1' });
+      expectTextContent(result, 'Activated workspace');
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/workspaces/w1/activate');
+    });
+  });
+
+  // ── tandem_workspace_delete ───────────────────────────────────────
+  describe('tandem_workspace_delete', () => {
+    const handler = getHandler(tools, 'tandem_workspace_delete');
+
+    it('deletes a workspace', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ id: 'w1' });
+      expectTextContent(result, 'Deleted workspace: w1');
+      expect(mockApiCall).toHaveBeenCalledWith('DELETE', '/workspaces/w1');
+    });
+
+    it('propagates API errors', async () => {
+      mockApiCall.mockRejectedValueOnce(new Error('not found'));
+      await expect(handler({ id: 'bad' })).rejects.toThrow('not found');
+    });
+  });
+
+  // ── tandem_workspace_update ───────────────────────────────────────
+  describe('tandem_workspace_update', () => {
+    const handler = getHandler(tools, 'tandem_workspace_update');
+
+    it('updates workspace properties', async () => {
+      mockApiCall.mockResolvedValueOnce({ workspace: { id: 'w1', name: 'New' } });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ id: 'w1', name: 'New', color: '#00ff00' });
+      expectTextContent(result, 'Updated workspace');
+    });
+  });
+
+  // ── tandem_workspace_move_tab ─────────────────────────────────────
+  describe('tandem_workspace_move_tab', () => {
+    const handler = getHandler(tools, 'tandem_workspace_move_tab');
+
+    it('moves a tab to a workspace', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      const result = await handler({ id: 'w1', tabId: 't5' });
+      expectTextContent(result, 'Moved tab t5 to workspace w1');
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/workspaces/w1/tabs', { tabId: 't5' });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add **272 unit tests** across 31 test files covering all MCP tool modules (31 of 32 files — only `window.ts` with its multi-step research logic excluded)
- Create shared `mcp-test-helper.ts` with mock McpServer that captures tool registrations for direct handler invocation
- Tests mock `apiCall`/`logActivity` and verify correct API endpoints, parameter passing, response formatting, and error propagation
- MCP tools directory line coverage: **0% → 89%**

## Test plan
- [x] `npx vitest run src/mcp/tests/` — all 272 tests pass
- [x] `npm run verify` — all 1751 tests pass, lint clean, consistency check green
- [ ] CI checks (verify.yml + codeql.yml) pass on PR