### PR TITLE
refactor: align 8 medium managers with standard pattern (P3-01 batch 2)

### DIFF
--- a/src/activity/tracker.ts
+++ b/src/activity/tracker.ts
@@ -22,12 +22,16 @@ function isPanelActivityType(value: string): value is ActivityEvent['type'] {
   return PANEL_ACTIVITY_TYPES.has(value as ActivityEvent['type']);
 }
 
+// ─── Types ──────────────────────────────────────────────────────────
+
 export interface ActivityEntry {
   id: number;
   type: string;
   timestamp: number;
   data: Record<string, unknown>;
 }
+
+// ─── Manager ────────────────────────────────────────────────────────
 
 /**
  * ActivityTracker — Tracks navigation, clicks, scrolls via Electron webview events.
@@ -38,6 +42,9 @@ export interface ActivityEntry {
  * Auto-snapshots on navigation events.
  */
 export class ActivityTracker {
+
+  // === 1. Private state ===
+
   private win: BrowserWindow;
   private panelManager: PanelManager;
   private drawManager: DrawOverlayManager;
@@ -47,12 +54,16 @@ export class ActivityTracker {
   private maxEntries = 1000;
   private autoSnapshotEnabled = false; // Disabled until stable
 
+  // === 2. Constructor ===
+
   constructor(win: BrowserWindow, panelManager: PanelManager, drawManager: DrawOverlayManager, wingmanStream?: WingmanStream) {
     this.win = win;
     this.panelManager = panelManager;
     this.drawManager = drawManager;
     this.wingmanStream = wingmanStream;
   }
+
+  // === 4. Public methods ===
 
   /** Handle webview event forwarded from renderer */
   onWebviewEvent(data: { type: string; url?: string; tabId?: string; [key: string]: unknown }): void {
@@ -90,6 +101,22 @@ export class ActivityTracker {
       }
     }
   }
+
+  /** Get activity log */
+  getLog(limit: number = 100, since?: number): ActivityEntry[] {
+    let entries = this.log;
+    if (since) {
+      entries = entries.filter(e => e.timestamp > since);
+    }
+    return entries.slice(-limit);
+  }
+
+  /** Enable/disable auto-snapshot */
+  setAutoSnapshot(enabled: boolean): void {
+    this.autoSnapshotEnabled = enabled;
+  }
+
+  // === 7. Private helpers ===
 
   /** Stream activity events to Wingman via WingmanStream */
   private streamToWingman(data: Record<string, unknown>): void {
@@ -177,19 +204,5 @@ export class ActivityTracker {
         }, 2000);
         break;
     }
-  }
-
-  /** Get activity log */
-  getLog(limit: number = 100, since?: number): ActivityEntry[] {
-    let entries = this.log;
-    if (since) {
-      entries = entries.filter(e => e.timestamp > since);
-    }
-    return entries.slice(-limit);
-  }
-
-  /** Enable/disable auto-snapshot */
-  setAutoSnapshot(enabled: boolean): void {
-    this.autoSnapshotEnabled = enabled;
   }
 }

--- a/src/behavior/observer.ts
+++ b/src/behavior/observer.ts
@@ -6,12 +6,14 @@ import { createLogger } from '../utils/logger';
 
 const log = createLogger('BehaviorObserver');
 
+// ─── Types ──────────────────────────────────────────────────────────
+
 /**
  * BehaviorObserver — Passive observation layer for behavioral learning.
- * 
+ *
  * CRITICAL: All tracking via Electron main process events (NOT in webview).
  * Appends events to ~/.tandem/behavior/raw/{date}.jsonl (append-only).
- * 
+ *
  * Tracks: mouse clicks, scroll events, keyboard timing, navigation.
  * Always runs in background, passively, minimal performance impact.
  */
@@ -22,7 +24,12 @@ interface BehaviorEvent {
   data: Record<string, unknown>;
 }
 
+// ─── Manager ────────────────────────────────────────────────────────
+
 export class BehaviorObserver {
+
+  // === 1. Private state ===
+
   private win: BrowserWindow;
   private rawDir: string;
   private currentStream: fs.WriteStream | null = null;
@@ -33,6 +40,8 @@ export class BehaviorObserver {
   private clickTimestamps: number[] = [];
   private readonly MAX_SAMPLES = 1000;
 
+  // === 2. Constructor ===
+
   constructor(win: BrowserWindow) {
     this.win = win;
     this.rawDir = tandemDir('behavior', 'raw');
@@ -42,67 +51,7 @@ export class BehaviorObserver {
     this.setupTracking();
   }
 
-  /** Get or create write stream for today's JSONL file */
-  private getStream(): fs.WriteStream {
-    const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
-    if (today !== this.currentDate || !this.currentStream) {
-      if (this.currentStream) {
-        this.currentStream.end();
-      }
-      this.currentDate = today;
-      const filePath = path.join(this.rawDir, `${today}.jsonl`);
-      this.currentStream = fs.createWriteStream(filePath, { flags: 'a' });
-    }
-    return this.currentStream;
-  }
-
-  /** Append a behavior event */
-  private record(event: BehaviorEvent): void {
-    try {
-      const stream = this.getStream();
-      stream.write(JSON.stringify(event) + '\n');
-      this.eventCount++;
-    } catch (e) {
-      log.warn('Behavior event write failed:', e instanceof Error ? e.message : String(e));
-    }
-  }
-
-  /** Set up main process event tracking */
-  private setupTracking(): void {
-    const wc = this.win.webContents;
-
-    // Track mouse clicks via input events on the shell window
-    wc.on('before-input-event', (_event, input) => {
-      const now = Date.now();
-
-      if (input.type === 'mouseDown' || input.type === 'mouseUp') {
-        // We can't easily get mouse position from before-input-event for mouse,
-        // so we track keyboard timing here instead
-      }
-
-      if (input.type === 'keyDown' && input.key && input.key.length === 1) {
-        // Track keyboard timing (interval between keystrokes)
-        if (this.lastKeypressTs > 0) {
-          const interval = now - this.lastKeypressTs;
-          if (interval < 5000) { // Only track reasonable intervals
-            // Efficient circular buffer management
-            if (this.keypressIntervals.length >= this.MAX_SAMPLES) {
-              this.keypressIntervals.shift(); // Remove oldest
-            }
-            this.keypressIntervals.push(interval);
-          }
-        }
-        this.lastKeypressTs = now;
-        this.record({
-          type: 'keypress',
-          ts: now,
-          data: { interval: this.lastKeypressTs > 0 ? now - this.lastKeypressTs : 0 },
-        });
-      }
-    });
-
-    log.info('🧬 Behavior observer active (passive mode)');
-  }
+  // === 4. Public methods ===
 
   /** Record a click event (called from activity tracker) */
   recordClick(x: number, y: number): void {
@@ -174,11 +123,77 @@ export class BehaviorObserver {
     };
   }
 
+  // === 6. Cleanup ===
+
   /** Cleanup */
   destroy(): void {
     if (this.currentStream) {
       this.currentStream.end();
       this.currentStream = null;
     }
+  }
+
+  // === 7. Private helpers ===
+
+  /** Get or create write stream for today's JSONL file */
+  private getStream(): fs.WriteStream {
+    const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+    if (today !== this.currentDate || !this.currentStream) {
+      if (this.currentStream) {
+        this.currentStream.end();
+      }
+      this.currentDate = today;
+      const filePath = path.join(this.rawDir, `${today}.jsonl`);
+      this.currentStream = fs.createWriteStream(filePath, { flags: 'a' });
+    }
+    return this.currentStream;
+  }
+
+  /** Append a behavior event */
+  private record(event: BehaviorEvent): void {
+    try {
+      const stream = this.getStream();
+      stream.write(JSON.stringify(event) + '\n');
+      this.eventCount++;
+    } catch (e) {
+      log.warn('Behavior event write failed:', e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  /** Set up main process event tracking */
+  private setupTracking(): void {
+    const wc = this.win.webContents;
+
+    // Track mouse clicks via input events on the shell window
+    wc.on('before-input-event', (_event, input) => {
+      const now = Date.now();
+
+      if (input.type === 'mouseDown' || input.type === 'mouseUp') {
+        // We can't easily get mouse position from before-input-event for mouse,
+        // so we track keyboard timing here instead
+      }
+
+      if (input.type === 'keyDown' && input.key && input.key.length === 1) {
+        // Track keyboard timing (interval between keystrokes)
+        if (this.lastKeypressTs > 0) {
+          const interval = now - this.lastKeypressTs;
+          if (interval < 5000) { // Only track reasonable intervals
+            // Efficient circular buffer management
+            if (this.keypressIntervals.length >= this.MAX_SAMPLES) {
+              this.keypressIntervals.shift(); // Remove oldest
+            }
+            this.keypressIntervals.push(interval);
+          }
+        }
+        this.lastKeypressTs = now;
+        this.record({
+          type: 'keypress',
+          ts: now,
+          data: { interval: this.lastKeypressTs > 0 ? now - this.lastKeypressTs : 0 },
+        });
+      }
+    });
+
+    log.info('🧬 Behavior observer active (passive mode)');
   }
 }

--- a/src/device/emulator.ts
+++ b/src/device/emulator.ts
@@ -3,6 +3,8 @@ import { createLogger } from '../utils/logger';
 
 const log = createLogger('DeviceEmulator');
 
+// ─── Types ──────────────────────────────────────────────────────────
+
 export interface DeviceProfile {
   name: string;
   width: number;
@@ -13,7 +15,20 @@ export interface DeviceProfile {
   userAgent: string;
 }
 
-// Built-in device profiles
+export interface EmulationState {
+  active: boolean;
+  profile?: DeviceProfile;
+  custom?: {
+    width: number;
+    height: number;
+    deviceScaleFactor?: number;
+    mobile?: boolean;
+    userAgent?: string;
+  };
+}
+
+// ─── Built-in profiles ──────────────────────────────────────────────
+
 export const DEVICE_PROFILES: Record<string, DeviceProfile> = {
   'iPhone 15': {
     name: 'iPhone 15',
@@ -71,22 +86,18 @@ export const DEVICE_PROFILES: Record<string, DeviceProfile> = {
   },
 };
 
-export interface EmulationState {
-  active: boolean;
-  profile?: DeviceProfile;
-  custom?: {
-    width: number;
-    height: number;
-    deviceScaleFactor?: number;
-    mobile?: boolean;
-    userAgent?: string;
-  };
-}
+// ─── Manager ────────────────────────────────────────────────────────
 
+/**
+ * DeviceEmulator — emulates mobile/tablet devices via Electron's device emulation API.
+ */
 export class DeviceEmulator {
+
+  // === 1. Private state ===
+
   private state: EmulationState = { active: false };
 
-  // ─── Enable emulation ─────────────────────────
+  // === 4. Public methods ===
 
   async emulateDevice(wc: WebContents, deviceName: string): Promise<DeviceProfile> {
     const profile = DEVICE_PROFILES[deviceName];
@@ -126,8 +137,6 @@ export class DeviceEmulator {
     this.state = { active: false };
   }
 
-  // ─── Persistence: re-apply after navigation ──
-
   /**
    * Called from main.ts after did-finish-load.
    * Re-applies the current emulation if active.
@@ -142,8 +151,6 @@ export class DeviceEmulator {
     }
   }
 
-  // ─── Status ───────────────────────────────────
-
   getStatus(): EmulationState {
     return { ...this.state };
   }
@@ -152,7 +159,7 @@ export class DeviceEmulator {
     return Object.values(DEVICE_PROFILES);
   }
 
-  // ─── Internal ────────────────────────────────
+  // === 7. Private helpers ===
 
   private async applyProfile(wc: WebContents, profile: DeviceProfile): Promise<void> {
     // Electron native device emulation API

--- a/src/events/stream.ts
+++ b/src/events/stream.ts
@@ -1,8 +1,6 @@
 import type { Request, Response } from 'express';
 
-// ═══════════════════════════════════════════════
-// Event Types
-// ═══════════════════════════════════════════════
+// ─── Types ──────────────────────────────────────────────────────────
 
 export type BrowserEventType =
   | 'navigation'     | 'page-loaded'   | 'tab-opened'
@@ -20,51 +18,28 @@ export interface BrowserEvent {
   data?: Record<string, unknown>;
 }
 
-// ═══════════════════════════════════════════════
-// EventStreamManager
-// ═══════════════════════════════════════════════
+// ─── Constants ──────────────────────────────────────────────────────
 
 const MAX_EVENTS = 100;
 const SCROLL_DEBOUNCE_MS = 5000;
 
+// ─── Manager ────────────────────────────────────────────────────────
+
+/**
+ * EventStreamManager — real-time browser event bus with SSE streaming.
+ */
 export class EventStreamManager {
+
+  // === 1. Private state ===
+
   private listeners = new Set<(event: BrowserEvent) => void>();
   private recentEvents: BrowserEvent[] = [];
   private eventCounter = 0;
   private lastScrollTime = 0;
 
-  // ─── Emit ────────────────────────────────────
+  // === 4. Public methods ===
 
-  private emit(event: BrowserEvent): void {
-    // Ring buffer: push and trim
-    this.recentEvents.push(event);
-    if (this.recentEvents.length > MAX_EVENTS) {
-      this.recentEvents.shift();
-    }
-
-    // Notify all subscribers
-    for (const listener of this.listeners) {
-      try {
-        listener(event);
-      } catch {
-        // Don't let a broken listener crash the stream
-      }
-    }
-  }
-
-  private createEvent(type: BrowserEventType, opts: { tabId?: string; url?: string; title?: string; data?: Record<string, unknown> } = {}): BrowserEvent {
-    return {
-      id: ++this.eventCounter,
-      type,
-      timestamp: Date.now(),
-      tabId: opts.tabId,
-      url: opts.url,
-      title: opts.title,
-      data: opts.data,
-    };
-  }
-
-  // ─── IPC Handlers ────────────────────────────
+  // --- IPC Handlers ---
 
   /** Handle webview events from IPC (activity-webview-event) */
   handleWebviewEvent(data: { type: string; url?: string; tabId?: string; title?: string }): void {
@@ -157,7 +132,7 @@ export class EventStreamManager {
     }));
   }
 
-  // ─── Subscribe / Query ───────────────────────
+  // --- Subscribe / Query ---
 
   /** Subscribe to events. Returns an unsubscribe function. */
   subscribe(cb: (event: BrowserEvent) => void): () => void {
@@ -173,7 +148,7 @@ export class EventStreamManager {
     return this.recentEvents.slice(-limit);
   }
 
-  // ─── SSE Handler ─────────────────────────────
+  // --- SSE Handler ---
 
   /** Express middleware for SSE endpoint: GET /events/stream */
   sseHandler = (req: Request, res: Response): void => {
@@ -220,4 +195,35 @@ export class EventStreamManager {
       unsubscribe();
     });
   };
+
+  // === 7. Private helpers ===
+
+  private emit(event: BrowserEvent): void {
+    // Ring buffer: push and trim
+    this.recentEvents.push(event);
+    if (this.recentEvents.length > MAX_EVENTS) {
+      this.recentEvents.shift();
+    }
+
+    // Notify all subscribers
+    for (const listener of this.listeners) {
+      try {
+        listener(event);
+      } catch {
+        // Don't let a broken listener crash the stream
+      }
+    }
+  }
+
+  private createEvent(type: BrowserEventType, opts: { tabId?: string; url?: string; title?: string; data?: Record<string, unknown> } = {}): BrowserEvent {
+    return {
+      id: ++this.eventCounter,
+      type,
+      timestamp: Date.now(),
+      tabId: opts.tabId,
+      url: opts.url,
+      title: opts.title,
+      data: opts.data,
+    };
+  }
 }

--- a/src/extensions/loader.ts
+++ b/src/extensions/loader.ts
@@ -7,6 +7,8 @@ import { assertChromeExtensionId, assertPathWithinRoot, resolvePathWithinRoot } 
 
 const log = createLogger('ExtensionLoader');
 
+// ─── Types ──────────────────────────────────────────────────────────
+
 interface LoadedExtension {
   id: string;
   name: string;
@@ -21,22 +23,31 @@ interface TandemExtensionMeta {
   [key: string]: unknown;
 }
 
+// ─── Manager ────────────────────────────────────────────────────────
+
 /**
  * ExtensionLoader — Loads unpacked Chrome extensions into the browser session.
- * 
+ *
  * Extensions are stored in ~/.tandem/extensions/
  * Each subfolder is an unpacked extension with a manifest.json.
- * 
+ *
  * Uses Electron's session.extensions.loadExtension() API.
  * Only supports manually-loaded local extensions — no extension store.
  */
 export class ExtensionLoader {
+
+  // === 1. Private state ===
+
   private extensionsDir: string;
   private loaded: LoadedExtension[] = [];
+
+  // === 2. Constructor ===
 
   constructor() {
     this.extensionsDir = ensureDir(tandemDir('extensions'));
   }
+
+  // === 4. Public methods ===
 
   /**
    * Load all extensions from ~/.tandem/extensions/ into the given session.
@@ -166,6 +177,8 @@ export class ExtensionLoader {
 
     return results;
   }
+
+  // === 7. Private helpers ===
 
   private getMetaPath(extPath: string): string {
     return resolvePathWithinRoot(extPath, '.tandem-meta.json');

--- a/src/passwords/manager.ts
+++ b/src/passwords/manager.ts
@@ -7,6 +7,8 @@ import { createLogger } from '../utils/logger';
 
 const log = createLogger('PasswordManager');
 
+// ─── Types ──────────────────────────────────────────────────────────
+
 export interface VaultItem {
     id?: number;
     domain: string;
@@ -16,10 +18,22 @@ export interface VaultItem {
     updated_at?: string;
 }
 
+// ─── Manager ────────────────────────────────────────────────────────
+
+/**
+ * PasswordManager — encrypted credential vault backed by SQLite.
+ *
+ * Persistence: ~/.tandem/security/vault.db
+ */
 export class PasswordManager {
+
+    // === 1. Private state ===
+
     private db: Database.Database;
     private vaultKey: Buffer | null = null;
     private isUnlocked: boolean = false;
+
+    // === 2. Constructor ===
 
     constructor() {
         const dir = tandemDir('security');
@@ -30,24 +44,7 @@ export class PasswordManager {
         this.init();
     }
 
-    private init() {
-        this.db.exec(`
-      CREATE TABLE IF NOT EXISTS vault (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        domain TEXT NOT NULL,
-        username TEXT NOT NULL,
-        encryptedBlob BLOB NOT NULL,
-        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-        UNIQUE(domain, username)
-      );
-
-      CREATE TABLE IF NOT EXISTS vault_meta (
-        key TEXT PRIMARY KEY,
-        value BLOB NOT NULL
-      );
-    `);
-    }
+    // === 4. Public methods ===
 
     /**
      * Initializes or verifies the master password.
@@ -105,9 +102,9 @@ export class PasswordManager {
         const encrypted = PasswordCrypto.encrypt(JSON.stringify(payload), this.vaultKey, salt);
 
         const stmt = this.db.prepare(`
-      INSERT INTO vault (domain, username, encryptedBlob) 
+      INSERT INTO vault (domain, username, encryptedBlob)
       VALUES (?, ?, ?)
-      ON CONFLICT(domain, username) DO UPDATE SET 
+      ON CONFLICT(domain, username) DO UPDATE SET
         encryptedBlob = excluded.encryptedBlob,
         updated_at = CURRENT_TIMESTAMP
     `);
@@ -160,6 +157,27 @@ export class PasswordManager {
     public isNewVault(): boolean {
         const meta = this.db.prepare('SELECT key FROM vault_meta WHERE key = ?').get('master_verification');
         return !meta;
+    }
+
+    // === 7. Private helpers ===
+
+    private init() {
+        this.db.exec(`
+      CREATE TABLE IF NOT EXISTS vault (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        domain TEXT NOT NULL,
+        username TEXT NOT NULL,
+        encryptedBlob BLOB NOT NULL,
+        created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+        UNIQUE(domain, username)
+      );
+
+      CREATE TABLE IF NOT EXISTS vault_meta (
+        key TEXT PRIMARY KEY,
+        value BLOB NOT NULL
+      );
+    `);
     }
 }
 let _instance: PasswordManager | null = null;

--- a/src/sessions/state.ts
+++ b/src/sessions/state.ts
@@ -4,8 +4,18 @@ import * as crypto from 'crypto';
 import { tandemDir } from '../utils/paths';
 import { assertSinglePathSegment, resolvePathWithinRoot } from '../utils/security';
 
+/**
+ * StateManager — saves and restores Electron session cookies to/from disk.
+ *
+ * Persistence: ~/.tandem/sessions/{name}.json (or .enc if encrypted)
+ */
 export class StateManager {
+
+  // === 1. Private state ===
+
   private stateDir: string;
+
+  // === 2. Constructor ===
 
   constructor() {
     this.stateDir = tandemDir('sessions');
@@ -14,10 +24,7 @@ export class StateManager {
     }
   }
 
-  private getStateFilePath(name: string, extension: 'enc' | 'json'): string {
-    const safeName = assertSinglePathSegment(name, 'state name');
-    return resolvePathWithinRoot(this.stateDir, `${safeName}.${extension}`);
-  }
+  // === 4. Public methods ===
 
   /** Save session cookies to disk */
   async save(name: string, partition: string): Promise<string> {
@@ -102,6 +109,13 @@ export class StateManager {
     return fs.readdirSync(this.stateDir)
       .filter(f => f.endsWith('.json') || f.endsWith('.enc'))
       .map(f => f.replace(/\.(json|enc)$/, ''));
+  }
+
+  // === 7. Private I/O ===
+
+  private getStateFilePath(name: string, extension: 'enc' | 'json'): string {
+    const safeName = assertSinglePathSegment(name, 'state name');
+    return resolvePathWithinRoot(this.stateDir, `${safeName}.${extension}`);
   }
 
   private encrypt(data: string, key: string): string {

--- a/src/sync/manager.ts
+++ b/src/sync/manager.ts
@@ -6,6 +6,8 @@ import type { HistoryEntry } from '../history/manager';
 
 const log = createLogger('SyncManager');
 
+// ─── Types ──────────────────────────────────────────────────────────
+
 export interface SyncConfig {
   enabled: boolean;
   syncRoot: string;
@@ -32,10 +34,22 @@ interface TabsFile {
   tabs: RemoteTab[];
 }
 
+// ─── Constants ──────────────────────────────────────────────────────
+
 const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000;
 
+// ─── Manager ────────────────────────────────────────────────────────
+
+/**
+ * SyncManager — cross-device sync via a shared filesystem folder.
+ */
 export class SyncManager {
+
+  // === 1. Private state ===
+
   private config: SyncConfig | null = null;
+
+  // === 4. Public methods ===
 
   /** Sanitize a hostname for use as directory name */
   static sanitizeDeviceName(name: string): string {
@@ -155,6 +169,15 @@ export class SyncManager {
     return this.config;
   }
 
+  // === 6. Cleanup ===
+
+  /** Clean up resources (currently a no-op). */
+  destroy(): void {
+    // nothing to clean up
+  }
+
+  // === 7. Private I/O ===
+
   /** Atomic write: write to temp file, then rename */
   private atomicWrite(filePath: string, data: unknown): void {
     const dir = path.dirname(filePath);
@@ -170,10 +193,5 @@ export class SyncManager {
       // Clean up tmp file if rename failed
       try { fs.unlinkSync(tmpPath); } catch { /* ignore */ }
     }
-  }
-
-  /** Clean up resources (currently a no-op). */
-  destroy(): void {
-    // nothing to clean up
   }
 }


### PR DESCRIPTION
## Summary
- Add 7-section comment headers (`// === 1. Private state ===`, etc.) and reorder methods to match `docs/templates/manager-pattern.md`
- Add class-level JSDoc where missing (StateManager, PasswordManager, SyncManager, DeviceEmulator, EventStreamManager)
- Move private helpers (encrypt/decrypt, atomicWrite, emit, etc.) to section 7 after public methods
- Reorder public methods before cleanup/destroy sections
- **No logic, method signatures, or public API changes**

## Managers touched
| Manager | File | Lines |
|---------|------|-------|
| StateManager | `src/sessions/state.ts` | 130 |
| PasswordManager | `src/passwords/manager.ts` | 173 |
| SyncManager | `src/sync/manager.ts` | 179 |
| DeviceEmulator | `src/device/emulator.ts` | 181 |
| BehaviorObserver | `src/behavior/observer.ts` | 184 |
| ExtensionLoader | `src/extensions/loader.ts` | 193 |
| ActivityTracker | `src/activity/tracker.ts` | 195 |
| EventStreamManager | `src/events/stream.ts` | 223 |

## Test plan
- [x] `npm run verify` passes (compile + lint + test + consistency)
- [x] All 1871 tests pass, 87 test files
- [x] No logic changes — diff is purely structural (comments + method reordering)