### PR TITLE
refactor: align 9 medium-large managers with standard pattern (P3-01 batch 3)

### DIFF
--- a/src/bookmarks/manager.ts
+++ b/src/bookmarks/manager.ts
@@ -5,6 +5,8 @@ import { createLogger } from '../utils/logger';
 
 const log = createLogger('BookmarkManager');
 
+// ─── Types ──────────────────────────────────────────────────────────
+
 /**
  * Bookmark — A single bookmark or folder.
  */
@@ -24,14 +26,21 @@ interface BookmarkStore {
   lastModified: string;
 }
 
+// ─── Manager ────────────────────────────────────────────────────────
+
 /**
  * BookmarkManager — CRUD operations for bookmarks with folder support.
- * 
+ *
  * Storage: ~/.tandem/bookmarks.json
  */
 export class BookmarkManager {
+
+  // === 1. Private state ===
+
   private storePath: string;
   private store: BookmarkStore;
+
+  // === 2. Constructor ===
 
   constructor() {
     const dir = ensureDir(tandemDir());
@@ -39,23 +48,7 @@ export class BookmarkManager {
     this.store = this.load();
   }
 
-  private load(): BookmarkStore {
-    try {
-      if (fs.existsSync(this.storePath)) {
-        return JSON.parse(fs.readFileSync(this.storePath, 'utf-8'));
-      }
-    } catch (e) { log.warn('Bookmarks file corrupted, starting fresh:', e instanceof Error ? e.message : String(e)); }
-    return { bookmarks: [], lastModified: new Date().toISOString() };
-  }
-
-  private save(): void {
-    this.store.lastModified = new Date().toISOString();
-    fs.writeFileSync(this.storePath, JSON.stringify(this.store, null, 2));
-  }
-
-  private generateId(): string {
-    return Date.now().toString(36) + Math.random().toString(36).substring(2, 8);
-  }
+  // === 4. Public methods ===
 
   /** Reload bookmarks from disk (e.g. after Chrome import overwrites the file) */
   reload(): void {
@@ -141,18 +134,6 @@ export class BookmarkManager {
     return removed;
   }
 
-  private removeFromList(id: string, list: Bookmark[]): boolean {
-    const idx = list.findIndex(b => b.id === id);
-    if (idx !== -1) {
-      list.splice(idx, 1);
-      return true;
-    }
-    for (const item of list) {
-      if (item.children && this.removeFromList(id, item.children)) return true;
-    }
-    return false;
-  }
-
   /** Update a bookmark */
   update(id: string, data: { name?: string; url?: string }): Bookmark | null {
     const bookmark = this.findById(id, this.store.bookmarks);
@@ -217,6 +198,38 @@ export class BookmarkManager {
     const barFolder = this.store.bookmarks.find(b => b.name === 'Bookmarks Bar' || b.name === 'Bladwijzerbalk');
     if (barFolder && barFolder.children) return barFolder.children;
     return this.store.bookmarks.filter(b => b.type === 'url').slice(0, 20);
+  }
+
+  // === 7. Private I/O ===
+
+  private load(): BookmarkStore {
+    try {
+      if (fs.existsSync(this.storePath)) {
+        return JSON.parse(fs.readFileSync(this.storePath, 'utf-8'));
+      }
+    } catch (e) { log.warn('Bookmarks file corrupted, starting fresh:', e instanceof Error ? e.message : String(e)); }
+    return { bookmarks: [], lastModified: new Date().toISOString() };
+  }
+
+  private save(): void {
+    this.store.lastModified = new Date().toISOString();
+    fs.writeFileSync(this.storePath, JSON.stringify(this.store, null, 2));
+  }
+
+  private generateId(): string {
+    return Date.now().toString(36) + Math.random().toString(36).substring(2, 8);
+  }
+
+  private removeFromList(id: string, list: Bookmark[]): boolean {
+    const idx = list.findIndex(b => b.id === id);
+    if (idx !== -1) {
+      list.splice(idx, 1);
+      return true;
+    }
+    for (const item of list) {
+      if (item.children && this.removeFromList(id, item.children)) return true;
+    }
+    return false;
   }
 
   /** Find a bookmark by ID in the tree */

--- a/src/bridge/context-bridge.ts
+++ b/src/bridge/context-bridge.ts
@@ -3,6 +3,8 @@ import path from 'path';
 import type { EventStreamManager, BrowserEvent, BrowserEventType } from '../events/stream';
 import { tandemDir } from '../utils/paths';
 
+// ─── Types ──────────────────────────────────────────────────────────
+
 export interface ContextSnapshot {
   url: string;
   domain: string;
@@ -23,13 +25,18 @@ export interface ContextSummary {
   text: string; // Pre-formatted text version
 }
 
+// ─── Manager ────────────────────────────────────────────────────────
+
 /**
  * ContextBridge — Makes everything Tandem reads available to external tools.
- * 
+ *
  * Stores context snapshots per URL in ~/.tandem/context/
  * Searchable, queryable via API. This is the bridge between Tandem and OpenClaw.
  */
 export class ContextBridge {
+
+  // === 1. Private state ===
+
   private contextDir: string;
   private indexPath: string;
   private index: Map<string, ContextSnapshot> = new Map();
@@ -42,6 +49,8 @@ export class ContextBridge {
   private unsubscribe: (() => void) | null = null;
   private contextChangeListeners = new Set<() => void>();
 
+  // === 2. Constructor ===
+
   constructor() {
     this.contextDir = tandemDir('context');
     this.indexPath = path.join(this.contextDir, '_index.json');
@@ -53,38 +62,18 @@ export class ContextBridge {
     this.loadIndex();
   }
 
-  /** Load the index from disk */
-  private loadIndex(): void {
-    try {
-      if (fs.existsSync(this.indexPath)) {
-        const raw: ContextSnapshot[] = JSON.parse(fs.readFileSync(this.indexPath, 'utf-8'));
-        for (const snap of raw) {
-          this.index.set(snap.url, snap);
-        }
-      }
-    } catch {
-      // Start fresh
-    }
+  // === 3. Dependency setters ===
+
+  /** Connect to EventStreamManager and start tracking live context */
+  connectEventStream(eventStream: EventStreamManager): void {
+    this.eventStream = eventStream;
+
+    this.unsubscribe = eventStream.subscribe((event) => {
+      this.handleEvent(event);
+    });
   }
 
-  /** Save the index to disk */
-  private saveIndex(): void {
-    try {
-      const entries = Array.from(this.index.values());
-      fs.writeFileSync(this.indexPath, JSON.stringify(entries, null, 2));
-    } catch {
-      // Silent fail
-    }
-  }
-
-  /** Extract domain from URL */
-  private getDomain(url: string): string {
-    try {
-      return new URL(url).hostname;
-    } catch {
-      return 'unknown';
-    }
-  }
+  // === 4. Public methods ===
 
   /**
    * Record a context snapshot for a page visit.
@@ -178,19 +167,6 @@ export class ContextBridge {
     return snap;
   }
 
-  // ═══════════════════════════════════════════════
-  // Live Context (Phase 2.2)
-  // ═══════════════════════════════════════════════
-
-  /** Connect to EventStreamManager and start tracking live context */
-  connectEventStream(eventStream: EventStreamManager): void {
-    this.eventStream = eventStream;
-
-    this.unsubscribe = eventStream.subscribe((event) => {
-      this.handleEvent(event);
-    });
-  }
-
   /** Update live tab list (call from main.ts when tabs change) */
   updateTabs(tabs: Array<{ id: string; title: string; url: string; active: boolean }>): void {
     this.openTabs = tabs.map(t => ({ id: t.id, title: t.title, url: t.url }));
@@ -215,45 +191,6 @@ export class ContextBridge {
   onContextChange(cb: () => void): () => void {
     this.contextChangeListeners.add(cb);
     return () => { this.contextChangeListeners.delete(cb); };
-  }
-
-  private notifyContextChange(): void {
-    for (const cb of this.contextChangeListeners) {
-      try { cb(); } catch { /* ignore */ }
-    }
-  }
-
-  private handleEvent(event: BrowserEvent): void {
-    // Update active tab on navigation/page-loaded/tab-focused
-    if ((event.type === 'navigation' || event.type === 'page-loaded' || event.type === 'tab-focused') && event.tabId) {
-      this.activeTab = {
-        tabId: event.tabId,
-        url: event.url || this.activeTab?.url || '',
-        title: event.title || this.activeTab?.title || '',
-      };
-    }
-
-    // Track voice status
-    if (event.type === 'voice-input' && event.data) {
-      if ('listening' in event.data) {
-        this.voiceActive = event.data.listening as boolean;
-      }
-    }
-
-    // Notify listeners on meaningful events
-    const meaningfulEvents: BrowserEventType[] = ['navigation', 'page-loaded', 'tab-opened', 'tab-closed', 'tab-focused'];
-    if (meaningfulEvents.includes(event.type)) {
-      this.notifyContextChange();
-    }
-  }
-
-  private timeAgo(timestamp: number): string {
-    const seconds = Math.floor((Date.now() - timestamp) / 1000);
-    if (seconds < 5) return 'just now';
-    if (seconds < 60) return `${seconds}s ago`;
-    const minutes = Math.floor(seconds / 60);
-    if (minutes < 60) return `${minutes}m ago`;
-    return `${Math.floor(minutes / 60)}h ago`;
   }
 
   /**
@@ -319,6 +256,8 @@ export class ContextBridge {
     };
   }
 
+  // === 6. Cleanup ===
+
   /** Cleanup */
   destroy(): void {
     if (this.unsubscribe) {
@@ -326,5 +265,79 @@ export class ContextBridge {
       this.unsubscribe = null;
     }
     this.contextChangeListeners.clear();
+  }
+
+  // === 7. Private I/O ===
+
+  /** Load the index from disk */
+  private loadIndex(): void {
+    try {
+      if (fs.existsSync(this.indexPath)) {
+        const raw: ContextSnapshot[] = JSON.parse(fs.readFileSync(this.indexPath, 'utf-8'));
+        for (const snap of raw) {
+          this.index.set(snap.url, snap);
+        }
+      }
+    } catch {
+      // Start fresh
+    }
+  }
+
+  /** Save the index to disk */
+  private saveIndex(): void {
+    try {
+      const entries = Array.from(this.index.values());
+      fs.writeFileSync(this.indexPath, JSON.stringify(entries, null, 2));
+    } catch {
+      // Silent fail
+    }
+  }
+
+  /** Extract domain from URL */
+  private getDomain(url: string): string {
+    try {
+      return new URL(url).hostname;
+    } catch {
+      return 'unknown';
+    }
+  }
+
+  private notifyContextChange(): void {
+    for (const cb of this.contextChangeListeners) {
+      try { cb(); } catch { /* ignore */ }
+    }
+  }
+
+  private handleEvent(event: BrowserEvent): void {
+    // Update active tab on navigation/page-loaded/tab-focused
+    if ((event.type === 'navigation' || event.type === 'page-loaded' || event.type === 'tab-focused') && event.tabId) {
+      this.activeTab = {
+        tabId: event.tabId,
+        url: event.url || this.activeTab?.url || '',
+        title: event.title || this.activeTab?.title || '',
+      };
+    }
+
+    // Track voice status
+    if (event.type === 'voice-input' && event.data) {
+      if ('listening' in event.data) {
+        this.voiceActive = event.data.listening as boolean;
+      }
+    }
+
+    // Notify listeners on meaningful events
+    const meaningfulEvents: BrowserEventType[] = ['navigation', 'page-loaded', 'tab-opened', 'tab-closed', 'tab-focused'];
+    if (meaningfulEvents.includes(event.type)) {
+      this.notifyContextChange();
+    }
+  }
+
+  private timeAgo(timestamp: number): string {
+    const seconds = Math.floor((Date.now() - timestamp) / 1000);
+    if (seconds < 5) return 'just now';
+    if (seconds < 60) return `${seconds}s ago`;
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes}m ago`;
+    return `${Math.floor(minutes / 60)}h ago`;
   }
 }

--- a/src/claronote/manager.ts
+++ b/src/claronote/manager.ts
@@ -2,6 +2,8 @@ import path from 'path';
 import fs from 'fs';
 import { tandemDir } from '../utils/paths';
 
+// ─── Types ──────────────────────────────────────────────────────────
+
 export interface ClaroNoteAuth {
   token: string;
   user: {
@@ -29,12 +31,24 @@ export interface CreateNoteResponse {
   key: string;
 }
 
+// ─── Manager ────────────────────────────────────────────────────────
+
+/**
+ * ClaroNoteManager — integration with the ClaroNote transcription API.
+ *
+ * Persistence: ~/.tandem/claronote-auth.json
+ */
 export class ClaroNoteManager {
+
+  // === 1. Private state ===
+
   private authFile: string;
   private baseUrl = 'https://api.claronote.com';
   private isRecording: boolean = false;
   private recordingStartTime: number = 0;
-  
+
+  // === 2. Constructor ===
+
   constructor() {
     const baseDir = tandemDir();
     if (!fs.existsSync(baseDir)) {
@@ -43,7 +57,9 @@ export class ClaroNoteManager {
     this.authFile = path.join(baseDir, 'claronote-auth.json');
   }
 
-  // ═══ Authentication ═══
+  // === 4. Public methods ===
+
+  // --- Authentication ---
 
   /** Authenticate with ClaroNote and persist the token to disk. */
   async login(email: string, password: string): Promise<{ success: boolean; error?: string }> {
@@ -59,16 +75,16 @@ export class ClaroNoteManager {
           user: response.user,
           expiresAt: Date.now() + (24 * 60 * 60 * 1000) // 24 hours
         };
-        
+
         fs.writeFileSync(this.authFile, JSON.stringify(auth, null, 2));
         return { success: true };
       } else {
         return { success: false, error: 'Invalid response format' };
       }
     } catch (error) {
-      return { 
-        success: false, 
-        error: error instanceof Error ? error.message : 'Unknown error' 
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
       };
     }
   }
@@ -84,15 +100,15 @@ export class ClaroNoteManager {
   getAuth(): ClaroNoteAuth | null {
     try {
       if (!fs.existsSync(this.authFile)) return null;
-      
+
       const auth: ClaroNoteAuth = JSON.parse(fs.readFileSync(this.authFile, 'utf-8'));
-      
+
       // Check if token is expired
       if (auth.expiresAt && Date.now() > auth.expiresAt) {
         void this.logout();
         return null;
       }
-      
+
       return auth;
     } catch {
       return null;
@@ -104,7 +120,7 @@ export class ClaroNoteManager {
   async getMe(): Promise<any> {
     const auth = this.getAuth();
     if (!auth) throw new Error('Not authenticated');
-    
+
     return await this.apiRequest('GET', '/auth/me', null, auth.token);
   }
 
@@ -113,7 +129,7 @@ export class ClaroNoteManager {
     return this.getAuth() !== null;
   }
 
-  // ═══ Recording ═══
+  // --- Recording ---
 
   /** Start tracking a recording session (actual MediaRecorder lives in renderer). */
   async startRecording(): Promise<{ success: boolean; error?: string }> {
@@ -126,12 +142,12 @@ export class ClaroNoteManager {
       // We just track the state here
       this.isRecording = true;
       this.recordingStartTime = Date.now();
-      
+
       return { success: true };
     } catch (error) {
-      return { 
-        success: false, 
-        error: error instanceof Error ? error.message : 'Failed to start recording' 
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to start recording'
       };
     }
   }
@@ -153,23 +169,23 @@ export class ClaroNoteManager {
 
       // Stop recording
       this.isRecording = false;
-      
+
       // Return success - the actual upload will be handled by the renderer process
       // For now, we'll just return a placeholder
       return { success: true, noteId: 'pending' };
     } catch (error) {
-      return { 
-        success: false, 
-        error: error instanceof Error ? error.message : 'Failed to stop recording' 
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Failed to stop recording'
       };
     }
   }
 
   /** Get the current recording state, including elapsed duration. */
-  getRecordingStatus(): { 
-    isRecording: boolean; 
-    duration?: number; 
-    startTime?: number; 
+  getRecordingStatus(): {
+    isRecording: boolean;
+    duration?: number;
+    startTime?: number;
   } {
     return {
       isRecording: this.isRecording,
@@ -178,13 +194,13 @@ export class ClaroNoteManager {
     };
   }
 
-  // ═══ Notes Management ═══
+  // --- Notes Management ---
 
   /** Fetch recent notes from ClaroNote, sorted newest first. */
   async getNotes(limit: number = 10): Promise<ClaroNote[]> {
     const auth = this.getAuth();
     if (!auth) throw new Error('Not authenticated');
-    
+
     const response = await this.apiRequest('GET', `/notes?limit=${limit}&sortBy=createdAt&sortOrder=desc`, null, auth.token);
     return response.data || response;
   }
@@ -193,11 +209,9 @@ export class ClaroNoteManager {
   async getNote(noteId: string): Promise<ClaroNote> {
     const auth = this.getAuth();
     if (!auth) throw new Error('Not authenticated');
-    
+
     return await this.apiRequest('GET', `/notes/${noteId}`, null, auth.token);
   }
-
-  // ═══ Public Methods for Audio Upload ═══
 
   /**
    * Upload an audio recording buffer to ClaroNote for transcription.
@@ -206,11 +220,11 @@ export class ClaroNoteManager {
   async uploadRecording(audioBuffer: Buffer, duration: number): Promise<string> {
     const auth = this.getAuth();
     if (!auth) throw new Error('Not authenticated');
-    
+
     return this.uploadAudioBuffer(audioBuffer, duration, auth.token);
   }
 
-  // ═══ Private Methods ═══
+  // === 7. Private helpers ===
 
   private async uploadAudioBuffer(audioBuffer: Buffer, duration: number, token: string): Promise<string> {
     // Step 1: Create note
@@ -263,7 +277,7 @@ export class ClaroNoteManager {
     }
 
     const response = await fetch(url, options);
-    
+
     if (!response.ok) {
       const errorText = await response.text();
       try {

--- a/src/headless/manager.ts
+++ b/src/headless/manager.ts
@@ -5,6 +5,8 @@ import { createLogger } from '../utils/logger';
 
 const log = createLogger('HeadlessManager');
 
+// ─── Constants ──────────────────────────────────────────────────────
+
 /** Page load timeout in milliseconds */
 const PAGE_LOAD_TIMEOUT_MS = 30000;
 
@@ -25,6 +27,8 @@ const CAPTCHA_SELECTORS = [
   '.cf-browser-verification',
 ];
 
+// ─── Types ──────────────────────────────────────────────────────────
+
 export interface HeadlessStatus {
   active: boolean;
   url: string | null;
@@ -34,17 +38,24 @@ export interface HeadlessStatus {
   captchaDetected: boolean;
 }
 
+// ─── Manager ────────────────────────────────────────────────────────
+
 /**
  * HeadlessManager — Background BrowserWindow for the AI wingman to browse solo.
- * 
+ *
  * Uses the same persist:tandem partition (cookies shared).
  * Same stealth patches as main window.
  * Auto-shows on captcha detection or errors.
  */
 export class HeadlessManager {
+
+  // === 1. Private state ===
+
   private window: BrowserWindow | null = null;
   private captchaDetected = false;
   private captchaCheckInterval: ReturnType<typeof setInterval> | null = null;
+
+  // === 4. Public methods ===
 
   /** Open a URL in the background window */
   async open(url: string): Promise<{ ok: boolean; error?: string }> {
@@ -143,6 +154,15 @@ export class HeadlessManager {
     this.captchaDetected = false;
   }
 
+  // === 6. Cleanup ===
+
+  /** Destroy everything */
+  destroy(): void {
+    this.close();
+  }
+
+  // === 7. Private helpers ===
+
   /** Create or reuse the hidden window */
   private async ensureWindow(): Promise<void> {
     if (this.window && !this.window.isDestroyed()) return;
@@ -231,10 +251,5 @@ export class HeadlessManager {
         this.captchaDetected = false;
       }
     } catch (e) { log.warn('Captcha detection check failed (window may be destroyed):', e instanceof Error ? e.message : String(e)); }
-  }
-
-  /** Destroy everything */
-  destroy(): void {
-    this.close();
   }
 }

--- a/src/locators/finder.ts
+++ b/src/locators/finder.ts
@@ -2,6 +2,8 @@ import type { DevToolsManager } from '../devtools/manager';
 import type { SnapshotManager } from '../snapshot/manager';
 import type { AccessibilityNode } from '../snapshot/types';
 
+// ─── Types ──────────────────────────────────────────────────────────
+
 export type LocatorStrategy = 'role' | 'text' | 'placeholder' | 'label' | 'testid';
 
 export interface LocatorQuery {
@@ -20,11 +22,21 @@ export interface LocatorResult {
   count?: number;      // Number of matches
 }
 
+// ─── Manager ────────────────────────────────────────────────────────
+
+/**
+ * LocatorFinder — finds elements by role, text, placeholder, label, or test ID.
+ */
 export class LocatorFinder {
+
+  // === 2. Constructor ===
+
   constructor(
     private devTools: DevToolsManager,
     private snapshot: SnapshotManager,
   ) {}
+
+  // === 4. Public methods ===
 
   async find(query: LocatorQuery): Promise<LocatorResult> {
     switch (query.by) {
@@ -50,7 +62,9 @@ export class LocatorFinder {
     }
   }
 
-  // ─── Role ─────────────────────────────────────
+  // === 7. Private helpers ===
+
+  // --- Role ---
 
   private async findByRole(query: LocatorQuery): Promise<LocatorResult> {
     const tree = await this.snapshot.getAccessibilityTree({ interactive: false });
@@ -76,7 +90,7 @@ export class LocatorFinder {
     return true;
   }
 
-  // ─── Text ─────────────────────────────────────
+  // --- Text ---
 
   private async findByText(query: LocatorQuery): Promise<LocatorResult> {
     const tree = await this.snapshot.getAccessibilityTree({ interactive: false });
@@ -132,7 +146,7 @@ export class LocatorFinder {
     }
   }
 
-  // ─── Placeholder ──────────────────────────────
+  // --- Placeholder ---
 
   private async findByPlaceholder(query: LocatorQuery): Promise<LocatorResult> {
     const exact = query.exact !== false;
@@ -150,7 +164,7 @@ export class LocatorFinder {
     return this.findAllByCssSelector(selector);
   }
 
-  // ─── Label ────────────────────────────────────
+  // --- Label ---
 
   private async findByLabel(query: LocatorQuery): Promise<LocatorResult> {
     try {
@@ -212,7 +226,7 @@ export class LocatorFinder {
     return result.found ? [result] : [];
   }
 
-  // ─── TestID ───────────────────────────────────
+  // --- TestID ---
 
   private async findByTestId(query: LocatorQuery): Promise<LocatorResult> {
     const exact = query.exact !== false;
@@ -230,7 +244,7 @@ export class LocatorFinder {
     return this.findAllByCssSelector(selector);
   }
 
-  // ─── Helpers ──────────────────────────────────
+  // --- CSS / DOM helpers ---
 
   private async findByCssSelector(selector: string): Promise<LocatorResult> {
     try {
@@ -302,7 +316,7 @@ export class LocatorFinder {
     }
   }
 
-  // ─── Tree walker ──────────────────────────────
+  // --- Tree walker ---
 
   private walkTree(
     nodes: AccessibilityNode[],

--- a/src/network/mocker.ts
+++ b/src/network/mocker.ts
@@ -5,9 +5,19 @@ import { createLogger } from '../utils/logger';
 
 const log = createLogger('NetworkMocker');
 
+// ─── Manager ────────────────────────────────────────────────────────
+
+/**
+ * NetworkMocker — intercepts and mocks network requests via CDP Fetch domain.
+ */
 export class NetworkMocker {
+
+  // === 1. Private state ===
+
   private rules: MockRule[] = [];
   private fetchEnabled = false;
+
+  // === 2. Constructor ===
 
   constructor(private devtools: DevToolsManager) {
     // Register CDP event subscriber for Fetch.requestPaused
@@ -17,6 +27,8 @@ export class NetworkMocker {
       handler: (_method: string, params: Record<string, unknown>) => this.handleRequestPaused(params),
     });
   }
+
+  // === 4. Public methods ===
 
   /** Add a mock/intercept rule */
   async addRule(rule: Omit<MockRule, 'id' | 'createdAt'>): Promise<MockRule> {
@@ -78,6 +90,21 @@ export class NetworkMocker {
   getRules(): MockRule[] {
     return [...this.rules];
   }
+
+  // === 6. Cleanup ===
+
+  /** Cleanup — called from will-quit handler */
+  destroy(): void {
+    this.rules = [];
+    this.devtools.unsubscribe('NetworkMocker');
+    // Don't await disableFetch here — app is quitting
+    if (this.fetchEnabled) {
+      this.devtools.sendCommand('Fetch.disable', {}).catch(e => log.warn('Fetch.disable on destroy failed:', e instanceof Error ? e.message : e));
+      this.fetchEnabled = false;
+    }
+  }
+
+  // === 7. Private helpers ===
 
   /** Enable CDP Fetch domain to intercept requests */
   private async enableFetch(): Promise<void> {
@@ -219,17 +246,6 @@ export class NetworkMocker {
       try {
         await this.devtools.sendCommand('Fetch.continueRequest', { requestId });
       } catch { /* ignore */ }
-    }
-  }
-
-  /** Cleanup — called from will-quit handler */
-  destroy(): void {
-    this.rules = [];
-    this.devtools.unsubscribe('NetworkMocker');
-    // Don't await disableFetch here — app is quitting
-    if (this.fetchEnabled) {
-      this.devtools.sendCommand('Fetch.disable', {}).catch(e => log.warn('Fetch.disable on destroy failed:', e instanceof Error ? e.message : e));
-      this.fetchEnabled = false;
     }
   }
 }

--- a/src/panel/manager.ts
+++ b/src/panel/manager.ts
@@ -9,6 +9,8 @@ import { IpcChannels } from '../shared/ipc-channels';
 
 const log = createLogger('PanelManager');
 
+// ─── Types ──────────────────────────────────────────────────────────
+
 export interface ActivityEvent {
   id: number;
   type: 'navigate' | 'click' | 'scroll' | 'input' | 'tab-switch' | 'tab-open' | 'tab-close' | 'press-key' | 'press-key-combo';
@@ -29,14 +31,19 @@ export interface AddChatMessageOptions {
   emitIpc?: boolean;
 }
 
+// ─── Manager ────────────────────────────────────────────────────────
+
 /**
  * PanelManager — Manages the Wingman side panel.
- * 
+ *
  * Tracks activity events from Electron webview events (NOT injected into webview).
  * Stores chat messages persistently in ~/.tandem/chat-history.json.
  * Supports typing indicator for the AI wingman.
  */
 export class PanelManager {
+
+  // === 1. Private state ===
+
   private win: BrowserWindow;
   private configManager?: ConfigManager;
   private activityLog: ActivityEvent[] = [];
@@ -49,6 +56,8 @@ export class PanelManager {
   private wingmanTyping = false;
   private chatImagesDir: string;
 
+  // === 2. Constructor ===
+
   constructor(win: BrowserWindow, configManager?: ConfigManager) {
     this.win = win;
     this.configManager = configManager;
@@ -58,33 +67,7 @@ export class PanelManager {
     this.loadChatHistory();
   }
 
-  /** Load chat history from disk */
-  private loadChatHistory(): void {
-    try {
-      if (fs.existsSync(this.chatHistoryPath)) {
-        const data = JSON.parse(fs.readFileSync(this.chatHistoryPath, 'utf-8'));
-        if (Array.isArray(data)) {
-          this.chatMessages = data;
-          this.chatCounter = this.chatMessages.length > 0
-            ? Math.max(...this.chatMessages.map(m => m.id))
-            : 0;
-        }
-      }
-    } catch {
-      // Corrupted file — start fresh
-      this.chatMessages = [];
-      this.chatCounter = 0;
-    }
-  }
-
-  /** Save chat history to disk */
-  private saveChatHistory(): void {
-    try {
-      fs.writeFileSync(this.chatHistoryPath, JSON.stringify(this.chatMessages, null, 2));
-    } catch {
-      // Silent fail
-    }
-  }
+  // === 4. Public methods ===
 
   /** Log an activity event */
   logActivity(type: ActivityEvent['type'], data: Record<string, unknown> = {}): ActivityEvent {
@@ -163,42 +146,6 @@ export class PanelManager {
     return msg;
   }
 
-  /** Fire webhook to notify OpenClaw of new chat message */
-  private async fireWebhook(msg: ChatMessage): Promise<void> {
-    if (!this.configManager) return;
-    const config = this.configManager.getConfig();
-    if (!config.webhook?.enabled || !config.webhook?.url) return;
-    // Only notify for robin messages (wingman messages come FROM OpenClaw, no need to echo back)
-    if (msg.from !== 'robin') return;
-    if (!config.webhook.notifyOnRobinChat) return;
-
-    const url = config.webhook.url.replace(/\/$/, '');
-
-    try {
-      const response = await fetch(`${url}/hooks/wake`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(config.webhook.secret ? { 'Authorization': `Bearer ${config.webhook.secret}` } : {}),
-        },
-        body: JSON.stringify({
-          text: `[Tandem Chat] Robin: ${msg.text}${msg.image ? ' [image attached]' : ''}`,
-          mode: 'now',
-        }),
-        signal: AbortSignal.timeout(5000),
-      });
-
-      if (!response.ok) {
-        log.warn(`⚠️ Webhook failed (${response.status}): ${response.statusText}`);
-      }
-    } catch (e) {
-      // Silent fail — OpenClaw might not be running
-      if (!(e instanceof Error) || e.name !== 'AbortError') {
-        log.warn('⚠️ Webhook dispatch failed (OpenClaw not running?):', e instanceof Error ? e.message : String(e));
-      }
-    }
-  }
-
   /** Get chat history */
   getChatMessages(limit: number = 50): ChatMessage[] {
     return this.chatMessages.slice(-limit);
@@ -207,31 +154,6 @@ export class PanelManager {
   /** Get messages since a given ID (for polling) */
   getChatMessagesSince(sinceId: number): ChatMessage[] {
     return this.chatMessages.filter(m => m.id > sinceId);
-  }
-
-  private maybeNotifyForIncomingReply(msg: ChatMessage): void {
-    if (this.panelOpen) return;
-    if (msg.from === 'robin') return;
-
-    const sender = this.getReplySenderLabel(msg.from);
-    const body = this.buildReplyNotificationBody(msg);
-    wingmanAlert(`${sender} replied`, body);
-  }
-
-  private getReplySenderLabel(from: ChatMessage['from']): string {
-    if (from === 'claude') return 'Claude';
-    return 'Wingman';
-  }
-
-  private buildReplyNotificationBody(msg: ChatMessage): string {
-    const trimmed = msg.text.trim();
-    if (trimmed.length > 0) {
-      return trimmed.length > 140 ? `${trimmed.slice(0, 137)}...` : trimmed;
-    }
-    if (msg.image) {
-      return 'Sent an image.';
-    }
-    return 'Sent a new message.';
   }
 
   /** Set Wingman typing indicator */
@@ -281,5 +203,96 @@ export class PanelManager {
   /** Get panel state */
   isPanelOpen(): boolean {
     return this.panelOpen;
+  }
+
+  // === 7. Private I/O ===
+
+  /** Load chat history from disk */
+  private loadChatHistory(): void {
+    try {
+      if (fs.existsSync(this.chatHistoryPath)) {
+        const data = JSON.parse(fs.readFileSync(this.chatHistoryPath, 'utf-8'));
+        if (Array.isArray(data)) {
+          this.chatMessages = data;
+          this.chatCounter = this.chatMessages.length > 0
+            ? Math.max(...this.chatMessages.map(m => m.id))
+            : 0;
+        }
+      }
+    } catch {
+      // Corrupted file — start fresh
+      this.chatMessages = [];
+      this.chatCounter = 0;
+    }
+  }
+
+  /** Save chat history to disk */
+  private saveChatHistory(): void {
+    try {
+      fs.writeFileSync(this.chatHistoryPath, JSON.stringify(this.chatMessages, null, 2));
+    } catch {
+      // Silent fail
+    }
+  }
+
+  /** Fire webhook to notify OpenClaw of new chat message */
+  private async fireWebhook(msg: ChatMessage): Promise<void> {
+    if (!this.configManager) return;
+    const config = this.configManager.getConfig();
+    if (!config.webhook?.enabled || !config.webhook?.url) return;
+    // Only notify for robin messages (wingman messages come FROM OpenClaw, no need to echo back)
+    if (msg.from !== 'robin') return;
+    if (!config.webhook.notifyOnRobinChat) return;
+
+    const url = config.webhook.url.replace(/\/$/, '');
+
+    try {
+      const response = await fetch(`${url}/hooks/wake`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(config.webhook.secret ? { 'Authorization': `Bearer ${config.webhook.secret}` } : {}),
+        },
+        body: JSON.stringify({
+          text: `[Tandem Chat] Robin: ${msg.text}${msg.image ? ' [image attached]' : ''}`,
+          mode: 'now',
+        }),
+        signal: AbortSignal.timeout(5000),
+      });
+
+      if (!response.ok) {
+        log.warn(`⚠️ Webhook failed (${response.status}): ${response.statusText}`);
+      }
+    } catch (e) {
+      // Silent fail — OpenClaw might not be running
+      if (!(e instanceof Error) || e.name !== 'AbortError') {
+        log.warn('⚠️ Webhook dispatch failed (OpenClaw not running?):', e instanceof Error ? e.message : String(e));
+      }
+    }
+  }
+
+  private maybeNotifyForIncomingReply(msg: ChatMessage): void {
+    if (this.panelOpen) return;
+    if (msg.from === 'robin') return;
+
+    const sender = this.getReplySenderLabel(msg.from);
+    const body = this.buildReplyNotificationBody(msg);
+    wingmanAlert(`${sender} replied`, body);
+  }
+
+  private getReplySenderLabel(from: ChatMessage['from']): string {
+    if (from === 'claude') return 'Claude';
+    return 'Wingman';
+  }
+
+  private buildReplyNotificationBody(msg: ChatMessage): string {
+    const trimmed = msg.text.trim();
+    if (trimmed.length > 0) {
+      return trimmed.length > 140 ? `${trimmed.slice(0, 137)}...` : trimmed;
+    }
+    if (msg.image) {
+      return 'Sent an image.';
+    }
+    return 'Sent a new message.';
   }
 }

--- a/src/video/recorder.ts
+++ b/src/video/recorder.ts
@@ -14,6 +14,8 @@ try {
   ffmpegPath = 'ffmpeg';
 }
 
+// ─── Types ──────────────────────────────────────────────────────────
+
 interface Recording {
   id: string;
   filename: string;
@@ -25,7 +27,17 @@ interface Recording {
   region?: { x: number; y: number; width: number; height: number };
 }
 
+// ─── Manager ────────────────────────────────────────────────────────
+
+/**
+ * VideoRecorderManager — records the browser window to MP4 via ffmpeg.
+ *
+ * Persistence: ~/Movies/Tandem/ and ~/.tandem/recordings/
+ */
 export class VideoRecorderManager {
+
+  // === 1. Private state ===
+
   private recording = false;
   private currentRecordingId: string | null = null;
   private startTime = 0;
@@ -38,6 +50,8 @@ export class VideoRecorderManager {
   private currentRegion?: { x: number; y: number; width: number; height: number };
   private writeStream: fs.WriteStream | null = null;
 
+  // === 2. Constructor ===
+
   constructor() {
     this.recordingsDir = tandemDir('recordings');
     this.tmpDir = path.join(this.recordingsDir, 'tmp');
@@ -48,26 +62,7 @@ export class VideoRecorderManager {
     this.loadIndex();
   }
 
-  private getIndexPath(): string {
-    return path.join(this.recordingsDir, 'index.json');
-  }
-
-  private loadIndex(): void {
-    try {
-      const p = this.getIndexPath();
-      if (fs.existsSync(p)) {
-        this.recordings = JSON.parse(fs.readFileSync(p, 'utf-8'));
-      }
-    } catch {
-      this.recordings = [];
-    }
-  }
-
-  private saveIndex(): void {
-    try {
-      fs.writeFileSync(this.getIndexPath(), JSON.stringify(this.recordings, null, 2));
-    } catch { /* ignore */ }
-  }
+  // === 4. Public methods ===
 
   startRecording(mode: 'application' | 'region', region?: { x: number; y: number; width: number; height: number }): { ok: boolean; id?: string; error?: string } {
     if (this.recording) return { ok: false, error: 'Already recording' };
@@ -167,30 +162,6 @@ export class VideoRecorderManager {
     return { ok: true, recording: rec };
   }
 
-  private convertToMp4(inputPath: string, outputPath: string): Promise<void> {
-    return new Promise((resolve, reject) => {
-      execFile(ffmpegPath, [
-        '-i', inputPath,
-        '-c:v', 'libx264',
-        '-preset', 'fast',
-        '-crf', '23',
-        '-r', '30',
-        '-c:a', 'aac',
-        '-b:a', '128k',
-        '-movflags', '+faststart',
-        '-y',
-        outputPath,
-      ], { timeout: 300_000 }, (err, _stdout, stderr) => {
-        if (err) {
-          log.warn('ffmpeg stderr:', stderr);
-          reject(err);
-        } else {
-          resolve();
-        }
-      });
-    });
-  }
-
   isRecording(): boolean {
     return this.recording;
   }
@@ -237,5 +208,52 @@ export class VideoRecorderManager {
           log.warn('Force-stop conversion failed, keeping webm:', e instanceof Error ? e.message : e);
         });
     }
+  }
+
+  // === 7. Private I/O ===
+
+  private getIndexPath(): string {
+    return path.join(this.recordingsDir, 'index.json');
+  }
+
+  private loadIndex(): void {
+    try {
+      const p = this.getIndexPath();
+      if (fs.existsSync(p)) {
+        this.recordings = JSON.parse(fs.readFileSync(p, 'utf-8'));
+      }
+    } catch {
+      this.recordings = [];
+    }
+  }
+
+  private saveIndex(): void {
+    try {
+      fs.writeFileSync(this.getIndexPath(), JSON.stringify(this.recordings, null, 2));
+    } catch { /* ignore */ }
+  }
+
+  private convertToMp4(inputPath: string, outputPath: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      execFile(ffmpegPath, [
+        '-i', inputPath,
+        '-c:v', 'libx264',
+        '-preset', 'fast',
+        '-crf', '23',
+        '-r', '30',
+        '-c:a', 'aac',
+        '-b:a', '128k',
+        '-movflags', '+faststart',
+        '-y',
+        outputPath,
+      ], { timeout: 300_000 }, (err, _stdout, stderr) => {
+        if (err) {
+          log.warn('ffmpeg stderr:', stderr);
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
   }
 }

--- a/src/watch/watcher.ts
+++ b/src/watch/watcher.ts
@@ -10,6 +10,8 @@ import { createLogger } from '../utils/logger';
 
 const log = createLogger('Watcher');
 
+// ─── Types ──────────────────────────────────────────────────────────
+
 export interface WatchEntry {
   id: string;
   url: string;
@@ -26,14 +28,19 @@ interface WatchState {
   watches: WatchEntry[];
 }
 
+// ─── Manager ────────────────────────────────────────────────────────
+
 /**
  * WatchManager — Scheduled background page watching.
- * 
+ *
  * Uses a hidden BrowserWindow to periodically check pages for changes.
  * Hashes page text content and compares with previous check.
  * Alerts the human/wingman when something changes.
  */
 export class WatchManager {
+
+  // === 1. Private state ===
+
   private watchFile: string;
   private state: WatchState;
   private timers: Map<string, ReturnType<typeof setInterval>> = new Map();
@@ -41,6 +48,8 @@ export class WatchManager {
   private counter = 0;
   private checking = false;
   private readonly MAX_WATCHES = 20;
+
+  // === 2. Constructor ===
 
   constructor() {
     const baseDir = tandemDir();
@@ -51,147 +60,7 @@ export class WatchManager {
     this.startAllTimers();
   }
 
-  private load(): WatchState {
-    try {
-      if (fs.existsSync(this.watchFile)) {
-        return JSON.parse(fs.readFileSync(this.watchFile, 'utf-8'));
-      }
-    } catch (e) { log.warn('Watch state load failed, starting fresh:', e instanceof Error ? e.message : String(e)); }
-    return { watches: [] };
-  }
-
-  private save(): void {
-    fs.writeFileSync(this.watchFile, JSON.stringify(this.state, null, 2));
-  }
-
-  private nextId(): string {
-    return `watch-${Date.now()}-${++this.counter}`;
-  }
-
-  /** Create hidden BrowserWindow for background checks */
-  private async getHiddenWindow(): Promise<BrowserWindow> {
-    if (this.hiddenWindow && !this.hiddenWindow.isDestroyed()) {
-      return this.hiddenWindow;
-    }
-
-    const partition = 'persist:tandem';
-    const _ses = session.fromPartition(partition);
-
-    this.hiddenWindow = new BrowserWindow({
-      show: false,
-      width: 1280,
-      height: 800,
-      webPreferences: {
-        partition,
-        contextIsolation: true,
-        nodeIntegration: false,
-      },
-    });
-
-    // Apply stealth script after page loads
-    this.hiddenWindow.webContents.on('did-finish-load', () => {
-      this.hiddenWindow?.webContents.executeJavaScript(StealthManager.getStealthScript()).catch((e) => log.warn('Watch stealth injection failed:', e.message));
-    });
-
-    return this.hiddenWindow;
-  }
-
-  /** Hash text content of a page */
-  private hashContent(text: string): string {
-    return crypto.createHash('sha256').update(text).digest('hex').substring(0, 16);
-  }
-
-  /** Check a single URL for changes */
-  async checkUrl(watchId: string): Promise<{ changed: boolean; error?: string }> {
-    const watch = this.state.watches.find(w => w.id === watchId);
-    if (!watch) return { changed: false, error: 'Watch not found' };
-
-    // Prevent concurrent checks
-    if (this.checking) return { changed: false, error: 'Already checking' };
-    this.checking = true;
-
-    try {
-      const win = await this.getHiddenWindow();
-      
-      await new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(() => {
-          reject(new Error('Page load timeout'));
-        }, DEFAULT_TIMEOUT_MS);
-
-        win.webContents.once('did-finish-load', () => {
-          clearTimeout(timeout);
-          // Small delay for dynamic content
-          setTimeout(resolve, 2000);
-        });
-
-        win.webContents.once('did-fail-load', (_event, errorCode, errorDescription) => {
-          clearTimeout(timeout);
-          reject(new Error(`Load failed: ${errorDescription} (${errorCode})`));
-        });
-
-        win.webContents.loadURL(watch.url).catch(reject);
-      });
-
-      // Extract text content
-      const textContent: string = await win.webContents.executeJavaScript(`
-        document.body ? document.body.innerText.replace(/\\s+/g, ' ').trim() : ''
-      `);
-
-      const title: string = await win.webContents.executeJavaScript('document.title');
-      const newHash = this.hashContent(textContent);
-      const changed = watch.lastHash !== null && watch.lastHash !== newHash;
-
-      watch.lastCheck = Date.now();
-      watch.lastTitle = title;
-      watch.lastError = null;
-
-      if (changed) {
-        watch.changeCount++;
-        wingmanAlert(
-          `Page changed: ${watch.lastTitle || watch.url}`,
-          `${watch.url} changed since the previous check.`
-        );
-      }
-
-      watch.lastHash = newHash;
-      this.save();
-
-      return { changed };
-    } catch (e) {
-      const message = e instanceof Error ? e.message : String(e);
-      watch.lastCheck = Date.now();
-      watch.lastError = message;
-      this.save();
-      return { changed: false, error: message };
-    } finally {
-      this.checking = false;
-    }
-  }
-
-  /** Start timer for a single watch */
-  private startTimer(watch: WatchEntry): void {
-    this.stopTimer(watch.id);
-    const timer = setInterval(() => {
-      this.checkUrl(watch.id).catch((e) => log.warn('Watch check failed for ' + watch.id + ':', e.message));
-    }, watch.intervalMs);
-    this.timers.set(watch.id, timer);
-  }
-
-  /** Stop timer for a watch */
-  private stopTimer(id: string): void {
-    const timer = this.timers.get(id);
-    if (timer) {
-      clearInterval(timer);
-      this.timers.delete(id);
-    }
-  }
-
-  /** Start all timers from saved state */
-  private startAllTimers(): void {
-    for (const watch of this.state.watches) {
-      this.startTimer(watch);
-    }
-  }
+  // === 4. Public methods ===
 
   /** Add a new watch */
   addWatch(url: string, intervalMinutes: number): WatchEntry | { error: string } {
@@ -257,6 +126,75 @@ export class WatchManager {
     return { results };
   }
 
+  /** Check a single URL for changes */
+  async checkUrl(watchId: string): Promise<{ changed: boolean; error?: string }> {
+    const watch = this.state.watches.find(w => w.id === watchId);
+    if (!watch) return { changed: false, error: 'Watch not found' };
+
+    // Prevent concurrent checks
+    if (this.checking) return { changed: false, error: 'Already checking' };
+    this.checking = true;
+
+    try {
+      const win = await this.getHiddenWindow();
+
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          reject(new Error('Page load timeout'));
+        }, DEFAULT_TIMEOUT_MS);
+
+        win.webContents.once('did-finish-load', () => {
+          clearTimeout(timeout);
+          // Small delay for dynamic content
+          setTimeout(resolve, 2000);
+        });
+
+        win.webContents.once('did-fail-load', (_event, errorCode, errorDescription) => {
+          clearTimeout(timeout);
+          reject(new Error(`Load failed: ${errorDescription} (${errorCode})`));
+        });
+
+        win.webContents.loadURL(watch.url).catch(reject);
+      });
+
+      // Extract text content
+      const textContent: string = await win.webContents.executeJavaScript(`
+        document.body ? document.body.innerText.replace(/\\s+/g, ' ').trim() : ''
+      `);
+
+      const title: string = await win.webContents.executeJavaScript('document.title');
+      const newHash = this.hashContent(textContent);
+      const changed = watch.lastHash !== null && watch.lastHash !== newHash;
+
+      watch.lastCheck = Date.now();
+      watch.lastTitle = title;
+      watch.lastError = null;
+
+      if (changed) {
+        watch.changeCount++;
+        wingmanAlert(
+          `Page changed: ${watch.lastTitle || watch.url}`,
+          `${watch.url} changed since the previous check.`
+        );
+      }
+
+      watch.lastHash = newHash;
+      this.save();
+
+      return { changed };
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      watch.lastCheck = Date.now();
+      watch.lastError = message;
+      this.save();
+      return { changed: false, error: message };
+    } finally {
+      this.checking = false;
+    }
+  }
+
+  // === 6. Cleanup ===
+
   /** Cleanup — stop all timers and close hidden window */
   destroy(): void {
     for (const [id] of this.timers) {
@@ -264,6 +202,83 @@ export class WatchManager {
     }
     if (this.hiddenWindow && !this.hiddenWindow.isDestroyed()) {
       this.hiddenWindow.close();
+    }
+  }
+
+  // === 7. Private I/O ===
+
+  private load(): WatchState {
+    try {
+      if (fs.existsSync(this.watchFile)) {
+        return JSON.parse(fs.readFileSync(this.watchFile, 'utf-8'));
+      }
+    } catch (e) { log.warn('Watch state load failed, starting fresh:', e instanceof Error ? e.message : String(e)); }
+    return { watches: [] };
+  }
+
+  private save(): void {
+    fs.writeFileSync(this.watchFile, JSON.stringify(this.state, null, 2));
+  }
+
+  private nextId(): string {
+    return `watch-${Date.now()}-${++this.counter}`;
+  }
+
+  /** Create hidden BrowserWindow for background checks */
+  private async getHiddenWindow(): Promise<BrowserWindow> {
+    if (this.hiddenWindow && !this.hiddenWindow.isDestroyed()) {
+      return this.hiddenWindow;
+    }
+
+    const partition = 'persist:tandem';
+    const _ses = session.fromPartition(partition);
+
+    this.hiddenWindow = new BrowserWindow({
+      show: false,
+      width: 1280,
+      height: 800,
+      webPreferences: {
+        partition,
+        contextIsolation: true,
+        nodeIntegration: false,
+      },
+    });
+
+    // Apply stealth script after page loads
+    this.hiddenWindow.webContents.on('did-finish-load', () => {
+      this.hiddenWindow?.webContents.executeJavaScript(StealthManager.getStealthScript()).catch((e) => log.warn('Watch stealth injection failed:', e.message));
+    });
+
+    return this.hiddenWindow;
+  }
+
+  /** Hash text content of a page */
+  private hashContent(text: string): string {
+    return crypto.createHash('sha256').update(text).digest('hex').substring(0, 16);
+  }
+
+  /** Start timer for a single watch */
+  private startTimer(watch: WatchEntry): void {
+    this.stopTimer(watch.id);
+    const timer = setInterval(() => {
+      this.checkUrl(watch.id).catch((e) => log.warn('Watch check failed for ' + watch.id + ':', e.message));
+    }, watch.intervalMs);
+    this.timers.set(watch.id, timer);
+  }
+
+  /** Stop timer for a watch */
+  private stopTimer(id: string): void {
+    const timer = this.timers.get(id);
+    if (timer) {
+      clearInterval(timer);
+      this.timers.delete(id);
+    }
+  }
+
+  /** Start all timers from saved state */
+  private startAllTimers(): void {
+    for (const watch of this.state.watches) {
+      this.startTimer(watch);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add 7-section comment headers (`// === 1. Private state ===`, etc.) and reorder methods to match `docs/templates/manager-pattern.md`
- Add class-level JSDoc where missing (NetworkMocker, VideoRecorderManager, ClaroNoteManager, LocatorFinder)
- Move private helpers (load/save, tree walkers, CDP helpers, etc.) to section 7
- Move destroy/cleanup methods to section 6
- **No logic, method signatures, or public API changes**

## Managers touched
| Manager | File | Lines |
|---------|------|-------|
| BookmarkManager | `src/bookmarks/manager.ts` | 233 |
| NetworkMocker | `src/network/mocker.ts` | 235 |
| HeadlessManager | `src/headless/manager.ts` | 240 |
| VideoRecorderManager | `src/video/recorder.ts` | 241 |
| WatchManager | `src/watch/watcher.ts` | 269 |
| PanelManager | `src/panel/manager.ts` | 285 |
| ClaroNoteManager | `src/claronote/manager.ts` | 284 |
| ContextBridge | `src/bridge/context-bridge.ts` | 330 |
| LocatorFinder | `src/locators/finder.ts` | 334 |

## Test plan
- [x] `npm run verify` passes (compile + lint + test + consistency)
- [x] All 1871 tests pass, 87 test files
- [x] No logic changes — diff is purely structural (comments + method reordering)