### PR TITLE
refactor: align 8 small managers with standard pattern (P3-01 batch 1)

### DIFF
--- a/src/clipboard/manager.ts
+++ b/src/clipboard/manager.ts
@@ -9,6 +9,8 @@ const log = createLogger('ClipboardManager');
 
 const MAX_IMAGE_BYTES = 10 * 1024 * 1024; // 10 MB
 
+// ─── Types ──────────────────────────────────────────────────────────
+
 // Save directory is fixed — no user-controlled paths to prevent path injection
 
 const DEFAULT_SAVE_DIR = path.join(os.homedir(), 'Pictures', 'Tandem', 'clipboard');
@@ -41,7 +43,14 @@ export interface ClipboardSaveResult {
   size: number;
 }
 
+// ─── Manager ────────────────────────────────────────────────────────
+
+/**
+ * ClipboardManager — reads, writes, and saves clipboard content (text and images).
+ */
 export class ClipboardManager {
+
+  // === 4. Public methods ===
 
   read(): ClipboardContent {
     const formats = clipboard.availableFormats();

--- a/src/context-menu/manager.ts
+++ b/src/context-menu/manager.ts
@@ -11,16 +11,23 @@ type ContextMenuListener = (event: Electron.Event, params: Electron.ContextMenuP
  * new webview as it's created via the 'web-contents-created' app event.
  */
 export class ContextMenuManager {
+
+  // === 1. Private state ===
+
   private builder: ContextMenuBuilder;
   private deps: ContextMenuDeps;
   /** Track registered webContents IDs → their context-menu listener for cleanup */
   private listeners: Map<number, { wc: WebContents; handler: ContextMenuListener }> = new Map();
   private lastPopupTime = 0;
 
+  // === 2. Constructor ===
+
   constructor(deps: ContextMenuDeps) {
     this.deps = deps;
     this.builder = new ContextMenuBuilder(deps);
   }
+
+  // === 4. Public methods ===
 
   /**
    * Register context-menu handling for a webview's webContents.
@@ -72,15 +79,6 @@ export class ContextMenuManager {
   }
 
   /**
-   * Find the tab ID that owns the given webContents by scanning TabManager.
-   */
-  private findTabIdForWebContents(wc: WebContents): string | undefined {
-    const tabs = this.deps.tabManager.listTabs();
-    const tab = tabs.find(t => t.webContentsId === wc.id);
-    return tab?.id;
-  }
-
-  /**
    * Show context menu for a tab in the tab bar (called via IPC from renderer).
    */
   showTabContextMenu(tabId: string): void {
@@ -89,6 +87,8 @@ export class ContextMenuManager {
       menu.popup({ window: this.deps.win });
     }
   }
+
+  // === 6. Cleanup ===
 
   /**
    * Cleanup on app quit — remove all context-menu listeners.
@@ -100,5 +100,16 @@ export class ContextMenuManager {
       }
     }
     this.listeners.clear();
+  }
+
+  // === 7. Private helpers ===
+
+  /**
+   * Find the tab ID that owns the given webContents by scanning TabManager.
+   */
+  private findTabIdForWebContents(wc: WebContents): string | undefined {
+    const tabs = this.deps.tabManager.listTabs();
+    const tab = tabs.find(t => t.webContentsId === wc.id);
+    return tab?.id;
   }
 }

--- a/src/downloads/manager.ts
+++ b/src/downloads/manager.ts
@@ -4,6 +4,8 @@ import path from 'path';
 import os from 'os';
 import { IpcChannels } from '../shared/ipc-channels';
 
+// ─── Types ──────────────────────────────────────────────────────────
+
 /**
  * DownloadItem — Tracked download entry.
  */
@@ -20,19 +22,28 @@ export interface DownloadEntry {
   mimeType: string;
 }
 
+// ─── Manager ────────────────────────────────────────────────────────
+
 /**
  * DownloadManager — Hooks into Electron's download system.
- * 
+ *
  * Tracks downloads, reports progress, sends notifications on completion.
  */
 export class DownloadManager {
+
+  // === 1. Private state ===
+
   private downloads: Map<string, DownloadEntry> = new Map();
   private downloadFolder: string;
   private idCounter = 0;
 
+  // === 2. Constructor ===
+
   constructor(downloadFolder?: string) {
     this.downloadFolder = downloadFolder || path.join(os.homedir(), 'Downloads');
   }
+
+  // === 4. Public methods ===
 
   /** Hook into an Electron session to intercept downloads */
   hookSession(ses: Electron.Session, win?: BrowserWindow): void {

--- a/src/history/manager.ts
+++ b/src/history/manager.ts
@@ -6,6 +6,8 @@ import type { SyncManager } from '../sync/manager';
 
 const log = createLogger('HistoryManager');
 
+// ─── Types ──────────────────────────────────────────────────────────
+
 /**
  * HistoryEntry — A single browsing history entry.
  */
@@ -22,18 +24,27 @@ interface HistoryStore {
   importedFrom?: string;
 }
 
+// ─── Storage path ───────────────────────────────────────────────────
+
 const MAX_ENTRIES = 10000;
+
+// ─── Manager ────────────────────────────────────────────────────────
 
 /**
  * HistoryManager — Auto-tracks page visits and provides search.
- * 
+ *
  * Storage: ~/.tandem/history.json (max 10000 entries, FIFO)
  */
 export class HistoryManager {
+
+  // === 1. Private state ===
+
   private storePath: string;
   private store: HistoryStore;
   private saveTimer: ReturnType<typeof setTimeout> | null = null;
   private syncManager: SyncManager | null = null;
+
+  // === 2. Constructor ===
 
   constructor() {
     const baseDir = tandemDir();
@@ -44,47 +55,14 @@ export class HistoryManager {
     this.store = this.load();
   }
 
+  // === 3. Dependency setters ===
+
   /** Wire up sync manager for cross-device history publishing. */
   setSyncManager(sm: SyncManager): void {
     this.syncManager = sm;
   }
 
-  private load(): HistoryStore {
-    try {
-      if (fs.existsSync(this.storePath)) {
-        return JSON.parse(fs.readFileSync(this.storePath, 'utf-8'));
-      }
-    } catch (e) { log.warn('History file corrupted, starting fresh:', e instanceof Error ? e.message : String(e)); }
-    return { entries: [] };
-  }
-
-  private save(): void {
-    if (this.saveTimer) clearTimeout(this.saveTimer);
-    this.saveTimer = setTimeout(() => {
-      this.saveTimer = null;
-      try {
-        fs.writeFileSync(this.storePath, JSON.stringify(this.store, null, 2));
-      } catch (e) {
-        log.warn('Failed to save:', e instanceof Error ? e.message : String(e));
-      }
-      if (this.syncManager?.isConfigured()) {
-        this.syncManager.publishHistory(this.store.entries);
-      }
-    }, 2000);
-  }
-
-  /** Flush pending history writes to disk on shutdown. */
-  destroy(): void {
-    if (this.saveTimer) {
-      clearTimeout(this.saveTimer);
-      this.saveTimer = null;
-      try {
-        fs.writeFileSync(this.storePath, JSON.stringify(this.store, null, 2));
-      } catch (e) {
-        log.warn('Failed to save on destroy:', e instanceof Error ? e.message : String(e));
-      }
-    }
-  }
+  // === 4. Public methods ===
 
   /** Record a page visit */
   recordVisit(url: string, title: string): void {
@@ -146,5 +124,46 @@ export class HistoryManager {
   /** Get total count */
   get count(): number {
     return this.store.entries.length;
+  }
+
+  // === 6. Cleanup ===
+
+  /** Flush pending history writes to disk on shutdown. */
+  destroy(): void {
+    if (this.saveTimer) {
+      clearTimeout(this.saveTimer);
+      this.saveTimer = null;
+      try {
+        fs.writeFileSync(this.storePath, JSON.stringify(this.store, null, 2));
+      } catch (e) {
+        log.warn('Failed to save on destroy:', e instanceof Error ? e.message : String(e));
+      }
+    }
+  }
+
+  // === 7. Private I/O ===
+
+  private load(): HistoryStore {
+    try {
+      if (fs.existsSync(this.storePath)) {
+        return JSON.parse(fs.readFileSync(this.storePath, 'utf-8'));
+      }
+    } catch (e) { log.warn('History file corrupted, starting fresh:', e instanceof Error ? e.message : String(e)); }
+    return { entries: [] };
+  }
+
+  private save(): void {
+    if (this.saveTimer) clearTimeout(this.saveTimer);
+    this.saveTimer = setTimeout(() => {
+      this.saveTimer = null;
+      try {
+        fs.writeFileSync(this.storePath, JSON.stringify(this.store, null, 2));
+      } catch (e) {
+        log.warn('Failed to save:', e instanceof Error ? e.message : String(e));
+      }
+      if (this.syncManager?.isConfigured()) {
+        this.syncManager.publishHistory(this.store.entries);
+      }
+    }, 2000);
   }
 }

--- a/src/pip/manager.ts
+++ b/src/pip/manager.ts
@@ -3,16 +3,23 @@ import path from 'path';
 
 /**
  * PiPManager — Picture-in-Picture always-on-top mini window.
- * 
+ *
  * A small frameless BrowserWindow that stays on top of everything.
  * Communicates with the main app via localhost API (not IPC).
  * Loads shell/pip.html as its UI.
  */
 export class PiPManager {
+
+  // === 1. Private state ===
+
   private pipWindow: BrowserWindow | null = null;
   private visible = false;
 
+  // === 2. Constructor ===
+
   constructor() {}
+
+  // === 4. Public methods ===
 
   /** Toggle the PiP window on/off */
   toggle(forceState?: boolean): boolean {
@@ -26,6 +33,26 @@ export class PiPManager {
 
     return this.visible;
   }
+
+  /** Get current PiP status */
+  getStatus(): { visible: boolean } {
+    return {
+      visible: this.visible && !!this.pipWindow && !this.pipWindow.isDestroyed(),
+    };
+  }
+
+  // === 6. Cleanup ===
+
+  /** Destroy the PiP window */
+  destroy(): void {
+    if (this.pipWindow && !this.pipWindow.isDestroyed()) {
+      this.pipWindow.close();
+    }
+    this.pipWindow = null;
+    this.visible = false;
+  }
+
+  // === 7. Private helpers ===
 
   /** Show the PiP window (create if needed) */
   private show(): void {
@@ -73,22 +100,6 @@ export class PiPManager {
     if (this.pipWindow && !this.pipWindow.isDestroyed()) {
       this.pipWindow.hide();
     }
-    this.visible = false;
-  }
-
-  /** Get current PiP status */
-  getStatus(): { visible: boolean } {
-    return {
-      visible: this.visible && !!this.pipWindow && !this.pipWindow.isDestroyed(),
-    };
-  }
-
-  /** Destroy the PiP window */
-  destroy(): void {
-    if (this.pipWindow && !this.pipWindow.isDestroyed()) {
-      this.pipWindow.close();
-    }
-    this.pipWindow = null;
     this.visible = false;
   }
 }

--- a/src/scripts/injector.ts
+++ b/src/scripts/injector.ts
@@ -3,6 +3,8 @@ import { createLogger } from '../utils/logger';
 
 const log = createLogger('ScriptInjector');
 
+// ─── Types ──────────────────────────────────────────────────────────
+
 export interface RegisteredScript {
   name: string;
   code: string;
@@ -17,11 +19,21 @@ export interface RegisteredStyle {
   addedAt: number;
 }
 
+// ─── Manager ────────────────────────────────────────────────────────
+
+/**
+ * ScriptInjector — manages user scripts and styles injected into webview tabs.
+ */
 export class ScriptInjector {
+
+  // === 1. Private state ===
+
   private scripts = new Map<string, RegisteredScript>();
   private styles = new Map<string, RegisteredStyle>();
 
-  // ─── Scripts ──────────────────────────────────
+  // === 4. Public methods ===
+
+  // --- Scripts ---
 
   addScript(name: string, code: string): RegisteredScript {
     const entry: RegisteredScript = {
@@ -56,7 +68,7 @@ export class ScriptInjector {
     return Array.from(this.scripts.values());
   }
 
-  // ─── Styles ───────────────────────────────────
+  // --- Styles ---
 
   addStyle(name: string, css: string): RegisteredStyle {
     const entry: RegisteredStyle = {
@@ -91,7 +103,7 @@ export class ScriptInjector {
     return Array.from(this.styles.values());
   }
 
-  // ─── Injection ────────────────────────────────
+  // --- Injection ---
 
   /**
    * Called after every did-finish-load.

--- a/src/sessions/manager.ts
+++ b/src/sessions/manager.ts
@@ -2,9 +2,17 @@ import { session } from 'electron';
 import type { Session } from './types';
 import { DEFAULT_PARTITION } from '../utils/constants';
 
+/**
+ * SessionManager — manages isolated Electron sessions with named partitions.
+ */
 export class SessionManager {
+
+  // === 1. Private state ===
+
   private sessions: Map<string, Session> = new Map();
   private activeSession = 'default';
+
+  // === 2. Constructor ===
 
   constructor() {
     // Register default session (the user's persist:tandem)
@@ -15,6 +23,8 @@ export class SessionManager {
       isDefault: true,
     });
   }
+
+  // === 4. Public methods ===
 
   /** Create a new isolated session */
   create(name: string): Session {

--- a/src/voice/recognition.ts
+++ b/src/voice/recognition.ts
@@ -4,26 +4,29 @@ import { IpcChannels } from '../shared/ipc-channels';
 
 /**
  * VoiceManager — Manages voice input via Web Speech API in the SHELL.
- * 
+ *
  * CRITICAL: Voice recognition runs in the Electron shell renderer,
  * NOT in any webview. Websites cannot detect it.
- * 
+ *
  * Flow: Cmd+M → shell starts SpeechRecognition → transcripts sent via IPC
  * → displayed in Wingman panel chat → sent as message on silence/Enter.
  */
 export class VoiceManager {
+
+  // === 1. Private state ===
+
   private win: BrowserWindow;
   private panelManager: PanelManager;
   private listening = false;
+
+  // === 2. Constructor ===
 
   constructor(win: BrowserWindow, panelManager: PanelManager) {
     this.win = win;
     this.panelManager = panelManager;
   }
 
-  private canSendToRenderer(): boolean {
-    return !this.win.isDestroyed() && !this.win.webContents.isDestroyed();
-  }
+  // === 4. Public methods ===
 
   /** Toggle voice on/off — tells renderer to start/stop SpeechRecognition */
   toggleVoice(): boolean {
@@ -84,5 +87,11 @@ export class VoiceManager {
   /** Is currently listening */
   isListening(): boolean {
     return this.listening;
+  }
+
+  // === 7. Private helpers ===
+
+  private canSendToRenderer(): boolean {
+    return !this.win.isDestroyed() && !this.win.webContents.isDestroyed();
   }
 }


### PR DESCRIPTION
## Summary
- Add 7-section comment headers (`// === 1. Private state ===`, etc.) and reorder methods to match `docs/templates/manager-pattern.md`
- Add class-level JSDoc where missing (SessionManager, ScriptInjector, ClipboardManager)
- Move private helpers (load/save, show/hide, etc.) to section 7 after public methods and cleanup
- **No logic, method signatures, or public API changes**

## Managers touched
| Manager | File | Lines |
|---------|------|-------|
| SessionManager | `src/sessions/manager.ts` | 91 |
| VoiceManager | `src/voice/recognition.ts` | 88 |
| PiPManager | `src/pip/manager.ts` | 94 |
| ContextMenuManager | `src/context-menu/manager.ts` | 104 |
| DownloadManager | `src/downloads/manager.ts` | 114 |
| ScriptInjector | `src/scripts/injector.ts` | 122 |
| ClipboardManager | `src/clipboard/manager.ts` | 144 |
| HistoryManager | `src/history/manager.ts` | 150 |

## Test plan
- [x] `npm run verify` passes (compile + lint + test + consistency)
- [x] All 1871 tests pass, 87 test files
- [x] No logic changes — diff is purely structural (comments + method reordering)