### PR TITLE
test(mcp): expand MCP tool test coverage to 89% (P3-04c)

### DIFF
--- a/src/mcp/tests/auth.test.ts
+++ b/src/mcp/tests/auth.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn(),
+  logActivity: vi.fn(),
+}));
+
+import { apiCall } from '../api-client.js';
+import { registerAuthTools } from '../tools/auth.js';
+import { createMockServer, getHandler, expectTextContent } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+
+describe('MCP auth tools', () => {
+  const { server, tools } = createMockServer();
+  registerAuthTools(server);
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('tandem_auth_states returns all auth states', async () => {
+    mockApiCall.mockResolvedValueOnce({ states: [] });
+    const result = await getHandler(tools, 'tandem_auth_states')({});
+    expectTextContent(result);
+    expect(mockApiCall).toHaveBeenCalledWith('GET', '/auth/states');
+  });
+
+  it('tandem_auth_state returns state for domain', async () => {
+    mockApiCall.mockResolvedValueOnce({ status: 'logged_in' });
+    await getHandler(tools, 'tandem_auth_state')({ domain: 'github.com' });
+    expect(mockApiCall).toHaveBeenCalledWith('GET', '/auth/state/github.com');
+  });
+
+  it('tandem_auth_check checks current page auth', async () => {
+    mockApiCall.mockResolvedValueOnce({ authenticated: true });
+    await getHandler(tools, 'tandem_auth_check')({});
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/auth/check');
+  });
+
+  it('tandem_auth_is_login_page detects login pages', async () => {
+    mockApiCall.mockResolvedValueOnce({ isLoginPage: true });
+    await getHandler(tools, 'tandem_auth_is_login_page')({});
+    expect(mockApiCall).toHaveBeenCalledWith('GET', '/auth/is-login-page');
+  });
+
+  it('tandem_auth_update updates auth state', async () => {
+    mockApiCall.mockResolvedValueOnce({ ok: true });
+    await getHandler(tools, 'tandem_auth_update')({ domain: 'x.com', status: 'logged_in', username: 'robin' });
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/auth/update', { domain: 'x.com', status: 'logged_in', username: 'robin' });
+  });
+
+  it('tandem_auth_delete deletes auth state', async () => {
+    mockApiCall.mockResolvedValueOnce({ ok: true });
+    await getHandler(tools, 'tandem_auth_delete')({ domain: 'x.com' });
+    expect(mockApiCall).toHaveBeenCalledWith('DELETE', '/auth/state/x.com');
+  });
+});

--- a/src/mcp/tests/awareness.test.ts
+++ b/src/mcp/tests/awareness.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn(),
+  logActivity: vi.fn(),
+}));
+
+vi.mock('../coerce.js', async (importOriginal) => importOriginal());
+
+import { apiCall } from '../api-client.js';
+import { registerAwarenessTools } from '../tools/awareness.js';
+import { createMockServer, getHandler, expectTextContent } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+
+describe('MCP awareness tools', () => {
+  const { server, tools } = createMockServer();
+  registerAwarenessTools(server);
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('tandem_awareness_digest returns digest', async () => {
+    mockApiCall.mockResolvedValueOnce({ summary: 'User reading docs' });
+    const result = await getHandler(tools, 'tandem_awareness_digest')({});
+    expectTextContent(result);
+    expect(mockApiCall).toHaveBeenCalledWith('GET', '/awareness/digest');
+  });
+
+  it('tandem_awareness_digest applies minutes filter', async () => {
+    mockApiCall.mockResolvedValueOnce({});
+    await getHandler(tools, 'tandem_awareness_digest')({ minutes: 15 });
+    const endpoint = mockApiCall.mock.calls[0][1] as string;
+    expect(endpoint).toContain('minutes=15');
+  });
+
+  it('tandem_awareness_focus returns focus', async () => {
+    mockApiCall.mockResolvedValueOnce({ focus: 'coding' });
+    const result = await getHandler(tools, 'tandem_awareness_focus')({});
+    expectTextContent(result);
+    expect(mockApiCall).toHaveBeenCalledWith('GET', '/awareness/focus');
+  });
+});

--- a/src/mcp/tests/chat.test.ts
+++ b/src/mcp/tests/chat.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn(),
+  logActivity: vi.fn(),
+}));
+
+vi.mock('../coerce.js', async (importOriginal) => importOriginal());
+
+import { apiCall, logActivity } from '../api-client.js';
+import { registerChatTools } from '../tools/chat.js';
+import { createMockServer, getHandler, expectTextContent } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+const mockLogActivity = vi.mocked(logActivity);
+
+describe('MCP chat tools', () => {
+  const { server, tools } = createMockServer();
+  registerChatTools(server);
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  describe('tandem_send_message', () => {
+    const handler = getHandler(tools, 'tandem_send_message');
+
+    it('sends a message', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      const result = await handler({ text: 'Hello Robin' });
+      expectTextContent(result, 'Message sent: "Hello Robin"');
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/chat', { text: 'Hello Robin', from: 'claude' });
+    });
+  });
+
+  describe('tandem_get_chat_history', () => {
+    const handler = getHandler(tools, 'tandem_get_chat_history');
+
+    it('returns formatted chat history', async () => {
+      mockApiCall.mockResolvedValueOnce({
+        messages: [{ from: 'robin', text: 'hi', timestamp: 1700000000000 }],
+      });
+      const result = await handler({ limit: 20 });
+      const text = expectTextContent(result, 'Chat history (1 messages)');
+      expect(text).toContain('robin: hi');
+    });
+
+    it('handles empty chat', async () => {
+      mockApiCall.mockResolvedValueOnce({ messages: [] });
+      const result = await handler({ limit: 10 });
+      expectTextContent(result, '(0 messages)');
+    });
+  });
+
+  describe('tandem_get_context', () => {
+    const handler = getHandler(tools, 'tandem_get_context');
+
+    it('returns browser context overview', async () => {
+      mockApiCall.mockResolvedValueOnce({ title: 'Google', url: 'https://google.com', loading: false });
+      mockApiCall.mockResolvedValueOnce({ tabs: [{ id: 't1', title: 'Google', url: 'https://google.com', active: true }] });
+      mockApiCall.mockResolvedValueOnce({ messages: [{ from: 'claude', text: 'hi' }] });
+
+      const result = await handler({});
+      const text = expectTextContent(result, 'Browser Context');
+      expect(text).toContain('Active tab: Google');
+      expect(text).toContain('Open tabs (1)');
+      expect(text).toContain('Recent chat');
+    });
+  });
+
+  describe('tandem_wingman_alert', () => {
+    const handler = getHandler(tools, 'tandem_wingman_alert');
+
+    it('sends an alert', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({ message: 'Watch out!', level: 'warning' });
+      expectTextContent(result, 'Alert sent: [warning] Watch out!');
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/wingman-alert', { title: 'Warning', body: 'Watch out!' });
+    });
+
+    it('defaults to info level', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({ message: 'FYI' });
+      expectTextContent(result, '[info]');
+    });
+  });
+});

--- a/src/mcp/tests/clipboard.test.ts
+++ b/src/mcp/tests/clipboard.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn(),
+  logActivity: vi.fn(),
+}));
+
+import { apiCall, logActivity } from '../api-client.js';
+import { registerClipboardTools } from '../tools/clipboard.js';
+import { createMockServer, getHandler, expectTextContent } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+const mockLogActivity = vi.mocked(logActivity);
+
+describe('MCP clipboard tools', () => {
+  const { server, tools } = createMockServer();
+  registerClipboardTools(server);
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  describe('tandem_clipboard_read', () => {
+    const handler = getHandler(tools, 'tandem_clipboard_read');
+
+    it('returns text content', async () => {
+      mockApiCall.mockResolvedValueOnce({ text: 'hello', formats: ['text'] });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({});
+      expect(result.content[0]).toEqual({ type: 'text', text: 'hello' });
+    });
+
+    it('returns image content', async () => {
+      mockApiCall.mockResolvedValueOnce({ image: { base64: 'data:image/png;base64,ABC' }, hasImage: true, formats: ['image'] });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({});
+      expect(result.content[0]).toMatchObject({ type: 'image', data: 'ABC', mimeType: 'image/png' });
+    });
+
+    it('returns empty message when clipboard is empty', async () => {
+      mockApiCall.mockResolvedValueOnce({ formats: [] });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({});
+      expect(result.content[0].text).toContain('Clipboard is empty');
+    });
+
+    it('falls back to html when no text', async () => {
+      mockApiCall.mockResolvedValueOnce({ html: '<b>hi</b>', formats: ['html'] });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({});
+      expect(result.content[0]).toEqual({ type: 'text', text: '<b>hi</b>' });
+    });
+  });
+
+  describe('tandem_clipboard_write', () => {
+    const handler = getHandler(tools, 'tandem_clipboard_write');
+
+    it('writes text to clipboard', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({ text: 'hello' });
+      expectTextContent(result, 'Copied text to clipboard');
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/clipboard/text', { text: 'hello' });
+    });
+
+    it('writes image to clipboard', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({ image_base64: 'ABC' });
+      expectTextContent(result, 'Copied image to clipboard');
+    });
+
+    it('writes both text and image', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({ text: 'hi', image_base64: 'ABC' });
+      expectTextContent(result, 'text and image');
+    });
+
+    it('returns error when nothing provided', async () => {
+      const result = await handler({});
+      expectTextContent(result, 'Error');
+    });
+  });
+
+  describe('tandem_clipboard_save', () => {
+    const handler = getHandler(tools, 'tandem_clipboard_save');
+
+    it('saves clipboard to file', async () => {
+      mockApiCall.mockResolvedValueOnce({ path: '/tmp/shot.png', size: 2048 });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({ filename: 'shot.png' });
+      expectTextContent(result, 'Saved to /tmp/shot.png');
+      expectTextContent(result, '2.0 KB');
+    });
+  });
+});

--- a/src/mcp/tests/content.test.ts
+++ b/src/mcp/tests/content.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn((tabId?: string) => (tabId ? { 'X-Tab-Id': tabId } : undefined)),
+  truncateToWords: vi.fn((text: string, max: number) => {
+    const words = text.split(/\s+/);
+    return words.length <= max ? text : words.slice(0, max).join(' ') + '...';
+  }),
+  logActivity: vi.fn(),
+}));
+
+import { apiCall, logActivity } from '../api-client.js';
+import { registerContentTools } from '../tools/content.js';
+import { createMockServer, getHandler, expectTextContent, expectImageContent } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+const mockLogActivity = vi.mocked(logActivity);
+
+describe('MCP content tools', () => {
+  const { server, tools } = createMockServer();
+  registerContentTools(server);
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  describe('tandem_read_page', () => {
+    const handler = getHandler(tools, 'tandem_read_page');
+
+    it('returns markdown-formatted page content', async () => {
+      mockApiCall.mockResolvedValueOnce({ title: 'Test', url: 'https://test.com', description: 'A test page', text: 'Body text' });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({});
+      const text = expectTextContent(result, '# Test');
+      expect(text).toContain('**URL:** https://test.com');
+      expect(text).toContain('> A test page');
+    });
+
+    it('handles missing description', async () => {
+      mockApiCall.mockResolvedValueOnce({ title: 'T', url: 'https://t.com', text: 'x' });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({});
+      const text = expectTextContent(result);
+      expect(text).not.toContain('>');
+    });
+  });
+
+  describe('tandem_screenshot', () => {
+    const handler = getHandler(tools, 'tandem_screenshot');
+
+    it('returns image content', async () => {
+      mockApiCall.mockResolvedValueOnce('base64data');
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({});
+      expectImageContent(result);
+    });
+  });
+
+  describe('tandem_get_page_html', () => {
+    const handler = getHandler(tools, 'tandem_get_page_html');
+
+    it('returns raw HTML string', async () => {
+      mockApiCall.mockResolvedValueOnce('<html>hi</html>');
+      const result = await handler({});
+      expectTextContent(result, '<html>hi</html>');
+    });
+
+    it('JSON-stringifies non-string response', async () => {
+      mockApiCall.mockResolvedValueOnce({ html: '<html/>' });
+      const result = await handler({});
+      expectTextContent(result, '"html"');
+    });
+  });
+
+  describe('tandem_extract_content', () => {
+    const handler = getHandler(tools, 'tandem_extract_content');
+
+    it('returns extracted content as JSON', async () => {
+      mockApiCall.mockResolvedValueOnce({ title: 'T', body: 'B' });
+      const result = await handler({});
+      expectTextContent(result);
+    });
+  });
+
+  describe('tandem_extract_url', () => {
+    const handler = getHandler(tools, 'tandem_extract_url');
+
+    it('extracts from URL', async () => {
+      mockApiCall.mockResolvedValueOnce({ content: 'extracted' });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      await handler({ url: 'https://a.com' });
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/content/extract/url', { url: 'https://a.com' });
+    });
+  });
+
+  describe('tandem_get_links', () => {
+    const handler = getHandler(tools, 'tandem_get_links');
+
+    it('formats link list', async () => {
+      mockApiCall.mockResolvedValueOnce({ links: [{ text: 'GH', href: 'https://gh.com', visible: true }] });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({});
+      expectTextContent(result, '[GH](https://gh.com)');
+    });
+
+    it('marks hidden links', async () => {
+      mockApiCall.mockResolvedValueOnce({ links: [{ text: 'X', href: 'https://x.com', visible: false }] });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({});
+      expectTextContent(result, '[hidden]');
+    });
+  });
+
+  describe('tandem_execute_js', () => {
+    const handler = getHandler(tools, 'tandem_execute_js');
+
+    it('executes code and returns result', async () => {
+      mockApiCall.mockResolvedValueOnce({ result: 42 });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({ code: '1+1' });
+      expectTextContent(result, '42');
+    });
+
+    it('returns error for rejected execution', async () => {
+      mockApiCall.mockRejectedValueOnce(new Error('User rejected'));
+      const result = await handler({ code: 'evil()' });
+      expectTextContent(result, 'User rejected JavaScript execution');
+    });
+
+    it('propagates non-rejection errors', async () => {
+      mockApiCall.mockRejectedValueOnce(new Error('network down'));
+      await expect(handler({ code: 'x' })).rejects.toThrow('network down');
+    });
+  });
+});

--- a/src/mcp/tests/context.test.ts
+++ b/src/mcp/tests/context.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn(),
+  logActivity: vi.fn(),
+}));
+
+vi.mock('../coerce.js', async (importOriginal) => importOriginal());
+
+import { apiCall } from '../api-client.js';
+import { registerContextTools } from '../tools/context.js';
+import { createMockServer, getHandler } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+
+describe('MCP context tools', () => {
+  const { server, tools } = createMockServer();
+  registerContextTools(server);
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('tandem_context_recent returns recent pages', async () => {
+    mockApiCall.mockResolvedValueOnce({ pages: [] });
+    await getHandler(tools, 'tandem_context_recent')({});
+    expect(mockApiCall).toHaveBeenCalledWith('GET', '/context/recent');
+  });
+
+  it('tandem_context_recent applies limit', async () => {
+    mockApiCall.mockResolvedValueOnce({ pages: [] });
+    await getHandler(tools, 'tandem_context_recent')({ limit: 10 });
+    const endpoint = mockApiCall.mock.calls[0][1] as string;
+    expect(endpoint).toContain('limit=10');
+  });
+
+  it('tandem_context_search searches context', async () => {
+    mockApiCall.mockResolvedValueOnce({ results: [] });
+    await getHandler(tools, 'tandem_context_search')({ query: 'react' });
+    expect(mockApiCall).toHaveBeenCalledWith('GET', '/context/search?q=react');
+  });
+
+  it('tandem_context_page gets page context', async () => {
+    mockApiCall.mockResolvedValueOnce({ data: {} });
+    await getHandler(tools, 'tandem_context_page')({ url: 'https://a.com' });
+    expect(mockApiCall).toHaveBeenCalledWith('GET', '/context/page?url=https%3A%2F%2Fa.com');
+  });
+
+  it('tandem_context_summary returns summary', async () => {
+    mockApiCall.mockResolvedValueOnce({ total: 50 });
+    await getHandler(tools, 'tandem_context_summary')({});
+    expect(mockApiCall).toHaveBeenCalledWith('GET', '/context/summary');
+  });
+
+  it('tandem_context_note adds a note', async () => {
+    mockApiCall.mockResolvedValueOnce({ ok: true });
+    await getHandler(tools, 'tandem_context_note')({ url: 'https://a.com', note: 'important' });
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/context/note', { url: 'https://a.com', note: 'important' });
+  });
+});

--- a/src/mcp/tests/data.test.ts
+++ b/src/mcp/tests/data.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn(),
+  logActivity: vi.fn(),
+}));
+
+import { apiCall } from '../api-client.js';
+import { registerDataTools } from '../tools/data.js';
+import { createMockServer, getHandler, expectTextContent } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+
+describe('MCP data tools', () => {
+  const { server, tools } = createMockServer();
+  registerDataTools(server);
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  describe('tandem_chrome_import_status', () => {
+    it('returns import status', async () => {
+      mockApiCall.mockResolvedValueOnce({ available: true });
+      const result = await getHandler(tools, 'tandem_chrome_import_status')({});
+      expectTextContent(result);
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/import/chrome/status');
+    });
+  });
+
+  describe('tandem_chrome_import_profiles', () => {
+    it('returns chrome profiles', async () => {
+      mockApiCall.mockResolvedValueOnce({ profiles: [] });
+      const result = await getHandler(tools, 'tandem_chrome_import_profiles')({});
+      expectTextContent(result);
+    });
+  });
+
+  describe('tandem_chrome_import_bookmarks', () => {
+    it('imports bookmarks', async () => {
+      mockApiCall.mockResolvedValueOnce({ imported: 50 });
+      await getHandler(tools, 'tandem_chrome_import_bookmarks')({});
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/import/chrome/bookmarks');
+    });
+  });
+
+  describe('tandem_chrome_import_history', () => {
+    it('imports history', async () => {
+      mockApiCall.mockResolvedValueOnce({ imported: 100 });
+      await getHandler(tools, 'tandem_chrome_import_history')({});
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/import/chrome/history');
+    });
+  });
+
+  describe('tandem_chrome_import_cookies', () => {
+    it('imports cookies', async () => {
+      mockApiCall.mockResolvedValueOnce({ imported: 20 });
+      await getHandler(tools, 'tandem_chrome_import_cookies')({});
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/import/chrome/cookies');
+    });
+  });
+
+  describe('tandem_chrome_sync_start', () => {
+    it('starts sync', async () => {
+      mockApiCall.mockResolvedValueOnce({ syncing: true });
+      await getHandler(tools, 'tandem_chrome_sync_start')({ profile: 'Default' });
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/import/chrome/sync/start', { profile: 'Default' });
+    });
+  });
+
+  describe('tandem_chrome_sync_stop', () => {
+    it('stops sync', async () => {
+      mockApiCall.mockResolvedValueOnce({ syncing: false });
+      await getHandler(tools, 'tandem_chrome_sync_stop')({});
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/import/chrome/sync/stop');
+    });
+  });
+
+  describe('tandem_data_export', () => {
+    it('exports data', async () => {
+      mockApiCall.mockResolvedValueOnce({ data: {} });
+      await getHandler(tools, 'tandem_data_export')({});
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/data/export');
+    });
+  });
+
+  describe('tandem_data_import', () => {
+    it('imports data', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: true });
+      await getHandler(tools, 'tandem_data_import')({ data: { bookmarks: [] } });
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/data/import', { bookmarks: [] });
+    });
+  });
+
+  describe('tandem_data_wipe', () => {
+    it('wipes data', async () => {
+      mockApiCall.mockResolvedValueOnce({ wiped: true });
+      await getHandler(tools, 'tandem_data_wipe')({});
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/data/wipe');
+    });
+  });
+
+  describe('tandem_downloads_list', () => {
+    it('lists downloads', async () => {
+      mockApiCall.mockResolvedValueOnce({ downloads: [] });
+      await getHandler(tools, 'tandem_downloads_list')({});
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/downloads');
+    });
+  });
+
+  describe('tandem_config_get', () => {
+    it('gets config', async () => {
+      mockApiCall.mockResolvedValueOnce({ theme: 'dark' });
+      await getHandler(tools, 'tandem_config_get')({});
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/config');
+    });
+  });
+
+  describe('tandem_config_update', () => {
+    it('updates config', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: true });
+      await getHandler(tools, 'tandem_config_update')({ settings: { theme: 'light' } });
+      expect(mockApiCall).toHaveBeenCalledWith('PATCH', '/config', { theme: 'light' });
+    });
+  });
+
+  describe('tandem_get_cookies', () => {
+    it('gets cookies with URL filter', async () => {
+      mockApiCall.mockResolvedValueOnce({ cookies: [] });
+      await getHandler(tools, 'tandem_get_cookies')({ url: 'https://a.com' });
+      const endpoint = mockApiCall.mock.calls[0][1] as string;
+      expect(endpoint).toContain('url=');
+    });
+
+    it('gets all cookies without filter', async () => {
+      mockApiCall.mockResolvedValueOnce({ cookies: [] });
+      await getHandler(tools, 'tandem_get_cookies')({});
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/cookies');
+    });
+  });
+
+  describe('tandem_clear_cookies', () => {
+    it('clears cookies', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: true });
+      await getHandler(tools, 'tandem_clear_cookies')({ domain: 'a.com' });
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/cookies/clear', { domain: 'a.com' });
+    });
+  });
+
+  describe('tandem_browser_status', () => {
+    it('returns status', async () => {
+      mockApiCall.mockResolvedValueOnce({ running: true });
+      await getHandler(tools, 'tandem_browser_status')({});
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/status');
+    });
+  });
+
+  describe('tandem_active_tab_context', () => {
+    it('returns active tab context', async () => {
+      mockApiCall.mockResolvedValueOnce({ title: 'Google' });
+      await getHandler(tools, 'tandem_active_tab_context')({});
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/active-tab/context');
+    });
+  });
+});

--- a/src/mcp/tests/devices.test.ts
+++ b/src/mcp/tests/devices.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn(),
+  logActivity: vi.fn(),
+}));
+
+vi.mock('../coerce.js', async (importOriginal) => importOriginal());
+
+import { apiCall, logActivity } from '../api-client.js';
+import { registerDeviceTools } from '../tools/devices.js';
+import { createMockServer, getHandler } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+const mockLogActivity = vi.mocked(logActivity);
+
+describe('MCP device tools', () => {
+  const { server, tools } = createMockServer();
+  registerDeviceTools(server);
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('tandem_device_profiles lists profiles', async () => {
+    mockApiCall.mockResolvedValueOnce({ profiles: [] });
+    await getHandler(tools, 'tandem_device_profiles')({});
+    expect(mockApiCall).toHaveBeenCalledWith('GET', '/device/profiles');
+  });
+
+  it('tandem_device_status returns status', async () => {
+    mockApiCall.mockResolvedValueOnce({ emulating: false });
+    await getHandler(tools, 'tandem_device_status')({});
+    expect(mockApiCall).toHaveBeenCalledWith('GET', '/device/status');
+  });
+
+  it('tandem_device_emulate emulates a device', async () => {
+    mockApiCall.mockResolvedValueOnce({ emulating: true });
+    mockLogActivity.mockResolvedValueOnce(undefined);
+    await getHandler(tools, 'tandem_device_emulate')({ device: 'iPhone 15' });
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/device/emulate', expect.objectContaining({ device: 'iPhone 15' }));
+  });
+
+  it('tandem_device_reset resets emulation', async () => {
+    mockApiCall.mockResolvedValueOnce({ emulating: false });
+    mockLogActivity.mockResolvedValueOnce(undefined);
+    await getHandler(tools, 'tandem_device_reset')({});
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/device/reset');
+  });
+});

--- a/src/mcp/tests/events.test.ts
+++ b/src/mcp/tests/events.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn(),
+  logActivity: vi.fn(),
+}));
+
+vi.mock('../coerce.js', async (importOriginal) => importOriginal());
+
+import { apiCall } from '../api-client.js';
+import { registerEventTools } from '../tools/events.js';
+import { createMockServer, getHandler } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+
+describe('MCP event tools', () => {
+  const { server, tools } = createMockServer();
+  registerEventTools(server);
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('tandem_events_recent returns recent events', async () => {
+    mockApiCall.mockResolvedValueOnce({ events: [] });
+    await getHandler(tools, 'tandem_events_recent')({});
+    expect(mockApiCall).toHaveBeenCalledWith('GET', '/events/recent');
+  });
+
+  it('tandem_events_recent applies limit', async () => {
+    mockApiCall.mockResolvedValueOnce({ events: [] });
+    await getHandler(tools, 'tandem_events_recent')({ limit: 10 });
+    const endpoint = mockApiCall.mock.calls[0][1] as string;
+    expect(endpoint).toContain('limit=10');
+  });
+
+  it('tandem_live_status returns live status', async () => {
+    mockApiCall.mockResolvedValueOnce({ enabled: true });
+    await getHandler(tools, 'tandem_live_status')({});
+    expect(mockApiCall).toHaveBeenCalledWith('GET', '/live/status');
+  });
+
+  it('tandem_live_toggle toggles monitoring', async () => {
+    mockApiCall.mockResolvedValueOnce({ enabled: false });
+    await getHandler(tools, 'tandem_live_toggle')({ enabled: false });
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/live/toggle', { enabled: false });
+  });
+
+  it('tandem_behavior_stats returns stats', async () => {
+    mockApiCall.mockResolvedValueOnce({ patterns: 5 });
+    await getHandler(tools, 'tandem_behavior_stats')({});
+    expect(mockApiCall).toHaveBeenCalledWith('GET', '/behavior/stats');
+  });
+
+  it('tandem_behavior_clear clears data', async () => {
+    mockApiCall.mockResolvedValueOnce({ ok: true });
+    await getHandler(tools, 'tandem_behavior_clear')({});
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/behavior/clear');
+  });
+});

--- a/src/mcp/tests/extensions.test.ts
+++ b/src/mcp/tests/extensions.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn(),
+  logActivity: vi.fn(),
+}));
+
+vi.mock('../coerce.js', async (importOriginal) => importOriginal());
+
+import { apiCall, logActivity } from '../api-client.js';
+import { registerExtensionTools } from '../tools/extensions.js';
+import { createMockServer, getHandler, expectTextContent } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+const mockLogActivity = vi.mocked(logActivity);
+
+describe('MCP extension tools', () => {
+  const { server, tools } = createMockServer();
+  registerExtensionTools(server);
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  describe('tandem_extensions_list', () => {
+    it('lists extensions', async () => {
+      mockApiCall.mockResolvedValueOnce([{ id: 'ext1' }]);
+      const result = await getHandler(tools, 'tandem_extensions_list')({});
+      expectTextContent(result);
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/extensions/list');
+    });
+  });
+
+  describe('tandem_extension_load', () => {
+    it('loads an extension from path', async () => {
+      mockApiCall.mockResolvedValueOnce({ id: 'ext2' });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      await getHandler(tools, 'tandem_extension_load')({ path: '/tmp/ext' });
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/extensions/load', { path: '/tmp/ext' });
+    });
+  });
+
+  describe('tandem_extension_install', () => {
+    it('installs an extension', async () => {
+      mockApiCall.mockResolvedValueOnce({ id: 'ext3' });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      await getHandler(tools, 'tandem_extension_install')({ input: 'ublock-origin' });
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/extensions/install', { input: 'ublock-origin' });
+    });
+  });
+
+  describe('tandem_extension_uninstall', () => {
+    it('uninstalls an extension', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      await getHandler(tools, 'tandem_extension_uninstall')({ id: 'ext1' });
+      expect(mockApiCall).toHaveBeenCalledWith('DELETE', '/extensions/uninstall/ext1');
+    });
+  });
+
+  describe('tandem_extensions_chrome_list', () => {
+    it('lists chrome extensions', async () => {
+      mockApiCall.mockResolvedValueOnce([]);
+      await getHandler(tools, 'tandem_extensions_chrome_list')({});
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/extensions/chrome/list');
+    });
+
+    it('filters by profile', async () => {
+      mockApiCall.mockResolvedValueOnce([]);
+      await getHandler(tools, 'tandem_extensions_chrome_list')({ profile: 'Work' });
+      const endpoint = mockApiCall.mock.calls[0][1] as string;
+      expect(endpoint).toContain('profile=Work');
+    });
+  });
+
+  describe('tandem_extensions_chrome_import', () => {
+    it('imports chrome extension', async () => {
+      mockApiCall.mockResolvedValueOnce({ imported: 1 });
+      await getHandler(tools, 'tandem_extensions_chrome_import')({ extensionId: 'abc' });
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/extensions/chrome/import', { extensionId: 'abc' });
+    });
+  });
+
+  describe('tandem_extensions_gallery', () => {
+    it('lists gallery extensions', async () => {
+      mockApiCall.mockResolvedValueOnce({ extensions: [] });
+      await getHandler(tools, 'tandem_extensions_gallery')({});
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/extensions/gallery');
+    });
+  });
+
+  describe('tandem_extensions_updates_check', () => {
+    it('checks for updates', async () => {
+      mockApiCall.mockResolvedValueOnce({ updates: [] });
+      await getHandler(tools, 'tandem_extensions_updates_check')({});
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/extensions/updates/check');
+    });
+  });
+
+  describe('tandem_extensions_disk_usage', () => {
+    it('returns disk usage', async () => {
+      mockApiCall.mockResolvedValueOnce({ total: 1024 });
+      await getHandler(tools, 'tandem_extensions_disk_usage')({});
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/extensions/disk-usage');
+    });
+  });
+
+  describe('tandem_extensions_conflicts', () => {
+    it('returns conflicts', async () => {
+      mockApiCall.mockResolvedValueOnce({ conflicts: [] });
+      await getHandler(tools, 'tandem_extensions_conflicts')({});
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/extensions/conflicts');
+    });
+  });
+});

--- a/src/mcp/tests/forms.test.ts
+++ b/src/mcp/tests/forms.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn((tabId?: string) => (tabId ? { 'X-Tab-Id': tabId } : undefined)),
+  logActivity: vi.fn(),
+}));
+
+import { apiCall } from '../api-client.js';
+import { registerFormTools } from '../tools/forms.js';
+import { createMockServer, getHandler } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+
+describe('MCP form tools', () => {
+  const { server, tools } = createMockServer();
+  registerFormTools(server);
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('tandem_forms_saved lists saved forms', async () => {
+    mockApiCall.mockResolvedValueOnce({ forms: [] });
+    await getHandler(tools, 'tandem_forms_saved')({});
+    expect(mockApiCall).toHaveBeenCalledWith('GET', '/forms/memory');
+  });
+
+  it('tandem_forms_saved filters by domain', async () => {
+    mockApiCall.mockResolvedValueOnce({ forms: [] });
+    await getHandler(tools, 'tandem_forms_saved')({ domain: 'github.com' });
+    expect(mockApiCall).toHaveBeenCalledWith('GET', '/forms/memory/github.com');
+  });
+
+  it('tandem_form_fill fills form', async () => {
+    mockApiCall.mockResolvedValueOnce({ filled: true });
+    await getHandler(tools, 'tandem_form_fill')({});
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/forms/fill', expect.any(Object), undefined);
+  });
+
+  it('tandem_forms_clear clears saved forms', async () => {
+    mockApiCall.mockResolvedValueOnce({ ok: true });
+    await getHandler(tools, 'tandem_forms_clear')({ domain: 'github.com' });
+    expect(mockApiCall).toHaveBeenCalledWith('DELETE', '/forms/memory/github.com');
+  });
+});

--- a/src/mcp/tests/headless.test.ts
+++ b/src/mcp/tests/headless.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn(),
+  logActivity: vi.fn(),
+}));
+
+import { apiCall } from '../api-client.js';
+import { registerHeadlessTools } from '../tools/headless.js';
+import { createMockServer, getHandler } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+
+describe('MCP headless tools', () => {
+  const { server, tools } = createMockServer();
+  registerHeadlessTools(server);
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('tandem_headless_open opens URL', async () => {
+    mockApiCall.mockResolvedValueOnce({ url: 'https://a.com' });
+
+    await getHandler(tools, 'tandem_headless_open')({ url: 'https://a.com' });
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/headless/open', { url: 'https://a.com' });
+  });
+
+  it('tandem_headless_content returns content', async () => {
+    mockApiCall.mockResolvedValueOnce({ html: '<html/>' });
+    await getHandler(tools, 'tandem_headless_content')({});
+    expect(mockApiCall).toHaveBeenCalledWith('GET', '/headless/content');
+  });
+
+  it('tandem_headless_status returns status', async () => {
+    mockApiCall.mockResolvedValueOnce({ open: false });
+    await getHandler(tools, 'tandem_headless_status')({});
+    expect(mockApiCall).toHaveBeenCalledWith('GET', '/headless/status');
+  });
+
+  it('tandem_headless_close closes browser', async () => {
+    mockApiCall.mockResolvedValueOnce({ ok: true });
+
+    await getHandler(tools, 'tandem_headless_close')({});
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/headless/close');
+  });
+
+  it('tandem_headless_show makes window visible', async () => {
+    mockApiCall.mockResolvedValueOnce({});
+    await getHandler(tools, 'tandem_headless_show')({});
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/headless/show');
+  });
+
+  it('tandem_headless_hide hides window', async () => {
+    mockApiCall.mockResolvedValueOnce({});
+    await getHandler(tools, 'tandem_headless_hide')({});
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/headless/hide');
+  });
+});

--- a/src/mcp/tests/history.test.ts
+++ b/src/mcp/tests/history.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn(),
+  logActivity: vi.fn(),
+}));
+
+vi.mock('../coerce.js', async (importOriginal) => importOriginal());
+
+import { apiCall, logActivity } from '../api-client.js';
+import { registerHistoryTools } from '../tools/history.js';
+import { createMockServer, getHandler, expectTextContent } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+const mockLogActivity = vi.mocked(logActivity);
+
+describe('MCP history tools', () => {
+  const { server, tools } = createMockServer();
+  registerHistoryTools(server);
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  describe('tandem_history_list', () => {
+    const handler = getHandler(tools, 'tandem_history_list');
+
+    it('returns formatted history entries', async () => {
+      mockApiCall.mockResolvedValueOnce({
+        entries: [{ url: 'https://a.com', title: 'A', lastVisitTime: '2024-01-01T00:00:00Z', visitCount: 3 }],
+        total: 1,
+      });
+      const result = await handler({});
+      const text = expectTextContent(result, 'Browsing history');
+      expect(text).toContain('[A](https://a.com)');
+      expect(text).toContain('3 visits');
+    });
+
+    it('builds query string with pagination', async () => {
+      mockApiCall.mockResolvedValueOnce({ entries: [], total: 0 });
+      await handler({ limit: 10, offset: 20 });
+      const endpoint = mockApiCall.mock.calls[0][1] as string;
+      expect(endpoint).toContain('limit=10');
+      expect(endpoint).toContain('offset=20');
+    });
+  });
+
+  describe('tandem_history_clear', () => {
+    const handler = getHandler(tools, 'tandem_history_clear');
+
+    it('clears history', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: true });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({});
+      expectTextContent(result);
+      expect(mockApiCall).toHaveBeenCalledWith('DELETE', '/history/clear');
+    });
+  });
+
+  describe('tandem_search_history', () => {
+    const handler = getHandler(tools, 'tandem_search_history');
+
+    it('returns search results', async () => {
+      mockApiCall.mockResolvedValueOnce({
+        results: [{ url: 'https://b.com', title: 'B', visitedAt: 1700000000000 }],
+      });
+      const result = await handler({ query: 'test' });
+      expectTextContent(result, 'History results for "test"');
+    });
+  });
+
+  describe('tandem_activity_log', () => {
+    const handler = getHandler(tools, 'tandem_activity_log');
+
+    it('returns activity entries', async () => {
+      mockApiCall.mockResolvedValueOnce({
+        entries: [{ type: 'navigate', detail: 'https://a.com', ts: 1700000000000 }],
+      });
+      const result = await handler({});
+      expectTextContent(result, 'Activity log');
+    });
+  });
+
+  describe('tandem_site_memory_list', () => {
+    const handler = getHandler(tools, 'tandem_site_memory_list');
+
+    it('lists remembered sites', async () => {
+      mockApiCall.mockResolvedValueOnce({ sites: [{ domain: 'github.com' }] });
+      const result = await handler({});
+      expectTextContent(result, 'github.com');
+    });
+  });
+
+  describe('tandem_site_memory_get', () => {
+    const handler = getHandler(tools, 'tandem_site_memory_get');
+
+    it('gets memory for domain', async () => {
+      mockApiCall.mockResolvedValueOnce({ notes: [] });
+      await handler({ domain: 'github.com' });
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/memory/site/github.com');
+    });
+  });
+
+  describe('tandem_site_memory_search', () => {
+    const handler = getHandler(tools, 'tandem_site_memory_search');
+
+    it('searches site memory', async () => {
+      mockApiCall.mockResolvedValueOnce({ results: [] });
+      await handler({ query: 'login' });
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/memory/search?q=login');
+    });
+  });
+
+  describe('tandem_site_memory_diff', () => {
+    const handler = getHandler(tools, 'tandem_site_memory_diff');
+
+    it('gets memory diff', async () => {
+      mockApiCall.mockResolvedValueOnce({ changes: [] });
+      await handler({ domain: 'github.com' });
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/memory/site/github.com/diff');
+    });
+  });
+});

--- a/src/mcp/tests/media.test.ts
+++ b/src/mcp/tests/media.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn(),
+  logActivity: vi.fn(),
+}));
+
+vi.mock('../coerce.js', async (importOriginal) => importOriginal());
+
+import { apiCall, logActivity } from '../api-client.js';
+import { registerMediaTools } from '../tools/media.js';
+import { createMockServer, getHandler, expectImageContent } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+const mockLogActivity = vi.mocked(logActivity);
+
+describe('MCP media tools', () => {
+  const { server, tools } = createMockServer();
+  registerMediaTools(server);
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  describe('tandem_voice_start', () => {
+    it('starts voice recognition', async () => {
+      mockApiCall.mockResolvedValueOnce({ listening: true });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      await getHandler(tools, 'tandem_voice_start')({});
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/voice/start');
+    });
+  });
+
+  describe('tandem_voice_stop', () => {
+    it('stops voice recognition', async () => {
+      mockApiCall.mockResolvedValueOnce({ listening: false });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      await getHandler(tools, 'tandem_voice_stop')({});
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/voice/stop');
+    });
+  });
+
+  describe('tandem_voice_status', () => {
+    it('returns voice status', async () => {
+      mockApiCall.mockResolvedValueOnce({ active: false });
+      await getHandler(tools, 'tandem_voice_status')({});
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/voice/status');
+    });
+  });
+
+  describe('tandem_audio_start', () => {
+    it('starts audio recording', async () => {
+      mockApiCall.mockResolvedValueOnce({ recording: true });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      await getHandler(tools, 'tandem_audio_start')({});
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/audio/start');
+    });
+  });
+
+  describe('tandem_audio_stop', () => {
+    it('stops audio recording', async () => {
+      mockApiCall.mockResolvedValueOnce({ recording: false });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      await getHandler(tools, 'tandem_audio_stop')({});
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/audio/stop');
+    });
+  });
+
+  describe('tandem_audio_recordings', () => {
+    it('lists recordings', async () => {
+      mockApiCall.mockResolvedValueOnce({ recordings: [] });
+      await getHandler(tools, 'tandem_audio_recordings')({});
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/audio/recordings');
+    });
+  });
+
+  describe('tandem_screenshot_annotated', () => {
+    it('returns annotated screenshot as image', async () => {
+      mockApiCall.mockResolvedValueOnce('base64png');
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await getHandler(tools, 'tandem_screenshot_annotated')({});
+      expectImageContent(result);
+    });
+  });
+
+  describe('tandem_screenshot_capture_annotated', () => {
+    it('captures annotated screenshot', async () => {
+      mockApiCall.mockResolvedValueOnce({ path: '/tmp/ss.png' });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      await getHandler(tools, 'tandem_screenshot_capture_annotated')({});
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/screenshot/annotated');
+    });
+  });
+
+  describe('tandem_screenshots_list', () => {
+    it('lists screenshots', async () => {
+      mockApiCall.mockResolvedValueOnce({ screenshots: [] });
+      await getHandler(tools, 'tandem_screenshots_list')({});
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/screenshots');
+    });
+
+    it('applies limit', async () => {
+      mockApiCall.mockResolvedValueOnce({ screenshots: [] });
+      await getHandler(tools, 'tandem_screenshots_list')({ limit: 5 });
+      const endpoint = mockApiCall.mock.calls[0][1] as string;
+      expect(endpoint).toContain('limit=5');
+    });
+  });
+
+  describe('tandem_draw_toggle', () => {
+    it('toggles draw mode', async () => {
+      mockApiCall.mockResolvedValueOnce({ enabled: true });
+      await getHandler(tools, 'tandem_draw_toggle')({ enabled: true });
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/draw/toggle', { enabled: true });
+    });
+  });
+
+  describe('tandem_wingman_stream_toggle', () => {
+    it('toggles wingman stream', async () => {
+      mockApiCall.mockResolvedValueOnce({ enabled: true });
+      await getHandler(tools, 'tandem_wingman_stream_toggle')({ enabled: true });
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/wingman-stream/toggle', { enabled: true });
+    });
+  });
+});

--- a/src/mcp/tests/passwords.test.ts
+++ b/src/mcp/tests/passwords.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn(),
+  logActivity: vi.fn(),
+}));
+
+vi.mock('../coerce.js', async (importOriginal) => importOriginal());
+
+import { apiCall, logActivity } from '../api-client.js';
+import { registerPasswordTools } from '../tools/passwords.js';
+import { createMockServer, getHandler } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+const mockLogActivity = vi.mocked(logActivity);
+
+describe('MCP password tools', () => {
+  const { server, tools } = createMockServer();
+  registerPasswordTools(server);
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('tandem_password_status returns vault status', async () => {
+    mockApiCall.mockResolvedValueOnce({ locked: true });
+    await getHandler(tools, 'tandem_password_status')({});
+    expect(mockApiCall).toHaveBeenCalledWith('GET', '/passwords/status');
+  });
+
+  it('tandem_password_unlock unlocks vault', async () => {
+    mockApiCall.mockResolvedValueOnce({ unlocked: true });
+    await getHandler(tools, 'tandem_password_unlock')({ masterPassword: 'secret' });
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/passwords/unlock', { password: 'secret' });
+  });
+
+  it('tandem_password_lock locks vault', async () => {
+    mockApiCall.mockResolvedValueOnce({ locked: true });
+    await getHandler(tools, 'tandem_password_lock')({});
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/passwords/lock');
+  });
+
+  it('tandem_password_generate generates password', async () => {
+    mockApiCall.mockResolvedValueOnce({ password: 'abc123' });
+    await getHandler(tools, 'tandem_password_generate')({ length: 32 });
+    const endpoint = mockApiCall.mock.calls[0][1] as string;
+    expect(endpoint).toContain('length=32');
+  });
+
+  it('tandem_password_suggest suggests passwords for URL', async () => {
+    mockApiCall.mockResolvedValueOnce({ suggestions: [] });
+    await getHandler(tools, 'tandem_password_suggest')({ url: 'github.com' });
+    expect(mockApiCall).toHaveBeenCalledWith('GET', '/passwords/suggest?domain=github.com');
+  });
+
+  it('tandem_password_save saves a password', async () => {
+    mockApiCall.mockResolvedValueOnce({ ok: true });
+    mockLogActivity.mockResolvedValueOnce(undefined);
+    await getHandler(tools, 'tandem_password_save')({ url: 'github.com', username: 'robin', password: 'pw123' });
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/passwords/save', { domain: 'github.com', username: 'robin', payload: 'pw123' });
+  });
+});

--- a/src/mcp/tests/pinboards.test.ts
+++ b/src/mcp/tests/pinboards.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn(),
+  logActivity: vi.fn(),
+}));
+
+import { apiCall, logActivity } from '../api-client.js';
+import { registerPinboardTools } from '../tools/pinboards.js';
+import { createMockServer, getHandler, expectTextContent } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+const mockLogActivity = vi.mocked(logActivity);
+
+describe('MCP pinboard tools', () => {
+  const { server, tools } = createMockServer();
+  registerPinboardTools(server);
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  describe('tandem_pinboard_list', () => {
+    it('lists pinboards', async () => {
+      mockApiCall.mockResolvedValueOnce([{ id: 'p1', name: 'Research' }]);
+      const result = await getHandler(tools, 'tandem_pinboard_list')({});
+      expectTextContent(result);
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/pinboards');
+    });
+  });
+
+  describe('tandem_pinboard_create', () => {
+    it('creates a pinboard', async () => {
+      mockApiCall.mockResolvedValueOnce({ id: 'p2' });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      await getHandler(tools, 'tandem_pinboard_create')({ name: 'Ideas', emoji: '💡' });
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/pinboards', { name: 'Ideas', emoji: '💡' });
+    });
+  });
+
+  describe('tandem_pinboard_get', () => {
+    it('gets a pinboard', async () => {
+      mockApiCall.mockResolvedValueOnce({ id: 'p1', items: [] });
+      await getHandler(tools, 'tandem_pinboard_get')({ id: 'p1' });
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/pinboards/p1');
+    });
+  });
+
+  describe('tandem_pinboard_update', () => {
+    it('updates a pinboard', async () => {
+      mockApiCall.mockResolvedValueOnce({ id: 'p1' });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      await getHandler(tools, 'tandem_pinboard_update')({ id: 'p1', name: 'Updated' });
+      expect(mockApiCall).toHaveBeenCalledWith('PUT', '/pinboards/p1', { name: 'Updated' });
+    });
+  });
+
+  describe('tandem_pinboard_delete', () => {
+    it('deletes a pinboard', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: true });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await getHandler(tools, 'tandem_pinboard_delete')({ id: 'p1' });
+      expectTextContent(result, 'Deleted pinboard: p1');
+    });
+
+    it('handles not found', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: false });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await getHandler(tools, 'tandem_pinboard_delete')({ id: 'bad' });
+      expectTextContent(result, 'Pinboard not found');
+    });
+  });
+
+  describe('tandem_pinboard_items', () => {
+    it('lists items', async () => {
+      mockApiCall.mockResolvedValueOnce({ items: [] });
+      await getHandler(tools, 'tandem_pinboard_items')({ id: 'p1' });
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/pinboards/p1/items');
+    });
+  });
+
+  describe('tandem_pinboard_add_item', () => {
+    it('adds an item', async () => {
+      mockApiCall.mockResolvedValueOnce({ id: 'item1' });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      await getHandler(tools, 'tandem_pinboard_add_item')({ id: 'p1', type: 'link', url: 'https://a.com' });
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/pinboards/p1/items', expect.objectContaining({ type: 'link', url: 'https://a.com' }));
+    });
+  });
+
+  describe('tandem_pinboard_remove_item', () => {
+    it('removes an item', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: true });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await getHandler(tools, 'tandem_pinboard_remove_item')({ id: 'p1', itemId: 'i1' });
+      expectTextContent(result, 'Removed item i1');
+    });
+
+    it('handles not found', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: false });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await getHandler(tools, 'tandem_pinboard_remove_item')({ id: 'p1', itemId: 'bad' });
+      expectTextContent(result, 'not found');
+    });
+  });
+
+  describe('tandem_pinboard_reorder_items', () => {
+    it('reorders items', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: true });
+      await getHandler(tools, 'tandem_pinboard_reorder_items')({ id: 'p1', itemIds: ['i2', 'i1'] });
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/pinboards/p1/items/reorder', { itemIds: ['i2', 'i1'] });
+    });
+  });
+});

--- a/src/mcp/tests/previews.test.ts
+++ b/src/mcp/tests/previews.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn(),
+  logActivity: vi.fn(),
+}));
+
+import { apiCall, logActivity } from '../api-client.js';
+import { registerPreviewTools } from '../tools/previews.js';
+import { createMockServer, getHandler, expectTextContent } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+const mockLogActivity = vi.mocked(logActivity);
+
+describe('MCP preview tools', () => {
+  const { server, tools } = createMockServer();
+  registerPreviewTools(server);
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('tandem_preview_create creates preview', async () => {
+    mockApiCall.mockResolvedValueOnce({ id: 'pv1', url: 'http://localhost:3000/pv1', title: 'Test' });
+    mockLogActivity.mockResolvedValueOnce(undefined);
+    await getHandler(tools, 'tandem_preview_create')({ html: '<h1>Hi</h1>', title: 'Test' });
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/preview', { html: '<h1>Hi</h1>', title: 'Test' });
+  });
+
+  it('tandem_preview_update updates preview', async () => {
+    mockApiCall.mockResolvedValueOnce({ id: 'pv1', version: 2, url: 'http://localhost/pv1' });
+    mockLogActivity.mockResolvedValueOnce(undefined);
+    await getHandler(tools, 'tandem_preview_update')({ id: 'pv1', html: '<h1>Updated</h1>' });
+    expect(mockApiCall).toHaveBeenCalledWith('PUT', '/preview/pv1', { html: '<h1>Updated</h1>' });
+  });
+
+  it('tandem_preview_list lists previews', async () => {
+    mockApiCall.mockResolvedValueOnce({ previews: [] });
+    await getHandler(tools, 'tandem_preview_list')({});
+    expect(mockApiCall).toHaveBeenCalledWith('GET', '/previews');
+  });
+
+  it('tandem_preview_delete deletes preview', async () => {
+    mockApiCall.mockResolvedValueOnce({});
+    mockLogActivity.mockResolvedValueOnce(undefined);
+    const result = await getHandler(tools, 'tandem_preview_delete')({ id: 'pv1' });
+    expectTextContent(result, "Preview 'pv1' deleted");
+    expect(mockApiCall).toHaveBeenCalledWith('DELETE', '/preview/pv1');
+  });
+});

--- a/src/mcp/tests/scripts.test.ts
+++ b/src/mcp/tests/scripts.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn(),
+  logActivity: vi.fn(),
+}));
+
+import { apiCall, logActivity } from '../api-client.js';
+import { registerScriptTools } from '../tools/scripts.js';
+import { createMockServer, getHandler, expectTextContent } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+const mockLogActivity = vi.mocked(logActivity);
+
+describe('MCP script/style tools', () => {
+  const { server, tools } = createMockServer();
+  registerScriptTools(server);
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  describe('tandem_scripts_list', () => {
+    const handler = getHandler(tools, 'tandem_scripts_list');
+
+    it('lists scripts', async () => {
+      mockApiCall.mockResolvedValueOnce([{ name: 'dark-mode' }]);
+      const result = await handler({});
+      expectTextContent(result);
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/scripts');
+    });
+  });
+
+  describe('tandem_script_add', () => {
+    const handler = getHandler(tools, 'tandem_script_add');
+
+    it('adds a script', async () => {
+      mockApiCall.mockResolvedValueOnce({ name: 'test', active: true });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({ name: 'test', code: 'console.log(1)' });
+      expectTextContent(result, 'Added script "test"');
+    });
+  });
+
+  describe('tandem_script_remove', () => {
+    const handler = getHandler(tools, 'tandem_script_remove');
+
+    it('removes a script', async () => {
+      mockApiCall.mockResolvedValueOnce({ removed: 'test' });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({ name: 'test' });
+      expectTextContent(result, 'Removed script: test');
+    });
+  });
+
+  describe('tandem_script_enable', () => {
+    const handler = getHandler(tools, 'tandem_script_enable');
+
+    it('enables a script', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({ name: 'test' });
+      expectTextContent(result, 'Enabled script: test');
+    });
+  });
+
+  describe('tandem_script_disable', () => {
+    const handler = getHandler(tools, 'tandem_script_disable');
+
+    it('disables a script', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({ name: 'test' });
+      expectTextContent(result, 'Disabled script: test');
+    });
+  });
+
+  describe('tandem_styles_list', () => {
+    const handler = getHandler(tools, 'tandem_styles_list');
+
+    it('lists styles', async () => {
+      mockApiCall.mockResolvedValueOnce([{ name: 'theme' }]);
+      const result = await handler({});
+      expectTextContent(result);
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/styles');
+    });
+  });
+
+  describe('tandem_style_add', () => {
+    const handler = getHandler(tools, 'tandem_style_add');
+
+    it('adds a style', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({ name: 'dark', css: 'body{color:white}' });
+      expectTextContent(result, 'Added style: dark');
+    });
+  });
+
+  describe('tandem_style_remove', () => {
+    const handler = getHandler(tools, 'tandem_style_remove');
+
+    it('removes a style', async () => {
+      mockApiCall.mockResolvedValueOnce({ removed: 'dark' });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({ name: 'dark' });
+      expectTextContent(result, 'Removed style: dark');
+    });
+  });
+
+  describe('tandem_style_enable', () => {
+    const handler = getHandler(tools, 'tandem_style_enable');
+
+    it('enables a style', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({ name: 'dark' });
+      expectTextContent(result, 'Enabled style: dark');
+    });
+  });
+
+  describe('tandem_style_disable', () => {
+    const handler = getHandler(tools, 'tandem_style_disable');
+
+    it('disables a style', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({ name: 'dark' });
+      expectTextContent(result, 'Disabled style: dark');
+    });
+  });
+});

--- a/src/mcp/tests/sidebar.test.ts
+++ b/src/mcp/tests/sidebar.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn(),
+  logActivity: vi.fn(),
+}));
+
+import { apiCall } from '../api-client.js';
+import { registerSidebarTools } from '../tools/sidebar.js';
+import { createMockServer, getHandler } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+
+describe('MCP sidebar tools', () => {
+  const { server, tools } = createMockServer();
+  registerSidebarTools(server);
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('tandem_sidebar_config returns config', async () => {
+    mockApiCall.mockResolvedValueOnce({ items: [] });
+    await getHandler(tools, 'tandem_sidebar_config')({});
+    expect(mockApiCall).toHaveBeenCalledWith('GET', '/sidebar/config');
+  });
+
+  it('tandem_sidebar_update updates config', async () => {
+    mockApiCall.mockResolvedValueOnce({ ok: true });
+    await getHandler(tools, 'tandem_sidebar_update')({ config: { width: 300 } });
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/sidebar/config', { width: 300 });
+  });
+
+  it('tandem_sidebar_toggle_item toggles item', async () => {
+    mockApiCall.mockResolvedValueOnce({ visible: true });
+    await getHandler(tools, 'tandem_sidebar_toggle_item')({ id: 'bookmarks' });
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/sidebar/items/bookmarks/toggle');
+  });
+
+  it('tandem_sidebar_activate_item activates item', async () => {
+    mockApiCall.mockResolvedValueOnce({ active: true });
+    await getHandler(tools, 'tandem_sidebar_activate_item')({ id: 'history' });
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/sidebar/items/history/activate');
+  });
+
+  it('tandem_sidebar_reorder reorders items', async () => {
+    mockApiCall.mockResolvedValueOnce({ ok: true });
+    await getHandler(tools, 'tandem_sidebar_reorder')({ orderedIds: ['a', 'b', 'c'] });
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/sidebar/reorder', { orderedIds: ['a', 'b', 'c'] });
+  });
+
+  it('tandem_sidebar_state sets state', async () => {
+    mockApiCall.mockResolvedValueOnce({ state: 'wide' });
+    await getHandler(tools, 'tandem_sidebar_state')({ state: 'wide' });
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/sidebar/state', { state: 'wide' });
+  });
+});

--- a/src/mcp/tests/system.test.ts
+++ b/src/mcp/tests/system.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn(),
+  logActivity: vi.fn(),
+}));
+
+import { apiCall } from '../api-client.js';
+import { registerSystemTools } from '../tools/system.js';
+import { createMockServer, getHandler } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+
+describe('MCP system tools', () => {
+  const { server, tools } = createMockServer();
+  registerSystemTools(server);
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('tandem_pick_folder opens folder picker', async () => {
+    mockApiCall.mockResolvedValueOnce({ path: '/Users/robin/Desktop' });
+    await getHandler(tools, 'tandem_pick_folder')({});
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/dialog/pick-folder');
+  });
+
+  it('tandem_injection_override sets override', async () => {
+    mockApiCall.mockResolvedValueOnce({ ok: true });
+    await getHandler(tools, 'tandem_injection_override')({ domain: 'example.com' });
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/security/injection-override', { domain: 'example.com' });
+  });
+
+  it('tandem_google_photos_status returns status', async () => {
+    mockApiCall.mockResolvedValueOnce({ connected: false });
+    await getHandler(tools, 'tandem_google_photos_status')({});
+    expect(mockApiCall).toHaveBeenCalledWith('GET', '/integrations/google-photos/status');
+  });
+
+  it('tandem_google_photos_connect initiates OAuth', async () => {
+    mockApiCall.mockResolvedValueOnce({ authUrl: 'https://accounts.google.com/...' });
+    await getHandler(tools, 'tandem_google_photos_connect')({});
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/integrations/google-photos/connect', expect.any(Object));
+  });
+
+  it('tandem_google_photos_disconnect disconnects', async () => {
+    mockApiCall.mockResolvedValueOnce({ ok: true });
+    await getHandler(tools, 'tandem_google_photos_disconnect')({});
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/integrations/google-photos/disconnect');
+  });
+
+  it('tandem_google_photos_config updates config', async () => {
+    mockApiCall.mockResolvedValueOnce({ ok: true });
+    await getHandler(tools, 'tandem_google_photos_config')({ clientId: 'abc' });
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/integrations/google-photos/config', { clientId: 'abc' });
+  });
+});

--- a/src/mcp/tests/tasks.test.ts
+++ b/src/mcp/tests/tasks.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn(),
+  logActivity: vi.fn(),
+}));
+
+vi.mock('../coerce.js', async (importOriginal) => importOriginal());
+
+import { apiCall, logActivity } from '../api-client.js';
+import { registerTaskTools } from '../tools/tasks.js';
+import { createMockServer, getHandler, expectTextContent } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+const mockLogActivity = vi.mocked(logActivity);
+
+describe('MCP task tools', () => {
+  const { server, tools } = createMockServer();
+  registerTaskTools(server);
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  describe('tandem_create_task', () => {
+    const handler = getHandler(tools, 'tandem_create_task');
+
+    it('creates a task with steps', async () => {
+      mockApiCall.mockResolvedValueOnce({ id: 'task-1', status: 'pending' });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({
+        description: 'Test task',
+        steps: [{ description: 'Go to page', actionType: 'navigate', params: { url: 'https://a.com' } }],
+      });
+      expectTextContent(result, 'Task created: task-1');
+      expectTextContent(result, 'Steps: 1');
+    });
+  });
+
+  describe('tandem_emergency_stop', () => {
+    const handler = getHandler(tools, 'tandem_emergency_stop');
+
+    it('stops all tasks', async () => {
+      mockApiCall.mockResolvedValueOnce({ stopped: 3 });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({});
+      expectTextContent(result, '3 tasks paused');
+    });
+  });
+
+  describe('tandem_task_list', () => {
+    const handler = getHandler(tools, 'tandem_task_list');
+
+    it('lists tasks', async () => {
+      mockApiCall.mockResolvedValueOnce([{ id: 't1', status: 'done' }]);
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({});
+      expectTextContent(result);
+    });
+  });
+
+  describe('tandem_task_get', () => {
+    const handler = getHandler(tools, 'tandem_task_get');
+
+    it('gets task details', async () => {
+      mockApiCall.mockResolvedValueOnce({ id: 't1', steps: [] });
+      const result = await handler({ id: 't1' });
+      expectTextContent(result);
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/tasks/t1');
+    });
+  });
+
+  describe('tandem_task_approve', () => {
+    const handler = getHandler(tools, 'tandem_task_approve');
+
+    it('approves a step', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({ id: 't1', stepId: 's1' });
+      expectTextContent(result, 'Step s1 of task t1 approved');
+    });
+  });
+
+  describe('tandem_task_reject', () => {
+    const handler = getHandler(tools, 'tandem_task_reject');
+
+    it('rejects a step', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({ id: 't1', stepId: 's1' });
+      expectTextContent(result, 'Step s1 of task t1 rejected');
+    });
+  });
+
+  describe('tandem_tab_lock', () => {
+    const handler = getHandler(tools, 'tandem_tab_lock');
+
+    it('acquires a tab lock', async () => {
+      mockApiCall.mockResolvedValueOnce({ locked: true });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      await handler({ tabId: 't1', agent: 'claude' });
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/tab-locks/acquire', { tabId: 't1', agent: 'claude' });
+    });
+  });
+
+  describe('tandem_tab_unlock', () => {
+    const handler = getHandler(tools, 'tandem_tab_unlock');
+
+    it('releases a tab lock', async () => {
+      mockApiCall.mockResolvedValueOnce({ released: true });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      await handler({ tabId: 't1' });
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/tab-locks/release', { tabId: 't1' });
+    });
+  });
+
+  describe('tandem_task_check_approval', () => {
+    const handler = getHandler(tools, 'tandem_task_check_approval');
+
+    it('checks approval with filters', async () => {
+      mockApiCall.mockResolvedValueOnce({ required: true });
+      await handler({ actionType: 'navigate', targetUrl: 'https://x.com' });
+      const endpoint = mockApiCall.mock.calls[0][1] as string;
+      expect(endpoint).toContain('actionType=navigate');
+      expect(endpoint).toContain('targetUrl=');
+    });
+  });
+
+  describe('tandem_autonomy_get', () => {
+    const handler = getHandler(tools, 'tandem_autonomy_get');
+
+    it('gets autonomy settings', async () => {
+      mockApiCall.mockResolvedValueOnce({ level: 'supervised' });
+      const result = await handler({});
+      expectTextContent(result);
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/autonomy');
+    });
+  });
+
+  describe('tandem_autonomy_update', () => {
+    const handler = getHandler(tools, 'tandem_autonomy_update');
+
+    it('updates autonomy settings', async () => {
+      mockApiCall.mockResolvedValueOnce({ level: 'autonomous' });
+      await handler({ settings: { level: 'autonomous' } });
+      expect(mockApiCall).toHaveBeenCalledWith('PATCH', '/autonomy', { level: 'autonomous' });
+    });
+  });
+
+  describe('tandem_agent_activity_log', () => {
+    const handler = getHandler(tools, 'tandem_agent_activity_log');
+
+    it('gets agent activity with limit', async () => {
+      mockApiCall.mockResolvedValueOnce({ entries: [] });
+      await handler({ limit: 10 });
+      const endpoint = mockApiCall.mock.calls[0][1] as string;
+      expect(endpoint).toContain('limit=10');
+    });
+  });
+
+  describe('tandem_tab_lock_status', () => {
+    const handler = getHandler(tools, 'tandem_tab_lock_status');
+
+    it('checks tab lock status', async () => {
+      mockApiCall.mockResolvedValueOnce({ locked: false });
+      await handler({ tabId: 't1' });
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/tab-locks/t1');
+    });
+  });
+});

--- a/src/mcp/tests/watches.test.ts
+++ b/src/mcp/tests/watches.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn(),
+  logActivity: vi.fn(),
+}));
+
+vi.mock('../coerce.js', async (importOriginal) => importOriginal());
+
+import { apiCall, logActivity } from '../api-client.js';
+import { registerWatchTools } from '../tools/watches.js';
+import { createMockServer, getHandler, expectTextContent } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+const mockLogActivity = vi.mocked(logActivity);
+
+describe('MCP watch tools', () => {
+  const { server, tools } = createMockServer();
+  registerWatchTools(server);
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('tandem_watch_list lists watches', async () => {
+    mockApiCall.mockResolvedValueOnce({ watches: [] });
+    mockLogActivity.mockResolvedValueOnce(undefined);
+    await getHandler(tools, 'tandem_watch_list')({});
+    expect(mockApiCall).toHaveBeenCalledWith('GET', '/watch/list');
+  });
+
+  it('tandem_watch_add adds a watch', async () => {
+    mockApiCall.mockResolvedValueOnce({ id: 'w1' });
+    mockLogActivity.mockResolvedValueOnce(undefined);
+    await getHandler(tools, 'tandem_watch_add')({ url: 'https://news.com', intervalMinutes: 60 });
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/watch/add', { url: 'https://news.com', intervalMinutes: 60 });
+  });
+
+  it('tandem_watch_remove removes a watch', async () => {
+    mockApiCall.mockResolvedValueOnce({ ok: true });
+    mockLogActivity.mockResolvedValueOnce(undefined);
+    const result = await getHandler(tools, 'tandem_watch_remove')({ url: 'https://news.com' });
+    expectTextContent(result, 'Removed watch');
+  });
+
+  it('tandem_watch_remove reports not found', async () => {
+    mockApiCall.mockResolvedValueOnce({ ok: false });
+    mockLogActivity.mockResolvedValueOnce(undefined);
+    const result = await getHandler(tools, 'tandem_watch_remove')({ id: 'bad' });
+    expectTextContent(result, 'Watch not found');
+  });
+
+  it('tandem_watch_check force-checks a watch', async () => {
+    mockApiCall.mockResolvedValueOnce({ changed: true });
+    mockLogActivity.mockResolvedValueOnce(undefined);
+    await getHandler(tools, 'tandem_watch_check')({ url: 'https://news.com' });
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/watch/check', { url: 'https://news.com' });
+  });
+});

--- a/src/mcp/tests/workflows.test.ts
+++ b/src/mcp/tests/workflows.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  tabHeaders: vi.fn(),
+  logActivity: vi.fn(),
+}));
+
+import { apiCall, logActivity } from '../api-client.js';
+import { registerWorkflowTools } from '../tools/workflows.js';
+import { createMockServer, getHandler, expectTextContent } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+const mockLogActivity = vi.mocked(logActivity);
+
+describe('MCP workflow tools', () => {
+  const { server, tools } = createMockServer();
+  registerWorkflowTools(server);
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  describe('tandem_workflow_list', () => {
+    const handler = getHandler(tools, 'tandem_workflow_list');
+
+    it('lists workflows', async () => {
+      mockApiCall.mockResolvedValueOnce([{ id: 'wf1', name: 'Deploy' }]);
+      const result = await handler({});
+      expectTextContent(result);
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/workflows');
+    });
+  });
+
+  describe('tandem_workflow_create', () => {
+    const handler = getHandler(tools, 'tandem_workflow_create');
+
+    it('creates a workflow', async () => {
+      mockApiCall.mockResolvedValueOnce({ id: 'wf2' });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({ name: 'Test', steps: [{ action: 'navigate' }] });
+      expectTextContent(result, 'Workflow created: wf2');
+      expectTextContent(result, 'Steps: 1');
+    });
+  });
+
+  describe('tandem_workflow_delete', () => {
+    const handler = getHandler(tools, 'tandem_workflow_delete');
+
+    it('deletes a workflow', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({ id: 'wf1' });
+      expectTextContent(result, 'Workflow wf1 deleted');
+    });
+  });
+
+  describe('tandem_workflow_run', () => {
+    const handler = getHandler(tools, 'tandem_workflow_run');
+
+    it('runs a workflow', async () => {
+      mockApiCall.mockResolvedValueOnce({ executionId: 'exec-1' });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({ id: 'wf1' });
+      expectTextContent(result, 'Execution ID: exec-1');
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/workflow/run', { workflowId: 'wf1', variables: undefined });
+    });
+  });
+
+  describe('tandem_workflow_status', () => {
+    const handler = getHandler(tools, 'tandem_workflow_status');
+
+    it('gets execution status', async () => {
+      mockApiCall.mockResolvedValueOnce({ status: 'running' });
+      await handler({ executionId: 'exec-1' });
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/workflow/status/exec-1');
+    });
+  });
+
+  describe('tandem_workflow_stop', () => {
+    const handler = getHandler(tools, 'tandem_workflow_stop');
+
+    it('stops an execution', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({ executionId: 'exec-1' });
+      expectTextContent(result, 'execution exec-1 stopped');
+    });
+  });
+
+  describe('tandem_workflow_running', () => {
+    const handler = getHandler(tools, 'tandem_workflow_running');
+
+    it('lists running executions', async () => {
+      mockApiCall.mockResolvedValueOnce([]);
+      const result = await handler({});
+      expectTextContent(result);
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/workflow/running');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add **180 more tests** across 22 additional test files, covering all remaining MCP tool modules
- Complements PR #96 (merged) which added the initial 92 tests for 8 core tool files
- Covers: auth, awareness, chat, clipboard, content, context, data, devices, events, extensions, forms, headless, history, media, passwords, pinboards, previews, scripts, sidebar, system, tasks, watches, workflows
- Only `window.ts` (multi-step research tool) excluded
- MCP tools directory line coverage: **25% → 89%**

## Test plan
- [x] `npx vitest run src/mcp/tests/` — all 272 tests pass
- [x] `npm run verify` — all 1751 tests pass, lint clean, consistency check green
- [ ] CI checks (verify.yml + codeql.yml) pass on PR