### PR TITLE
refactor: align 7 large managers with standard pattern (P3-01 batch 4)

### DIFF
--- a/src/auth/login-manager.ts
+++ b/src/auth/login-manager.ts
@@ -6,6 +6,8 @@ import { createLogger } from '../utils/logger';
 
 const log = createLogger('LoginManager');
 
+// ─── Types ───
+
 interface LoginState {
   domain: string;
   status: 'logged-in' | 'logged-out' | 'unknown';
@@ -31,12 +33,19 @@ interface DomainConfig {
   loggedOutRules: LoginDetectionRule[];
 }
 
+// ─── Manager ───
+
+/**
+ * LoginManager — Detects and tracks login state across websites.
+ */
 export class LoginManager {
+  // === 1. Private state ===
   private statesFile: string;
   private configFile: string;
   private states: Map<string, LoginState> = new Map();
   private domainConfigs: Map<string, DomainConfig> = new Map();
 
+  // === 2. Constructor ===
   constructor() {
     const authDir = tandemDir('auth');
     if (!fs.existsSync(authDir)) {
@@ -45,11 +54,13 @@ export class LoginManager {
 
     this.statesFile = path.join(authDir, 'login-states.json');
     this.configFile = path.join(authDir, 'domain-configs.json');
-    
+
     this.loadStates();
     this.loadDomainConfigs();
     this.initializeDefaultConfigs();
   }
+
+  // === 4. Public methods ===
 
   /**
    * Get login state for a specific domain
@@ -88,12 +99,12 @@ export class LoginManager {
   async checkCurrentPage(webview: BrowserWindow): Promise<LoginState> {
     const url = webview.webContents.getURL();
     const domain = this.extractDomain(url);
-    
+
     const state = await this.detectLoginState(webview, domain);
-    
+
     this.states.set(domain, state);
     this.saveStates();
-    
+
     return state;
   }
 
@@ -119,32 +130,32 @@ export class LoginManager {
       (() => {
         const url = window.location.href.toLowerCase();
         const title = document.title.toLowerCase();
-        
+
         // URL patterns
         const loginPatterns = [
           '/login', '/signin', '/sign-in', '/auth', '/authenticate',
           '/log-in', '/logon', '/log_in', '/session', '/account/login',
           'login.', 'signin.', 'auth.', 'accounts.'
         ];
-        
+
         if (loginPatterns.some(pattern => url.includes(pattern))) {
           return true;
         }
-        
+
         // Title patterns
         const titlePatterns = ['login', 'sign in', 'log in', 'authenticate'];
         if (titlePatterns.some(pattern => title.includes(pattern))) {
           return true;
         }
-        
+
         // Form detection
         const passwordFields = document.querySelectorAll('input[type="password"]');
         const emailFields = document.querySelectorAll('input[type="email"], input[name*="email"], input[name*="username"], input[name*="user"]');
-        
+
         if (passwordFields.length > 0 && emailFields.length > 0) {
           return true;
         }
-        
+
         // Login form detection by common class names and IDs
         const loginSelectors = [
           'form[class*="login"]', 'form[id*="login"]',
@@ -153,13 +164,13 @@ export class LoginManager {
           '.login-form', '.signin-form', '.auth-form',
           '#login-form', '#signin-form', '#auth-form'
         ];
-        
+
         for (const selector of loginSelectors) {
           if (document.querySelector(selector)) {
             return true;
           }
         }
-        
+
         return false;
       })()
     `);
@@ -170,13 +181,13 @@ export class LoginManager {
    */
   async updateLoginState(domain: string, status: 'logged-in' | 'logged-out', username?: string): Promise<void> {
     const existing = this.states.get(domain) || await this.getLoginState(domain);
-    
+
     existing.status = status;
     existing.lastUpdated = new Date().toISOString();
     existing.username = username;
     existing.detectionMethod = 'manual';
     existing.confidence = 100;
-    
+
     this.states.set(domain, existing);
     this.saveStates();
   }
@@ -191,10 +202,12 @@ export class LoginManager {
     state.lastUpdated = new Date().toISOString();
     state.detectionMethod = 'cleared';
     state.confidence = 0;
-    
+
     this.states.set(domain, state);
     this.saveStates();
   }
+
+  // === 7. Private helpers ===
 
   private async detectLoginState(webview: BrowserWindow, domain: string): Promise<LoginState> {
     const config = this.domainConfigs.get(domain);
@@ -231,7 +244,7 @@ export class LoginManager {
             loggedIn: [],
             loggedOut: []
           };
-          
+
           // Common logged-in indicators
           const loggedInSelectors = [
             'button[class*="logout"]', 'a[href*="logout"]', '.logout',
@@ -241,14 +254,14 @@ export class LoginManager {
             '.account-menu', '.user-dropdown',
             '[class*="dashboard"]', '[href*="dashboard"]'
           ];
-          
+
           for (const selector of loggedInSelectors) {
             const elements = document.querySelectorAll(selector);
             if (elements.length > 0) {
               indicators.loggedIn.push(selector);
             }
           }
-          
+
           // Common logged-out indicators
           const loggedOutSelectors = [
             'button[class*="login"]', 'a[href*="login"]', '.login',
@@ -256,18 +269,18 @@ export class LoginManager {
             'button[class*="sign-in"]', 'a[href*="sign-in"]', '.sign-in',
             'input[type="password"]'
           ];
-          
+
           for (const selector of loggedOutSelectors) {
             const elements = document.querySelectorAll(selector);
             if (elements.length > 0) {
               indicators.loggedOut.push(selector);
             }
           }
-          
+
           // Check for username/email display
           const userNameElements = document.querySelectorAll('[class*="username"], [class*="user-name"], [class*="email"]');
           let username = null;
-          
+
           for (const el of userNameElements) {
             const text = el.textContent?.trim();
             if (text && text.includes('@') && text.length > 5 && text.length < 50) {
@@ -276,7 +289,7 @@ export class LoginManager {
               break;
             }
           }
-          
+
           return {
             loggedIn: indicators.loggedIn,
             loggedOut: indicators.loggedOut,
@@ -295,7 +308,7 @@ export class LoginManager {
       // Determine status
       let status: 'logged-in' | 'logged-out' | 'unknown';
       let confidence: number;
-      
+
       if (loggedInScore > loggedOutScore && loggedInScore >= 20) {
         status = 'logged-in';
         confidence = Math.min(100, (loggedInScore / Math.max(loggedOutScore + loggedInScore, 1)) * 100);
@@ -319,7 +332,7 @@ export class LoginManager {
 
     } catch (error) {
       log.error('Error detecting login state:', error);
-      
+
       return {
         domain,
         status: 'unknown',
@@ -339,16 +352,16 @@ export class LoginManager {
             (() => {
               const elements = document.querySelectorAll('${rule.pattern}');
               const exists = elements.length > 0;
-              
+
               if ('${rule.condition}' === 'exists') return exists;
               if ('${rule.condition}' === 'not-exists') return !exists;
-              
+
               if ('${rule.value}' && elements.length > 0) {
                 const text = Array.from(elements).map(el => el.textContent || el.value || '').join(' ');
                 if ('${rule.condition}' === 'contains') return text.includes('${rule.value}');
                 if ('${rule.condition}' === 'not-contains') return !text.includes('${rule.value}');
               }
-              
+
               return false;
             })()
           `);
@@ -367,10 +380,10 @@ export class LoginManager {
             (() => {
               const text = document.body.textContent || '';
               const contains = text.includes('${rule.pattern}');
-              
+
               if ('${rule.condition}' === 'contains') return contains;
               if ('${rule.condition}' === 'not-contains') return !contains;
-              
+
               return false;
             })()
           `);
@@ -416,7 +429,7 @@ export class LoginManager {
       if (fs.existsSync(this.statesFile)) {
         const data = fs.readFileSync(this.statesFile, 'utf8');
         const states = JSON.parse(data) as LoginState[];
-        
+
         this.states.clear();
         for (const state of states) {
           this.states.set(state.domain, state);
@@ -441,7 +454,7 @@ export class LoginManager {
       if (fs.existsSync(this.configFile)) {
         const data = fs.readFileSync(this.configFile, 'utf8');
         const configs = JSON.parse(data) as DomainConfig[];
-        
+
         this.domainConfigs.clear();
         for (const config of configs) {
           this.domainConfigs.set(config.domain, config);

--- a/src/config/manager.ts
+++ b/src/config/manager.ts
@@ -8,6 +8,8 @@ import { createLogger } from '../utils/logger';
 import { detectOpenClaw } from '../utils/openclaw-detect';
 const log = createLogger('ConfigManager');
 
+// ─── Types ───
+
 export interface QuickLinkConfig {
   id: string;
   label: string;
@@ -186,18 +188,22 @@ const DEFAULT_CONFIG: TandemConfig = {
   onboardingComplete: false,
 };
 
+// ─── Manager ───
+
 /**
  * ConfigManager — Manages Tandem's configuration.
- * 
+ *
  * Loads from ~/.tandem/config.json on startup.
  * Supports partial updates via PATCH semantics.
  * Emits change callbacks for live application of settings.
  */
 export class ConfigManager {
+  // === 1. Private state ===
   private config: TandemConfig;
   private configPath: string;
   private changeListeners: Array<(config: TandemConfig, changed: Partial<TandemConfig>) => void> = [];
 
+  // === 2. Constructor ===
   constructor() {
     const baseDir = tandemDir();
     if (!fs.existsSync(baseDir)) {
@@ -205,89 +211,12 @@ export class ConfigManager {
     }
     this.configPath = path.join(baseDir, 'config.json');
     this.config = this.load();
-    
+
     // Auto-sync webhook.secret with OpenClaw hooks.token if empty
     void this.autoSyncWebhookSecret();
   }
 
-  /**
-   * Auto-sync webhook.secret with OpenClaw hooks.token.
-   * Runs async during startup, does not block config load.
-   * Always syncs — not just when empty — so token rotations are picked up automatically.
-   */
-  private async autoSyncWebhookSecret(): Promise<void> {
-    const status = await detectOpenClaw();
-
-    if (status.ok && status.hooksToken) {
-      if (this.config.webhook.secret !== status.hooksToken) {
-        log.info('✅ Auto-synced webhook.secret with OpenClaw hooks.token');
-        this.config.webhook.secret = status.hooksToken;
-        this.save();
-      }
-    } else if (!this.config.webhook.secret) {
-      log.debug('OpenClaw not detected — webhook.secret remains empty');
-    }
-  }
-
-
-  /** Load config from disk, merging with defaults */
-  private load(): TandemConfig {
-    try {
-      if (fs.existsSync(this.configPath)) {
-        const raw = JSON.parse(fs.readFileSync(this.configPath, 'utf-8'));
-        // Backward compat: migrate old kees* config keys
-        if (raw.general) {
-          if (raw.general.keesPanelPosition && !raw.general.wingmanPanelPosition) {
-            raw.general.wingmanPanelPosition = raw.general.keesPanelPosition;
-          }
-          if (raw.general.keesPanelDefaultOpen !== undefined && raw.general.wingmanPanelDefaultOpen === undefined) {
-            raw.general.wingmanPanelDefaultOpen = raw.general.keesPanelDefaultOpen;
-          }
-          if (raw.general.startPage === 'kees') {
-            raw.general.startPage = 'wingman';
-          }
-          delete raw.general.keesPanelPosition;
-          delete raw.general.keesPanelDefaultOpen;
-        }
-        const merged = this.deepMerge(DEFAULT_CONFIG as unknown as Record<string, unknown>, raw) as unknown as TandemConfig;
-        return this.normalizeConfig(merged);
-      }
-    } catch (e) {
-      log.warn('Config file corrupted, using defaults:', e instanceof Error ? e.message : String(e));
-    }
-    return this.normalizeConfig(JSON.parse(JSON.stringify(DEFAULT_CONFIG)) as TandemConfig);
-  }
-
-  /** Save config to disk */
-  private save(): void {
-    try {
-      fs.writeFileSync(this.configPath, JSON.stringify(this.config, null, 2));
-    } catch (e) {
-      log.warn('Config save failed:', e instanceof Error ? e.message : String(e));
-    }
-  }
-
-  /** Deep merge source into target (returns new object) */
-  private deepMerge(target: Record<string, unknown>, source: Record<string, unknown>): Record<string, unknown> {
-    const result = { ...target };
-    for (const key of Object.keys(source)) {
-      const sourceVal = source[key];
-      const targetVal = target[key];
-      if (
-        sourceVal &&
-        typeof sourceVal === 'object' &&
-        !Array.isArray(sourceVal) &&
-        targetVal &&
-        typeof targetVal === 'object' &&
-        !Array.isArray(targetVal)
-      ) {
-        result[key] = this.deepMerge(targetVal as Record<string, unknown>, sourceVal as Record<string, unknown>);
-      } else {
-        result[key] = sourceVal;
-      }
-    }
-    return result;
-  }
+  // === 4. Public methods ===
 
   /** Get the full config */
   getConfig(): TandemConfig {
@@ -359,6 +288,91 @@ export class ConfigManager {
     });
   }
 
+  /** Register a change listener */
+  onChange(listener: (config: TandemConfig, changed: Partial<TandemConfig>) => void): void {
+    this.changeListeners.push(listener);
+  }
+
+  // === 7. Private helpers ===
+
+  /**
+   * Auto-sync webhook.secret with OpenClaw hooks.token.
+   * Runs async during startup, does not block config load.
+   * Always syncs — not just when empty — so token rotations are picked up automatically.
+   */
+  private async autoSyncWebhookSecret(): Promise<void> {
+    const status = await detectOpenClaw();
+
+    if (status.ok && status.hooksToken) {
+      if (this.config.webhook.secret !== status.hooksToken) {
+        log.info('✅ Auto-synced webhook.secret with OpenClaw hooks.token');
+        this.config.webhook.secret = status.hooksToken;
+        this.save();
+      }
+    } else if (!this.config.webhook.secret) {
+      log.debug('OpenClaw not detected — webhook.secret remains empty');
+    }
+  }
+
+  /** Load config from disk, merging with defaults */
+  private load(): TandemConfig {
+    try {
+      if (fs.existsSync(this.configPath)) {
+        const raw = JSON.parse(fs.readFileSync(this.configPath, 'utf-8'));
+        // Backward compat: migrate old kees* config keys
+        if (raw.general) {
+          if (raw.general.keesPanelPosition && !raw.general.wingmanPanelPosition) {
+            raw.general.wingmanPanelPosition = raw.general.keesPanelPosition;
+          }
+          if (raw.general.keesPanelDefaultOpen !== undefined && raw.general.wingmanPanelDefaultOpen === undefined) {
+            raw.general.wingmanPanelDefaultOpen = raw.general.keesPanelDefaultOpen;
+          }
+          if (raw.general.startPage === 'kees') {
+            raw.general.startPage = 'wingman';
+          }
+          delete raw.general.keesPanelPosition;
+          delete raw.general.keesPanelDefaultOpen;
+        }
+        const merged = this.deepMerge(DEFAULT_CONFIG as unknown as Record<string, unknown>, raw) as unknown as TandemConfig;
+        return this.normalizeConfig(merged);
+      }
+    } catch (e) {
+      log.warn('Config file corrupted, using defaults:', e instanceof Error ? e.message : String(e));
+    }
+    return this.normalizeConfig(JSON.parse(JSON.stringify(DEFAULT_CONFIG)) as TandemConfig);
+  }
+
+  /** Save config to disk */
+  private save(): void {
+    try {
+      fs.writeFileSync(this.configPath, JSON.stringify(this.config, null, 2));
+    } catch (e) {
+      log.warn('Config save failed:', e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  /** Deep merge source into target (returns new object) */
+  private deepMerge(target: Record<string, unknown>, source: Record<string, unknown>): Record<string, unknown> {
+    const result = { ...target };
+    for (const key of Object.keys(source)) {
+      const sourceVal = source[key];
+      const targetVal = target[key];
+      if (
+        sourceVal &&
+        typeof sourceVal === 'object' &&
+        !Array.isArray(sourceVal) &&
+        targetVal &&
+        typeof targetVal === 'object' &&
+        !Array.isArray(targetVal)
+      ) {
+        result[key] = this.deepMerge(targetVal as Record<string, unknown>, sourceVal as Record<string, unknown>);
+      } else {
+        result[key] = sourceVal;
+      }
+    }
+    return result;
+  }
+
   private normalizeConfig(config: TandemConfig): TandemConfig {
     return {
       ...config,
@@ -401,11 +415,6 @@ export class ConfigManager {
     } catch {
       return null;
     }
-  }
-
-  /** Register a change listener */
-  onChange(listener: (config: TandemConfig, changed: Partial<TandemConfig>) => void): void {
-    this.changeListeners.push(listener);
   }
 
   /** Notify all change listeners */

--- a/src/content/extractor.ts
+++ b/src/content/extractor.ts
@@ -5,6 +5,8 @@ import { hostnameMatches, isSearchEngineResultsUrl, pathnameMatchesPrefix, tryPa
 
 const log = createLogger('ContentExtractor');
 
+// ─── Types ───
+
 interface PageContent {
   url: string;
   title: string;
@@ -72,9 +74,16 @@ interface GenericContent {
   }>;
 }
 
+// ─── Manager ───
+
+/**
+ * ContentExtractor — Extracts structured content from web pages.
+ */
 export class ContentExtractor {
+  // === 1. Private state ===
   private turndown: TurndownService;
 
+  // === 2. Constructor ===
   constructor() {
     this.turndown = new TurndownService({
       headingStyle: 'atx',
@@ -91,17 +100,19 @@ export class ContentExtractor {
     });
   }
 
+  // === 4. Public methods ===
+
   /**
    * Extract structured content from the current page
    */
   async extractCurrentPage(webview: BrowserWindow): Promise<PageContent> {
     const url = webview.webContents.getURL();
     const title = webview.webContents.getTitle();
-    
+
     // Get page content
     const html = await this.getPageHTML(webview);
     const pageType = this.detectPageType(url, html);
-    
+
     let content: ArticleContent | ProfileContent | ProductContent | SearchContent | GenericContent;
     switch (pageType) {
       case 'article':
@@ -135,11 +146,11 @@ export class ContentExtractor {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- HeadlessManager API mismatch (legacy dead code)
   async extractFromURL(url: string, headlessManager: any): Promise<PageContent> {
     const headlessWindow = await headlessManager.openHeadless(url);
-    
+
     try {
       // Wait for page to load
       await new Promise(resolve => setTimeout(resolve, 3000));
-      
+
       const result = await this.extractCurrentPage(headlessWindow);
       return result;
     } finally {
@@ -148,6 +159,8 @@ export class ContentExtractor {
       }
     }
   }
+
+  // === 7. Private helpers ===
 
   private async getPageHTML(webview: BrowserWindow): Promise<string> {
     return await webview.webContents.executeJavaScript(`
@@ -202,7 +215,7 @@ export class ContentExtractor {
         const titleEl = document.querySelector('h1') || document.querySelector('.title') || document.querySelector('[class*="title"]');
         const authorEl = document.querySelector('[class*="author"]') || document.querySelector('.byline') || document.querySelector('[rel="author"]');
         const dateEl = document.querySelector('time') || document.querySelector('[class*="date"]') || document.querySelector('[class*="published"]');
-        
+
         // Extract images
         const images = Array.from(document.querySelectorAll('img'))
           .map(img => img.src)
@@ -212,7 +225,7 @@ export class ContentExtractor {
         // Get main content
         const contentEl = article || document.querySelector('.content') || document.querySelector('#content') || document.body;
         let bodyText = '';
-        
+
         if (contentEl) {
           // Remove unwanted elements
           const unwanted = contentEl.querySelectorAll('script, style, nav, header, footer, aside, .advertisement, .ads, .social-share');
@@ -238,7 +251,7 @@ export class ContentExtractor {
           (() => {
             const article = document.querySelector('article') || document.querySelector('[role="main"]') || document.querySelector('main');
             const contentEl = article || document.querySelector('.content') || document.querySelector('#content');
-            
+
             if (contentEl) {
               // Clean up
               const unwanted = contentEl.cloneNode(true).querySelectorAll('script, style, nav, header, footer, aside, .advertisement, .ads, .social-share');
@@ -328,14 +341,14 @@ export class ContentExtractor {
         // Product images
         const images = Array.from(document.querySelectorAll('img'))
           .map(img => img.src)
-          .filter(src => src && !src.includes('data:image') && 
+          .filter(src => src && !src.includes('data:image') &&
                   (src.includes('product') || src.includes('item') || img.alt?.toLowerCase().includes(name?.toLowerCase().split(' ')[0] || '')))
           .slice(0, 5);
 
         // Reviews summary
         const rating = document.querySelector('[class*="rating"]')?.textContent?.trim() ||
                       document.querySelector('.stars')?.textContent?.trim();
-        
+
         const reviewCountEl = document.querySelector('[class*="review-count"], [class*="reviews"]');
         const reviewCount = reviewCountEl ? parseInt(reviewCountEl.textContent.replace(/D/g, '')) : undefined;
 
@@ -387,10 +400,10 @@ export class ContentExtractor {
               const title = titleEl?.textContent?.trim() || '';
               const url = titleEl?.href || '';
               const snippet = el.querySelector('.snippet, [class*="snippet"], [class*="description"]')?.textContent?.trim() || '';
-              
+
               return { title, url, snippet };
             }).filter(result => result.title && result.url);
-            
+
             if (results.length > 0) break;
           }
         }
@@ -408,9 +421,9 @@ export class ContentExtractor {
       (() => {
         const title = document.title;
         const description = document.querySelector('meta[name="description"]')?.getAttribute('content');
-        
+
         // Get main content
-        const main = document.querySelector('main') || document.querySelector('[role="main"]') || 
+        const main = document.querySelector('main') || document.querySelector('[role="main"]') ||
                      document.querySelector('.content') || document.querySelector('#content') ||
                      document.body;
 
@@ -428,8 +441,8 @@ export class ContentExtractor {
 
         // Extract important links
         const links = Array.from(document.querySelectorAll('a'))
-          .filter(a => a.href && a.textContent?.trim() && 
-                      !a.href.startsWith('javascript:') && 
+          .filter(a => a.href && a.textContent?.trim() &&
+                      !a.href.startsWith('javascript:') &&
                       !a.href.startsWith('#'))
           .slice(0, 10)
           .map(a => ({

--- a/src/draw/overlay.ts
+++ b/src/draw/overlay.ts
@@ -11,15 +11,18 @@ import { IpcChannels } from '../shared/ipc-channels';
 
 const log = createLogger('DrawOverlay');
 
+// ─── Manager ───
+
 /**
  * DrawOverlayManager — Manages the transparent annotation canvas overlay.
- * 
+ *
  * CRITICAL: The canvas overlay exists in the Electron SHELL layer,
  * NOT inside the webview. Websites cannot detect it.
- * 
+ *
  * Screenshots are composited: webview capture + canvas annotations → PNG.
  */
 export class DrawOverlayManager {
+  // === 1. Private state ===
   private win: BrowserWindow;
   private configManager: ConfigManager | null;
   private googlePhotosManager: GooglePhotosManager | null;
@@ -28,6 +31,7 @@ export class DrawOverlayManager {
   private picturesDir: string;
   private lastScreenshotPath: string | null = null;
 
+  // === 2. Constructor ===
   constructor(win: BrowserWindow, configManager?: ConfigManager, googlePhotosManager?: GooglePhotosManager) {
     this.win = win;
     this.configManager = configManager ?? null;
@@ -41,6 +45,8 @@ export class DrawOverlayManager {
       fs.mkdirSync(this.picturesDir, { recursive: true });
     }
   }
+
+  // === 4. Public methods ===
 
   /** Toggle draw mode on/off */
   toggleDrawMode(enabled?: boolean): boolean {
@@ -97,50 +103,6 @@ export class DrawOverlayManager {
     } catch (e) {
       return { ok: false, error: e instanceof Error ? e.message : String(e) };
     }
-  }
-
-  /**
-   * URL to slug for filenames.
-   */
-  private urlToSlug(url: string): string {
-    try {
-      const u = new URL(url);
-      return (u.hostname + u.pathname)
-        .replace(/[^a-zA-Z0-9]/g, '-')
-        .replace(/-+/g, '-')
-        .replace(/^-|-$/g, '')
-        .substring(0, 60);
-    } catch {
-      return 'unknown';
-    }
-  }
-
-  private persistScreenshotBuffer(
-    buffer: Buffer,
-    currentUrl: string,
-  ): { picturesPath: string; appPath: string; filename: string; base64: string } {
-    const image = nativeImage.createFromBuffer(buffer);
-    clipboard.writeImage(image);
-
-    const slug = this.urlToSlug(currentUrl);
-    const timestamp = Date.now();
-    const filename = `tandem-${slug}-${timestamp}.png`;
-    const picturesPath = path.join(this.picturesDir, filename);
-    fs.writeFileSync(picturesPath, buffer);
-
-    const appPath = path.join(this.screenshotDir, filename);
-    fs.writeFileSync(appPath, buffer);
-    this.lastScreenshotPath = appPath;
-
-    this.importToApplePhotos(picturesPath);
-    void this.importToGooglePhotos(picturesPath);
-
-    return {
-      picturesPath,
-      appPath,
-      filename,
-      base64: buffer.toString('base64'),
-    };
   }
 
   /**
@@ -293,6 +255,76 @@ export class DrawOverlayManager {
     }
   }
 
+  /** Get last annotated screenshot as PNG buffer */
+  getLastScreenshot(): Buffer | null {
+    if (!this.lastScreenshotPath || !fs.existsSync(this.lastScreenshotPath)) {
+      return null;
+    }
+    return fs.readFileSync(this.lastScreenshotPath);
+  }
+
+  /** Get screenshot directory */
+  getScreenshotDir(): string {
+    return this.screenshotDir;
+  }
+
+  /** List recent screenshots */
+  listScreenshots(limit: number = 10): string[] {
+    if (!fs.existsSync(this.screenshotDir)) return [];
+    const files = fs.readdirSync(this.screenshotDir)
+      .filter(f => f.endsWith('.png'))
+      .sort()
+      .reverse()
+      .slice(0, limit);
+    return files.map(f => path.join(this.screenshotDir, f));
+  }
+
+  // === 7. Private helpers ===
+
+  /**
+   * URL to slug for filenames.
+   */
+  private urlToSlug(url: string): string {
+    try {
+      const u = new URL(url);
+      return (u.hostname + u.pathname)
+        .replace(/[^a-zA-Z0-9]/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-|-$/g, '')
+        .substring(0, 60);
+    } catch {
+      return 'unknown';
+    }
+  }
+
+  private persistScreenshotBuffer(
+    buffer: Buffer,
+    currentUrl: string,
+  ): { picturesPath: string; appPath: string; filename: string; base64: string } {
+    const image = nativeImage.createFromBuffer(buffer);
+    clipboard.writeImage(image);
+
+    const slug = this.urlToSlug(currentUrl);
+    const timestamp = Date.now();
+    const filename = `tandem-${slug}-${timestamp}.png`;
+    const picturesPath = path.join(this.picturesDir, filename);
+    fs.writeFileSync(picturesPath, buffer);
+
+    const appPath = path.join(this.screenshotDir, filename);
+    fs.writeFileSync(appPath, buffer);
+    this.lastScreenshotPath = appPath;
+
+    this.importToApplePhotos(picturesPath);
+    void this.importToGooglePhotos(picturesPath);
+
+    return {
+      picturesPath,
+      appPath,
+      filename,
+      base64: buffer.toString('base64'),
+    };
+  }
+
   /**
    * Import screenshot into Apple Photos via osascript.
    * Runs async in background — never blocks the screenshot flow.
@@ -348,29 +380,5 @@ export class DrawOverlayManager {
     } catch (error) {
       log.warn('📸 Google Photos upload failed:', error instanceof Error ? error.message : String(error));
     }
-  }
-
-  /** Get last annotated screenshot as PNG buffer */
-  getLastScreenshot(): Buffer | null {
-    if (!this.lastScreenshotPath || !fs.existsSync(this.lastScreenshotPath)) {
-      return null;
-    }
-    return fs.readFileSync(this.lastScreenshotPath);
-  }
-
-  /** Get screenshot directory */
-  getScreenshotDir(): string {
-    return this.screenshotDir;
-  }
-
-  /** List recent screenshots */
-  listScreenshots(limit: number = 10): string[] {
-    if (!fs.existsSync(this.screenshotDir)) return [];
-    const files = fs.readdirSync(this.screenshotDir)
-      .filter(f => f.endsWith('.png'))
-      .sort()
-      .reverse()
-      .slice(0, limit);
-    return files.map(f => path.join(this.screenshotDir, f));
   }
 }

--- a/src/integrations/google-photos.ts
+++ b/src/integrations/google-photos.ts
@@ -13,6 +13,8 @@ const GOOGLE_PHOTOS_UPLOAD_URL = 'https://photoslibrary.googleapis.com/v1/upload
 const GOOGLE_PHOTOS_BATCH_CREATE_URL = 'https://photoslibrary.googleapis.com/v1/mediaItems:batchCreate';
 const GOOGLE_PHOTOS_SCOPE = 'https://www.googleapis.com/auth/photoslibrary.appendonly';
 
+// ─── Types ───
+
 interface GooglePhotosAuth {
   accessToken: string;
   refreshToken?: string;
@@ -68,12 +70,19 @@ function parseJsonFile<T>(filePath: string): T | null {
   }
 }
 
+// ─── Manager ───
+
+/**
+ * GooglePhotosManager — Handles Google Photos OAuth and screenshot uploads.
+ */
 export class GooglePhotosManager {
+  // === 1. Private state ===
   private configManager: ConfigManager;
   private configPath: string;
   private authPath: string;
   private pendingAuth: PendingAuth | null = null;
 
+  // === 2. Constructor ===
   constructor(configManager: ConfigManager) {
     this.configManager = configManager;
     const baseDir = tandemDir();
@@ -83,6 +92,8 @@ export class GooglePhotosManager {
     this.configPath = path.join(baseDir, 'google-photos.json');
     this.authPath = path.join(baseDir, 'google-photos-auth.json');
   }
+
+  // === 4. Public methods ===
 
   /** Get the current connection and configuration status. */
   getStatus(): GooglePhotosStatus {
@@ -272,6 +283,8 @@ export class GooglePhotosManager {
       productUrl: result.mediaItem.productUrl,
     };
   }
+
+  // === 7. Private helpers ===
 
   private getRedirectUri(): string {
     return `http://127.0.0.1:${API_PORT}/google-photos/oauth/callback`;

--- a/src/network/inspector.ts
+++ b/src/network/inspector.ts
@@ -7,6 +7,8 @@ import { createLogger } from '../utils/logger';
 
 const log = createLogger('NetworkInspector');
 
+// ─── Types ───
+
 export interface NetworkRequest {
   id: number;
   url: string;
@@ -93,6 +95,8 @@ export interface HarExport {
   };
 }
 
+// ─── Manager ───
+
 /**
  * NetworkInspector — Logs and analyzes network traffic via RequestDispatcher.
  *
@@ -100,6 +104,7 @@ export interface HarExport {
  * Stores last 1000 requests in memory, flushes per-domain data to ~/.tandem/network/.
  */
 export class NetworkInspector {
+  // === 1. Private state ===
   private requests: NetworkRequest[] = [];
   private pendingRequests: Map<string, Partial<NetworkRequest>> = new Map();
   private counter = 0;
@@ -107,12 +112,15 @@ export class NetworkInspector {
   private networkDir: string;
   private domainStats: Map<string, DomainData> = new Map();
 
+  // === 2. Constructor ===
   constructor() {
     this.networkDir = tandemDir('network');
     if (!fs.existsSync(this.networkDir)) {
       fs.mkdirSync(this.networkDir, { recursive: true });
     }
   }
+
+  // === 3. Dependency setters ===
 
   /** Register as a dispatcher consumer (late registration supported) */
   registerWith(dispatcher: RequestDispatcher): void {
@@ -207,71 +215,7 @@ export class NetworkInspector {
     });
   }
 
-  /** Add a completed request to the log */
-  private addRequest(req: NetworkRequest): void {
-    this.requests.push(req);
-    if (this.requests.length > this.maxRequests) {
-      this.requests = this.requests.slice(-this.maxRequests);
-    }
-
-    // Update domain stats
-    let domainData = this.domainStats.get(req.domain);
-    if (!domainData) {
-      domainData = { domain: req.domain, requests: 0, apis: [], lastSeen: 0 };
-      this.domainStats.set(req.domain, domainData);
-    }
-    domainData.requests++;
-    domainData.lastSeen = req.timestamp;
-
-    // Auto-discover API endpoints
-    if (this.isApiEndpoint(req)) {
-      const apiPath = this.extractApiPath(req.url);
-      if (apiPath && !domainData.apis.includes(apiPath)) {
-        domainData.apis.push(apiPath);
-      }
-    }
-  }
-
-  /** Check if a request looks like an API call */
-  private isApiEndpoint(req: NetworkRequest): boolean {
-    const ct = req.contentType.toLowerCase();
-    const url = req.url.toLowerCase();
-
-    // JSON responses
-    if (ct.includes('application/json')) return true;
-    // Known API path patterns
-    if (url.includes('/api/') || url.includes('/v1/') || url.includes('/v2/') || url.includes('/v3/')) return true;
-    if (url.includes('/graphql')) return true;
-    if (url.includes('/rest/')) return true;
-    // XHR-like endpoints
-    if (ct.includes('application/xml') && !url.endsWith('.xml')) return true;
-
-    return false;
-  }
-
-  /** Extract a normalized API path from a URL */
-  private extractApiPath(url: string): string {
-    try {
-      const parsed = new URL(url);
-      // Remove query params, normalize
-      let p = parsed.pathname;
-      // Replace UUIDs and numeric IDs with placeholders
-      p = p.replace(/\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, '/{uuid}');
-      p = p.replace(/\/\d+/g, '/{id}');
-      return p;
-    } catch {
-      return '';
-    }
-  }
-
-  /** Extract domain from URL */
-  private extractDomain(url: string): string {
-    try {
-      return new URL(url).hostname;
-    } catch {
-      return '';
-    }
-  }
+  // === 4. Public methods ===
 
   /** Flush domain data to disk (call on navigation away) */
   flushDomain(domain: string): void {
@@ -371,10 +315,80 @@ export class NetworkInspector {
     this.domainStats.clear();
   }
 
+  // === 6. Cleanup ===
+
   /** Destroy — flush all domains */
   destroy(): void {
     for (const domain of this.domainStats.keys()) {
       this.flushDomain(domain);
+    }
+  }
+
+  // === 7. Private helpers ===
+
+  /** Add a completed request to the log */
+  private addRequest(req: NetworkRequest): void {
+    this.requests.push(req);
+    if (this.requests.length > this.maxRequests) {
+      this.requests = this.requests.slice(-this.maxRequests);
+    }
+
+    // Update domain stats
+    let domainData = this.domainStats.get(req.domain);
+    if (!domainData) {
+      domainData = { domain: req.domain, requests: 0, apis: [], lastSeen: 0 };
+      this.domainStats.set(req.domain, domainData);
+    }
+    domainData.requests++;
+    domainData.lastSeen = req.timestamp;
+
+    // Auto-discover API endpoints
+    if (this.isApiEndpoint(req)) {
+      const apiPath = this.extractApiPath(req.url);
+      if (apiPath && !domainData.apis.includes(apiPath)) {
+        domainData.apis.push(apiPath);
+      }
+    }
+  }
+
+  /** Check if a request looks like an API call */
+  private isApiEndpoint(req: NetworkRequest): boolean {
+    const ct = req.contentType.toLowerCase();
+    const url = req.url.toLowerCase();
+
+    // JSON responses
+    if (ct.includes('application/json')) return true;
+    // Known API path patterns
+    if (url.includes('/api/') || url.includes('/v1/') || url.includes('/v2/') || url.includes('/v3/')) return true;
+    if (url.includes('/graphql')) return true;
+    if (url.includes('/rest/')) return true;
+    // XHR-like endpoints
+    if (ct.includes('application/xml') && !url.endsWith('.xml')) return true;
+
+    return false;
+  }
+
+  /** Extract a normalized API path from a URL */
+  private extractApiPath(url: string): string {
+    try {
+      const parsed = new URL(url);
+      // Remove query params, normalize
+      let p = parsed.pathname;
+      // Replace UUIDs and numeric IDs with placeholders
+      p = p.replace(/\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi, '/{uuid}');
+      p = p.replace(/\/\d+/g, '/{id}');
+      return p;
+    } catch {
+      return '';
+    }
+  }
+
+  /** Extract domain from URL */
+  private extractDomain(url: string): string {
+    try {
+      return new URL(url).hostname;
+    } catch {
+      return '';
     }
   }
 

--- a/src/stealth/manager.ts
+++ b/src/stealth/manager.ts
@@ -6,9 +6,11 @@ import { isGoogleAuthUrl } from '../utils/security';
 
 const log = createLogger('StealthManager');
 
+// ─── Manager ───
+
 /**
  * StealthManager — Makes Tandem Browser look like a regular human browser.
- * 
+ *
  * Anti-detection measures:
  * 1. Realistic User-Agent (matches real Chrome)
  * 2. Remove automation indicators
@@ -17,12 +19,14 @@ const log = createLogger('StealthManager');
  * 5. Realistic request headers
  */
 export class StealthManager {
+  // === 1. Private state ===
   private session: Session;
   private partitionSeed: string;
   private readonly originalUserAgent: string;
   private readonly USER_AGENT: string;
   private readonly chromeMajor: string;
 
+  // === 2. Constructor ===
   constructor(session: Session, partition: string = 'persist:tandem') {
     this.session = session;
     // Store the real Electron UA before overwriting — needed for Google auth
@@ -36,6 +40,8 @@ export class StealthManager {
     this.USER_AGENT =
       `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${chromeVersion} Safari/537.36`;
   }
+
+  // === 4. Public methods ===
 
   /** Apply stealth patches to the Electron session (User-Agent override). */
   async apply(): Promise<void> {
@@ -307,7 +313,7 @@ export class StealthManager {
 
       // Hide webdriver flag
       Object.defineProperty(navigator, 'webdriver', { get: () => false });
-      
+
       // Hide Electron from plugins
       Object.defineProperty(navigator, 'plugins', {
         get: () => [


### PR DESCRIPTION
## Summary
- Add 7-section comment headers (`Private state`, `Constructor`, `Dependency setters`, `Public methods`, `Sync integration`, `Cleanup`, `Private helpers`) to 7 large manager files
- Add `// ─── Types ───` and `// ─── Manager ───` section dividers above classes where applicable
- Reorder methods to match the standard pattern (public methods before private helpers, destroy in cleanup section)
- No logic, method signatures, or public API changes

## Files refactored
1. `src/draw/overlay.ts` (DrawOverlayManager)
2. `src/integrations/google-photos.ts` (GooglePhotosManager)
3. `src/config/manager.ts` (ConfigManager)
4. `src/stealth/manager.ts` (StealthManager)
5. `src/network/inspector.ts` (NetworkInspector)
6. `src/content/extractor.ts` (ContentExtractor)
7. `src/auth/login-manager.ts` (LoginManager)

## Test plan
- [x] `npm run compile` passes
- [x] `npm run lint` passes (0 errors)
- [x] `npm test` passes (1871 tests, 87 suites)
- [x] `npm run check-consistency` passes