### PR TITLE
refactor: align remaining large managers with standard pattern (P3-01 batch 5)

### DIFF
--- a/src/activity/wingman-stream.ts
+++ b/src/activity/wingman-stream.ts
@@ -1,5 +1,7 @@
 import type { ConfigManager } from '../config/manager';
 
+// ─── Types ───────────────────────────────────────────────────────────────────
+
 interface WingmanEvent {
   type: string;
   tabId: string;
@@ -7,23 +9,28 @@ interface WingmanEvent {
   data: Record<string, unknown>;
 }
 
+// ─── Manager ─────────────────────────────────────────────────────────────────
+
 /**
- * WingmanStream — Pushes real-time activity events to OpenClaw
- * so the AI wingman can see what the human is doing in Tandem.
- *
- * Same webhook pattern as PanelManager.fireWebhook().
- * Non-blocking, silent fail if OpenClaw is not running.
+ * WingmanStream — Pushes real-time activity events to OpenClaw.
  */
 export class WingmanStream {
+
+  // === 1. Private state ===
+
   private configManager: ConfigManager;
   private debounceTimers: Map<string, NodeJS.Timeout> = new Map();
   private enabled: boolean = true;
   private eventCount: number = 0;
   private rateLimitResetTime: number = 0;
 
+  // === 2. Constructor ===
+
   constructor(configManager: ConfigManager) {
     this.configManager = configManager;
   }
+
+  // === 4. Public methods ===
 
   /** Send event to OpenClaw (non-blocking) */
   async emit(event: WingmanEvent): Promise<void> {
@@ -76,6 +83,28 @@ export class WingmanStream {
     }, delayMs));
   }
 
+  /** Toggle stream on/off */
+  setEnabled(enabled: boolean): void {
+    this.enabled = enabled;
+  }
+
+  /** Check if stream is enabled */
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  // === 6. Cleanup ===
+
+  /** Cleanup timers */
+  destroy(): void {
+    for (const timer of this.debounceTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.debounceTimers.clear();
+  }
+
+  // === 7. Private helpers ===
+
   /** Format event as readable text for the AI wingman */
   private formatEventText(event: WingmanEvent): string {
     switch (event.type) {
@@ -98,23 +127,5 @@ export class WingmanStream {
       default:
         return `[Tandem] Activity: ${event.type}`;
     }
-  }
-
-  /** Toggle stream on/off */
-  setEnabled(enabled: boolean): void {
-    this.enabled = enabled;
-  }
-
-  /** Check if stream is enabled */
-  isEnabled(): boolean {
-    return this.enabled;
-  }
-
-  /** Cleanup timers */
-  destroy(): void {
-    for (const timer of this.debounceTimers.values()) {
-      clearTimeout(timer);
-    }
-    this.debounceTimers.clear();
   }
 }

--- a/src/agents/tab-lock-manager.ts
+++ b/src/agents/tab-lock-manager.ts
@@ -1,14 +1,6 @@
-/**
- * TabLockManager — Prevents multiple agents from controlling the same tab (Phase 5)
- *
- * Simple lock mechanism:
- * - First agent to claim a tab gets the lock
- * - Robin always has priority (can override any lock)
- * - Locks timeout after 60 seconds to prevent abandoned locks
- * - Fail-safe: if lock not acquired, returns clear error (never crashes)
- */
-
 import { EventEmitter } from 'events';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
 
 export interface TabLock {
   tabId: string;
@@ -19,14 +11,26 @@ export interface TabLock {
 
 const DEFAULT_LOCK_TIMEOUT_MS = 60_000; // 60 seconds
 
+// ─── Manager ─────────────────────────────────────────────────────────────────
+
+/**
+ * TabLockManager — Prevents multiple agents from controlling the same tab.
+ */
 export class TabLockManager extends EventEmitter {
+
+  // === 1. Private state ===
+
   private locks: Map<string, TabLock> = new Map();
   private lockTimeoutMs: number;
+
+  // === 2. Constructor ===
 
   constructor(lockTimeoutMs = DEFAULT_LOCK_TIMEOUT_MS) {
     super();
     this.lockTimeoutMs = lockTimeoutMs;
   }
+
+  // === 4. Public methods ===
 
   /**
    * Try to acquire a lock on a tab for an agent.
@@ -124,6 +128,18 @@ export class TabLockManager extends EventEmitter {
     return released;
   }
 
+  // === 6. Cleanup ===
+
+  /**
+   * Cleanup: release all locks.
+   */
+  destroy(): void {
+    this.locks.clear();
+    this.removeAllListeners();
+  }
+
+  // === 7. Private helpers ===
+
   /**
    * Remove all expired locks.
    */
@@ -135,13 +151,5 @@ export class TabLockManager extends EventEmitter {
         this.emit('lock-expired', { tabId, agentId: lock.agentId });
       }
     }
-  }
-
-  /**
-   * Cleanup: release all locks.
-   */
-  destroy(): void {
-    this.locks.clear();
-    this.removeAllListeners();
   }
 }

--- a/src/agents/task-manager.ts
+++ b/src/agents/task-manager.ts
@@ -16,9 +16,7 @@ import { EventEmitter } from 'events';
 import { tandemDir, ensureDir } from '../utils/paths';
 import { assertSinglePathSegment, hostnameMatches, resolvePathWithinRoot, tryParseUrl } from '../utils/security';
 
-// ═══════════════════════════════════════════════
-// Interfaces
-// ═══════════════════════════════════════════════
+// ─── Types ───────────────────────────────────────────────────────────────────
 
 export type RiskLevel = 'none' | 'low' | 'medium' | 'high';
 export type TaskStatus = 'pending' | 'running' | 'paused' | 'waiting-approval' | 'done' | 'failed' | 'cancelled';
@@ -70,9 +68,7 @@ export interface AutonomySettings {
   trustedSites: string[];
 }
 
-// ═══════════════════════════════════════════════
-// Risk assessment
-// ═══════════════════════════════════════════════
+// ── Risk assessment ──
 
 const ACTION_RISK: Record<string, RiskLevel> = {
   'read_page': 'none',
@@ -100,9 +96,7 @@ export function getRiskLevel(actionType: string): RiskLevel {
   return ACTION_RISK[actionType] || 'medium';
 }
 
-// ═══════════════════════════════════════════════
-// TaskManager
-// ═══════════════════════════════════════════════
+// ── Defaults & sanitizers ──
 
 const DEFAULT_AUTONOMY: AutonomySettings = {
   autoApproveRead: true,
@@ -142,11 +136,21 @@ function sanitizeAutonomySettings(raw: unknown, base: AutonomySettings = DEFAULT
   };
 }
 
+// ─── Manager ─────────────────────────────────────────────────────────────────
+
+/**
+ * TaskManager — Manages AI tasks, approval workflow, risk assessment, and emergency stop.
+ */
 export class TaskManager extends EventEmitter {
+
+  // === 1. Private state ===
+
   private tasksDir: string;
   private activityLog: TaskActivityEntry[] = [];
   private emergencyStopped = false;
   private autonomy: AutonomySettings;
+
+  // === 2. Constructor ===
 
   constructor() {
     super();
@@ -155,25 +159,9 @@ export class TaskManager extends EventEmitter {
     this.activityLog = this.loadActivityLog();
   }
 
+  // === 4. Public methods ===
+
   // ── Autonomy Settings ──
-
-  private loadAutonomySettings(): AutonomySettings {
-    const settingsPath = tandemDir('autonomy-settings.json');
-    try {
-      if (fs.existsSync(settingsPath)) {
-        const raw = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
-        return sanitizeAutonomySettings(raw);
-      }
-    } catch { /* use defaults */ }
-    return { ...DEFAULT_AUTONOMY };
-  }
-
-  private saveAutonomySettings(): void {
-    const settingsPath = tandemDir('autonomy-settings.json');
-    try {
-      fs.writeFileSync(settingsPath, JSON.stringify(this.autonomy, null, 2));
-    } catch { /* silent */ }
-  }
 
   getAutonomySettings(): AutonomySettings {
     return { ...this.autonomy };
@@ -183,15 +171,6 @@ export class TaskManager extends EventEmitter {
     this.autonomy = sanitizeAutonomySettings(patch, this.autonomy);
     this.saveAutonomySettings();
     return this.getAutonomySettings();
-  }
-
-  private getTaskFilePath(taskId: string): string {
-    const safeTaskId = assertSinglePathSegment(taskId, 'task id');
-    return resolvePathWithinRoot(this.tasksDir, `${safeTaskId}.json`);
-  }
-
-  private isValidStepIndex(task: AITask, stepIndex: number): boolean {
-    return Number.isInteger(stepIndex) && stepIndex >= 0 && stepIndex < task.steps.length;
   }
 
   // ── Task CRUD ──
@@ -243,16 +222,6 @@ export class TaskManager extends EventEmitter {
       }
     } catch { /* empty */ }
     return tasks.sort((a, b) => b.createdAt - a.createdAt);
-  }
-
-  private saveTask(task: AITask): void {
-    task.updatedAt = Date.now();
-    try {
-      fs.writeFileSync(
-        this.getTaskFilePath(task.id),
-        JSON.stringify(task, null, 2)
-      );
-    } catch { /* silent */ }
   }
 
   // ── Approval Logic ──
@@ -474,6 +443,62 @@ export class TaskManager extends EventEmitter {
 
   // ── Activity Log ──
 
+  logActivity(entry: TaskActivityEntry): void {
+    this.activityLog.push(entry);
+    this.saveActivityLog();
+    this.emit('activity', entry);
+  }
+
+  getActivityLog(limit = 50): TaskActivityEntry[] {
+    return this.activityLog.slice(-limit);
+  }
+
+  // === 6. Cleanup ===
+
+  destroy(): void {
+    this.emergencyStop();
+    this.removeAllListeners();
+  }
+
+  // === 7. Private helpers ===
+
+  private loadAutonomySettings(): AutonomySettings {
+    const settingsPath = tandemDir('autonomy-settings.json');
+    try {
+      if (fs.existsSync(settingsPath)) {
+        const raw = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+        return sanitizeAutonomySettings(raw);
+      }
+    } catch { /* use defaults */ }
+    return { ...DEFAULT_AUTONOMY };
+  }
+
+  private saveAutonomySettings(): void {
+    const settingsPath = tandemDir('autonomy-settings.json');
+    try {
+      fs.writeFileSync(settingsPath, JSON.stringify(this.autonomy, null, 2));
+    } catch { /* silent */ }
+  }
+
+  private getTaskFilePath(taskId: string): string {
+    const safeTaskId = assertSinglePathSegment(taskId, 'task id');
+    return resolvePathWithinRoot(this.tasksDir, `${safeTaskId}.json`);
+  }
+
+  private isValidStepIndex(task: AITask, stepIndex: number): boolean {
+    return Number.isInteger(stepIndex) && stepIndex >= 0 && stepIndex < task.steps.length;
+  }
+
+  private saveTask(task: AITask): void {
+    task.updatedAt = Date.now();
+    try {
+      fs.writeFileSync(
+        this.getTaskFilePath(task.id),
+        JSON.stringify(task, null, 2)
+      );
+    } catch { /* silent */ }
+  }
+
   private loadActivityLog(): TaskActivityEntry[] {
     const logPath = tandemDir('activity-log.json');
     try {
@@ -493,22 +518,5 @@ export class TaskManager extends EventEmitter {
       const trimmed = this.activityLog.slice(-500);
       fs.writeFileSync(logPath, JSON.stringify(trimmed, null, 2));
     } catch { /* silent */ }
-  }
-
-  logActivity(entry: TaskActivityEntry): void {
-    this.activityLog.push(entry);
-    this.saveActivityLog();
-    this.emit('activity', entry);
-  }
-
-  getActivityLog(limit = 50): TaskActivityEntry[] {
-    return this.activityLog.slice(-limit);
-  }
-
-  // ── Cleanup ──
-
-  destroy(): void {
-    this.emergencyStop();
-    this.removeAllListeners();
   }
 }

--- a/src/devtools/manager.ts
+++ b/src/devtools/manager.ts
@@ -15,10 +15,14 @@ const log = createLogger('CDP');
 
 export type { CDPSubscriber };
 
+// ─── Types ───────────────────────────────────────────────────────────────────
+
 interface AttachedSession {
   messageHandler: (_event: Electron.Event, method: string, params: Record<string, unknown>) => void;
   detachHandler: (_event: Electron.Event, reason: string) => void;
 }
+
+// ─── Manager ─────────────────────────────────────────────────────────────────
 
 /**
  * DevToolsManager — Provides CDP (Chrome DevTools Protocol) access to webview tabs.
@@ -38,6 +42,9 @@ interface AttachedSession {
  *   and our attach() will fail — we handle this gracefully
  */
 export class DevToolsManager {
+
+  // === 1. Private state ===
+
   private tabManager: TabManager;
   private wingmanStream?: WingmanStream;
   private activityTracker?: ActivityTracker;
@@ -55,12 +62,16 @@ export class DevToolsManager {
   // CDP subscriber system (Phase 3: security modules subscribe to events)
   private subscribers: CDPSubscriber[] = [];
 
+  // === 2. Constructor ===
+
   constructor(tabManager: TabManager) {
     this.tabManager = tabManager;
     this.consoleCapture = new ConsoleCapture();
     this.networkCapture = new NetworkCapture(() => this.ensureAttached());
     this.pageInspector = new PageInspector(() => this.ensureAttached());
   }
+
+  // === 3. Dependency setters ===
 
   setWingmanStream(stream: WingmanStream): void {
     this.wingmanStream = stream;
@@ -70,7 +81,9 @@ export class DevToolsManager {
     this.activityTracker = tracker;
   }
 
-  // ═══ CDP Subscriber System (Phase 3) ═══
+  // === 4. Public methods ===
+
+  // ── CDP Subscriber System (Phase 3) ──
 
   /** Register a subscriber to receive specific CDP events */
   subscribe(subscriber: CDPSubscriber): void {
@@ -118,7 +131,7 @@ export class DevToolsManager {
     return this.getAttachedWebContents(this.dispatchWcId);
   }
 
-  // ═══ Lifecycle ═══
+  // ── Lifecycle ──
 
   /**
    * Ensure the debugger is attached to the active tab.
@@ -143,6 +156,188 @@ export class DevToolsManager {
 
     return this.attach(wc, { makePrimary: opts?.makePrimary ?? true });
   }
+
+  detachFromTab(wcId: number, opts?: { skipDebuggerDetach?: boolean }): void {
+    const session = this.attachedSessions.get(wcId);
+    if (!session) return;
+    try {
+      const wc = webContents.fromId(wcId);
+      if (wc && !wc.isDestroyed()) {
+        wc.debugger.removeListener('message', session.messageHandler);
+        wc.debugger.removeListener('detach', session.detachHandler);
+      }
+      if (!opts?.skipDebuggerDetach && wc && !wc.isDestroyed() && wc.debugger.isAttached()) {
+        wc.debugger.detach();
+      }
+    } catch (e) {
+      log.warn('CDP detach error (harmless):', e instanceof Error ? e.message : e);
+    }
+    this.attachedSessions.delete(wcId);
+    if (this.primaryWcId === wcId) {
+      this.primaryWcId = null;
+    }
+  }
+
+  // ── Delegated: Console (→ ConsoleCapture) ──
+
+  getConsoleEntries(opts?: { level?: string; sinceId?: number; limit?: number; search?: string }): ConsoleEntry[] {
+    return this.consoleCapture.getEntries(opts);
+  }
+
+  getConsoleErrors(limit?: number): ConsoleEntry[] {
+    return this.consoleCapture.getErrors(limit);
+  }
+
+  getConsoleCounts(): Record<string, number> {
+    return this.consoleCapture.getCounts();
+  }
+
+  clearConsole(): void {
+    this.consoleCapture.clear();
+  }
+
+  // ── Delegated: Network (→ NetworkCapture) ──
+
+  getNetworkEntries(opts?: {
+    limit?: number;
+    domain?: string;
+    type?: string;
+    statusMin?: number;
+    statusMax?: number;
+    failed?: boolean;
+    search?: string;
+  }): CDPNetworkEntry[] {
+    return this.networkCapture.getEntries(opts);
+  }
+
+  async getResponseBody(requestId: string): Promise<{ body: string; base64Encoded: boolean } | null> {
+    return this.networkCapture.getResponseBody(requestId);
+  }
+
+  clearNetwork(): void {
+    this.networkCapture.clear();
+  }
+
+  // ── Delegated: Page Inspection (→ PageInspector) ──
+
+  async queryDOM(selector: string, maxResults = 10): Promise<DOMNodeInfo[]> {
+    return this.pageInspector.queryDOM(selector, maxResults);
+  }
+
+  async queryXPath(expression: string, maxResults = 10): Promise<DOMNodeInfo[]> {
+    return this.pageInspector.queryXPath(expression, maxResults);
+  }
+
+  async getStorage(): Promise<StorageData> {
+    return this.pageInspector.getStorage();
+  }
+
+  async getPerformanceMetrics(): Promise<PerformanceMetrics | null> {
+    return this.pageInspector.getPerformanceMetrics();
+  }
+
+  async screenshotElement(selector: string): Promise<Buffer | null> {
+    return this.pageInspector.screenshotElement(selector);
+  }
+
+  // ── Raw CDP ──
+
+  /** Send an arbitrary CDP command (for advanced use) */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- CDP command payloads are heterogeneous and caller-defined
+  async sendCommand(method: string, params?: Record<string, any>): Promise<any> {
+    const wc = await this.ensureAttached();
+    if (!wc) throw new Error('No active tab or CDP attach failed');
+
+    return wc.debugger.sendCommand(method, params || {});
+  }
+
+  /** Send a CDP command to a specific attached tab without switching the primary target. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- CDP command payloads are heterogeneous and caller-defined
+  async sendCommandToTab(wcId: number, method: string, params?: Record<string, any>): Promise<any> {
+    const wc = await this.attachToTab(wcId, { makePrimary: false });
+    if (!wc) throw new Error(`No tab for webContents ${wcId} or CDP attach failed`);
+
+    return wc.debugger.sendCommand(method, params || {});
+  }
+
+  // ── Evaluate ──
+
+  /** Evaluate JavaScript in the page context via CDP (more powerful than executeJS) */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Runtime.evaluate returns arbitrary page values
+  async evaluate(expression: string, opts?: { returnByValue?: boolean; awaitPromise?: boolean }): Promise<any> {
+    const wc = await this.ensureAttached();
+    if (!wc) throw new Error('No active tab or CDP attach failed');
+
+    const result = await wc.debugger.sendCommand('Runtime.evaluate', {
+      expression,
+      returnByValue: opts?.returnByValue ?? true,
+      awaitPromise: opts?.awaitPromise ?? true,
+      generatePreview: true,
+    });
+
+    if (result.exceptionDetails) {
+      throw new Error(result.exceptionDetails.text || 'Evaluation failed');
+    }
+
+    return result.result?.value ?? result.result;
+  }
+
+  /** Evaluate JavaScript in a specific tab without switching the primary target. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Runtime.evaluate returns arbitrary page values
+  async evaluateInTab(wcId: number, expression: string, opts?: { returnByValue?: boolean; awaitPromise?: boolean }): Promise<any> {
+    const wc = await this.attachToTab(wcId, { makePrimary: false });
+    if (!wc) throw new Error(`No tab for webContents ${wcId} or CDP attach failed`);
+
+    const result = await wc.debugger.sendCommand('Runtime.evaluate', {
+      expression,
+      returnByValue: opts?.returnByValue ?? true,
+      awaitPromise: opts?.awaitPromise ?? true,
+      generatePreview: true,
+    });
+
+    if (result.exceptionDetails) {
+      throw new Error(result.exceptionDetails.text || 'Evaluation failed');
+    }
+
+    return result.result?.value ?? result.result;
+  }
+
+  // ── Status ──
+
+  getStatus(): {
+    attached: boolean;
+    tabId: string | null;
+    wcId: number | null;
+    console: { entries: number; errors: number; lastId: number };
+    network: { entries: number };
+  } {
+    const tabId = this.primaryWcId ? this.findTabIdByWcId(this.primaryWcId) || null : null;
+    return {
+      attached: this.primaryWcId !== null,
+      tabId,
+      wcId: this.primaryWcId,
+      console: {
+        entries: this.consoleCapture.entryCount,
+        errors: this.consoleCapture.getErrors().length,
+        lastId: this.consoleCapture.lastEntryId,
+      },
+      network: {
+        entries: this.networkCapture.entryCount,
+      },
+    };
+  }
+
+  // === 6. Cleanup ===
+
+  destroy(): void {
+    for (const wcId of Array.from(this.attachedSessions.keys())) {
+      this.detachFromTab(wcId);
+    }
+    this.consoleCapture.clear();
+    this.networkCapture.clear();
+  }
+
+  // === 7. Private helpers ===
 
   private async attach(wc: WebContents, opts?: { makePrimary?: boolean }): Promise<WebContents | null> {
     if (this.attachedSessions.has(wc.id)) {
@@ -287,27 +482,6 @@ export class DevToolsManager {
     }
   }
 
-  detachFromTab(wcId: number, opts?: { skipDebuggerDetach?: boolean }): void {
-    const session = this.attachedSessions.get(wcId);
-    if (!session) return;
-    try {
-      const wc = webContents.fromId(wcId);
-      if (wc && !wc.isDestroyed()) {
-        wc.debugger.removeListener('message', session.messageHandler);
-        wc.debugger.removeListener('detach', session.detachHandler);
-      }
-      if (!opts?.skipDebuggerDetach && wc && !wc.isDestroyed() && wc.debugger.isAttached()) {
-        wc.debugger.detach();
-      }
-    } catch (e) {
-      log.warn('CDP detach error (harmless):', e instanceof Error ? e.message : e);
-    }
-    this.attachedSessions.delete(wcId);
-    if (this.primaryWcId === wcId) {
-      this.primaryWcId = null;
-    }
-  }
-
   /** Route CDP events to sub-captures and subscribers */
   private handleCDPEvent(wcId: number, method: string, params: Record<string, unknown>): void {
     const previousDispatchWcId = this.dispatchWcId;
@@ -349,157 +523,6 @@ export class DevToolsManager {
       this.dispatchWcId = previousDispatchWcId;
     }
   }
-
-  // === Delegated: Console (→ ConsoleCapture) ===
-
-  getConsoleEntries(opts?: { level?: string; sinceId?: number; limit?: number; search?: string }): ConsoleEntry[] {
-    return this.consoleCapture.getEntries(opts);
-  }
-
-  getConsoleErrors(limit?: number): ConsoleEntry[] {
-    return this.consoleCapture.getErrors(limit);
-  }
-
-  getConsoleCounts(): Record<string, number> {
-    return this.consoleCapture.getCounts();
-  }
-
-  clearConsole(): void {
-    this.consoleCapture.clear();
-  }
-
-  // === Delegated: Network (→ NetworkCapture) ===
-
-  getNetworkEntries(opts?: {
-    limit?: number;
-    domain?: string;
-    type?: string;
-    statusMin?: number;
-    statusMax?: number;
-    failed?: boolean;
-    search?: string;
-  }): CDPNetworkEntry[] {
-    return this.networkCapture.getEntries(opts);
-  }
-
-  async getResponseBody(requestId: string): Promise<{ body: string; base64Encoded: boolean } | null> {
-    return this.networkCapture.getResponseBody(requestId);
-  }
-
-  clearNetwork(): void {
-    this.networkCapture.clear();
-  }
-
-  // === Delegated: Page Inspection (→ PageInspector) ===
-
-  async queryDOM(selector: string, maxResults = 10): Promise<DOMNodeInfo[]> {
-    return this.pageInspector.queryDOM(selector, maxResults);
-  }
-
-  async queryXPath(expression: string, maxResults = 10): Promise<DOMNodeInfo[]> {
-    return this.pageInspector.queryXPath(expression, maxResults);
-  }
-
-  async getStorage(): Promise<StorageData> {
-    return this.pageInspector.getStorage();
-  }
-
-  async getPerformanceMetrics(): Promise<PerformanceMetrics | null> {
-    return this.pageInspector.getPerformanceMetrics();
-  }
-
-  async screenshotElement(selector: string): Promise<Buffer | null> {
-    return this.pageInspector.screenshotElement(selector);
-  }
-
-  // ═══ Raw CDP ═══
-
-  /** Send an arbitrary CDP command (for advanced use) */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- CDP command payloads are heterogeneous and caller-defined
-  async sendCommand(method: string, params?: Record<string, any>): Promise<any> {
-    const wc = await this.ensureAttached();
-    if (!wc) throw new Error('No active tab or CDP attach failed');
-
-    return wc.debugger.sendCommand(method, params || {});
-  }
-
-  /** Send a CDP command to a specific attached tab without switching the primary target. */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- CDP command payloads are heterogeneous and caller-defined
-  async sendCommandToTab(wcId: number, method: string, params?: Record<string, any>): Promise<any> {
-    const wc = await this.attachToTab(wcId, { makePrimary: false });
-    if (!wc) throw new Error(`No tab for webContents ${wcId} or CDP attach failed`);
-
-    return wc.debugger.sendCommand(method, params || {});
-  }
-
-  // ═══ Evaluate ═══
-
-  /** Evaluate JavaScript in the page context via CDP (more powerful than executeJS) */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Runtime.evaluate returns arbitrary page values
-  async evaluate(expression: string, opts?: { returnByValue?: boolean; awaitPromise?: boolean }): Promise<any> {
-    const wc = await this.ensureAttached();
-    if (!wc) throw new Error('No active tab or CDP attach failed');
-
-    const result = await wc.debugger.sendCommand('Runtime.evaluate', {
-      expression,
-      returnByValue: opts?.returnByValue ?? true,
-      awaitPromise: opts?.awaitPromise ?? true,
-      generatePreview: true,
-    });
-
-    if (result.exceptionDetails) {
-      throw new Error(result.exceptionDetails.text || 'Evaluation failed');
-    }
-
-    return result.result?.value ?? result.result;
-  }
-
-  /** Evaluate JavaScript in a specific tab without switching the primary target. */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Runtime.evaluate returns arbitrary page values
-  async evaluateInTab(wcId: number, expression: string, opts?: { returnByValue?: boolean; awaitPromise?: boolean }): Promise<any> {
-    const wc = await this.attachToTab(wcId, { makePrimary: false });
-    if (!wc) throw new Error(`No tab for webContents ${wcId} or CDP attach failed`);
-
-    const result = await wc.debugger.sendCommand('Runtime.evaluate', {
-      expression,
-      returnByValue: opts?.returnByValue ?? true,
-      awaitPromise: opts?.awaitPromise ?? true,
-      generatePreview: true,
-    });
-
-    if (result.exceptionDetails) {
-      throw new Error(result.exceptionDetails.text || 'Evaluation failed');
-    }
-
-    return result.result?.value ?? result.result;
-  }
-
-  // ═══ Status ═══
-
-  getStatus(): {
-    attached: boolean;
-    tabId: string | null;
-    wcId: number | null;
-    console: { entries: number; errors: number; lastId: number };
-    network: { entries: number };
-  } {
-    const tabId = this.primaryWcId ? this.findTabIdByWcId(this.primaryWcId) || null : null;
-    return {
-      attached: this.primaryWcId !== null,
-      tabId,
-      wcId: this.primaryWcId,
-      console: {
-        entries: this.consoleCapture.entryCount,
-        errors: this.consoleCapture.getErrors().length,
-        lastId: this.consoleCapture.lastEntryId,
-      },
-      network: {
-        entries: this.networkCapture.entryCount,
-      },
-    };
-  }
-
-  // ═══ Wingman Vision ═══
 
   private onWingmanBinding(params: { name: string; payload: string }, tabId?: string, wcId?: number): void {
     if (!this.wingmanStream) return;
@@ -554,8 +577,6 @@ export class DevToolsManager {
     }
   }
 
-  // ═══ Helpers ═══
-
   private findTabId(wc: WebContents): string | undefined {
     return this.findTabIdByWcId(wc.id);
   }
@@ -563,15 +584,5 @@ export class DevToolsManager {
   private findTabIdByWcId(wcId: number): string | undefined {
     const tabs = this.tabManager.listTabs();
     return tabs.find(t => t.webContentsId === wcId)?.id;
-  }
-
-  // ═══ Cleanup ═══
-
-  destroy(): void {
-    for (const wcId of Array.from(this.attachedSessions.keys())) {
-      this.detachFromTab(wcId);
-    }
-    this.consoleCapture.clear();
-    this.networkCapture.clear();
   }
 }

--- a/src/extensions/manager.ts
+++ b/src/extensions/manager.ts
@@ -101,6 +101,8 @@ const EXTENSION_ROUTE_POLICIES: Record<string, ExtensionRoutePolicy> = {
   },
 };
 
+// ─── Manager ─────────────────────────────────────────────────────────────────
+
 /**
  * ExtensionManager — Central extension management layer.
  *
@@ -108,6 +110,9 @@ const EXTENSION_ROUTE_POLICIES: Record<string, ExtensionRoutePolicy> = {
  * into a single interface for install, uninstall, and metadata access.
  */
 export class ExtensionManager {
+
+  // === 1. Private state ===
+
   private loader: ExtensionLoader;
   private downloader: CrxDownloader;
   private nativeMessaging: NativeMessagingSetup;
@@ -115,6 +120,8 @@ export class ExtensionManager {
   private actionPolyfill: ActionPolyfill;
   private updateChecker: UpdateChecker;
   private conflictDetector: ConflictDetector;
+
+  // === 2. Constructor ===
 
   constructor(apiPort: number = API_PORT) {
     this.loader = new ExtensionLoader();
@@ -125,6 +132,8 @@ export class ExtensionManager {
     this.updateChecker = new UpdateChecker(this.downloader, this.loader);
     this.conflictDetector = new ConflictDetector();
   }
+
+  // === 4. Public methods ===
 
   /**
    * Initialize: load all existing extensions from ~/.tandem/extensions/.
@@ -364,6 +373,131 @@ export class ExtensionManager {
     return this.identityPolyfill;
   }
 
+  // ── Update Methods (Phase 9) ──
+
+  /** Get the update checker instance */
+  getUpdateChecker(): UpdateChecker {
+    return this.updateChecker;
+  }
+
+  /** Check all installed extensions for updates (batch protocol) */
+  async checkForUpdates(): Promise<UpdateCheckResult[]> {
+    const installed = this.updateChecker.getInstalledExtensions();
+    return this.updateChecker.checkAll(installed);
+  }
+
+  /** Apply update for a single extension */
+  async applyUpdate(extensionId: string, session: Session): Promise<UpdateResult> {
+    return this.updateChecker.updateOne(extensionId, session);
+  }
+
+  /** Apply all available updates */
+  async applyAllUpdates(session: Session): Promise<UpdateResult[]> {
+    return this.updateChecker.updateAll(session);
+  }
+
+  /** Get current update state */
+  getUpdateState(): UpdateState {
+    return this.updateChecker.getState();
+  }
+
+  /** Get next scheduled check time */
+  getNextScheduledCheck(): string | null {
+    return this.updateChecker.getNextScheduledCheck();
+  }
+
+  /** Get installed extensions list (for update checking) */
+  getInstalledExtensions(): InstalledExtension[] {
+    return this.updateChecker.getInstalledExtensions();
+  }
+
+  /** Get disk usage for all extensions */
+  getDiskUsage(): { totalBytes: number; extensions: Array<{ id: string; name: string; sizeBytes: number }> } {
+    return this.updateChecker.getDiskUsage();
+  }
+
+  // ── Conflict Detection Methods (Phase 10a) ──
+
+  /** Get the conflict detector instance */
+  getConflictDetector(): ConflictDetector {
+    return this.conflictDetector;
+  }
+
+  /** Analyze a single extension's manifest for conflicts */
+  getConflictsForExtension(extensionId: string): ExtensionConflict[] {
+    const extensionsDir = tandemDir('extensions');
+    const manifestPath = path.join(extensionsDir, extensionId, 'manifest.json');
+    return this.conflictDetector.analyzeManifest(manifestPath);
+  }
+
+  /** Get all conflicts across all installed extensions */
+  getAllConflicts(): { conflicts: ExtensionConflict[]; summary: { info: number; warnings: number; critical: number } } {
+    const conflicts = this.conflictDetector.getAllConflicts();
+    const summary = this.conflictDetector.getSummary(conflicts);
+    return { conflicts, summary };
+  }
+
+  // ── Isolated Session Loading (Phase 10a Foundation) ──
+
+  /**
+   * Load all installed extensions into a given Electron session.
+   *
+   * This is the foundation for loading extensions in isolated sessions
+   * (persist:session-{name}). Currently NOT wired into SessionManager —
+   * that requires careful consideration of:
+   * - Security stack: isolated sessions also need a RequestDispatcher + Guardian
+   * - Performance: loading 10+ extensions per session has startup cost
+   * - User preference: not all users want extensions in isolated sessions
+   *
+   * Future integration point: SessionManager.create() could call this method
+   * after setting up the security stack for the new session.
+   *
+   * @param session - The Electron session to load extensions into
+   * @returns Array of loaded extension names
+   */
+  async loadInSession(session: Session): Promise<string[]> {
+    const extensionsDir = tandemDir('extensions');
+    const loaded: string[] = [];
+
+    try {
+      const dirs = fs.readdirSync(extensionsDir, { withFileTypes: true })
+        .filter(d => d.isDirectory());
+
+      for (const dir of dirs) {
+        const extPath = path.join(extensionsDir, dir.name);
+        const manifestPath = path.join(extPath, 'manifest.json');
+
+        if (!fs.existsSync(manifestPath)) continue;
+
+        try {
+          const ext = await session.extensions.loadExtension(extPath, { allowFileAccess: true });
+          loaded.push(ext.name || dir.name);
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err);
+          log.warn(`⚠️ Failed to load extension ${dir.name} into session: ${message}`);
+        }
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.warn(`⚠️ Could not read extensions directory for session loading: ${message}`);
+    }
+
+    if (loaded.length > 0) {
+      log.info(`🧩 Loaded ${loaded.length} extension(s) into session: ${loaded.join(', ')}`);
+    }
+
+    return loaded;
+  }
+
+  // === 6. Cleanup ===
+
+  /** Stop update checker and clean up */
+  destroyUpdateChecker(): void {
+    this.updateChecker.destroy();
+  }
+
+  // === 7. Private helpers ===
+
   private resolveInstalledExtension(extensionId: string): ResolvedExtensionIdentity | null {
     const { loaded, available } = this.list();
     const loadedMatch = loaded.find((extension) =>
@@ -487,126 +621,5 @@ export class ExtensionManager {
       permissions,
       auditLabel: `${labelBase} [${level}${idParts.length > 0 ? `; ${idParts.join(', ')}` : ''}]`,
     };
-  }
-
-  // ─── Update Methods (Phase 9) ──────────────────────────────────────────
-
-  /** Get the update checker instance */
-  getUpdateChecker(): UpdateChecker {
-    return this.updateChecker;
-  }
-
-  /** Check all installed extensions for updates (batch protocol) */
-  async checkForUpdates(): Promise<UpdateCheckResult[]> {
-    const installed = this.updateChecker.getInstalledExtensions();
-    return this.updateChecker.checkAll(installed);
-  }
-
-  /** Apply update for a single extension */
-  async applyUpdate(extensionId: string, session: Session): Promise<UpdateResult> {
-    return this.updateChecker.updateOne(extensionId, session);
-  }
-
-  /** Apply all available updates */
-  async applyAllUpdates(session: Session): Promise<UpdateResult[]> {
-    return this.updateChecker.updateAll(session);
-  }
-
-  /** Get current update state */
-  getUpdateState(): UpdateState {
-    return this.updateChecker.getState();
-  }
-
-  /** Get next scheduled check time */
-  getNextScheduledCheck(): string | null {
-    return this.updateChecker.getNextScheduledCheck();
-  }
-
-  /** Get installed extensions list (for update checking) */
-  getInstalledExtensions(): InstalledExtension[] {
-    return this.updateChecker.getInstalledExtensions();
-  }
-
-  /** Get disk usage for all extensions */
-  getDiskUsage(): { totalBytes: number; extensions: Array<{ id: string; name: string; sizeBytes: number }> } {
-    return this.updateChecker.getDiskUsage();
-  }
-
-  /** Stop update checker and clean up */
-  destroyUpdateChecker(): void {
-    this.updateChecker.destroy();
-  }
-
-  // ─── Conflict Detection Methods (Phase 10a) ──────────────────────────
-
-  /** Get the conflict detector instance */
-  getConflictDetector(): ConflictDetector {
-    return this.conflictDetector;
-  }
-
-  /** Analyze a single extension's manifest for conflicts */
-  getConflictsForExtension(extensionId: string): ExtensionConflict[] {
-    const extensionsDir = tandemDir('extensions');
-    const manifestPath = path.join(extensionsDir, extensionId, 'manifest.json');
-    return this.conflictDetector.analyzeManifest(manifestPath);
-  }
-
-  /** Get all conflicts across all installed extensions */
-  getAllConflicts(): { conflicts: ExtensionConflict[]; summary: { info: number; warnings: number; critical: number } } {
-    const conflicts = this.conflictDetector.getAllConflicts();
-    const summary = this.conflictDetector.getSummary(conflicts);
-    return { conflicts, summary };
-  }
-
-  // ─── Isolated Session Loading (Phase 10a Foundation) ──────────────────
-
-  /**
-   * Load all installed extensions into a given Electron session.
-   *
-   * This is the foundation for loading extensions in isolated sessions
-   * (persist:session-{name}). Currently NOT wired into SessionManager —
-   * that requires careful consideration of:
-   * - Security stack: isolated sessions also need a RequestDispatcher + Guardian
-   * - Performance: loading 10+ extensions per session has startup cost
-   * - User preference: not all users want extensions in isolated sessions
-   *
-   * Future integration point: SessionManager.create() could call this method
-   * after setting up the security stack for the new session.
-   *
-   * @param session - The Electron session to load extensions into
-   * @returns Array of loaded extension names
-   */
-  async loadInSession(session: Session): Promise<string[]> {
-    const extensionsDir = tandemDir('extensions');
-    const loaded: string[] = [];
-
-    try {
-      const dirs = fs.readdirSync(extensionsDir, { withFileTypes: true })
-        .filter(d => d.isDirectory());
-
-      for (const dir of dirs) {
-        const extPath = path.join(extensionsDir, dir.name);
-        const manifestPath = path.join(extPath, 'manifest.json');
-
-        if (!fs.existsSync(manifestPath)) continue;
-
-        try {
-          const ext = await session.extensions.loadExtension(extPath, { allowFileAccess: true });
-          loaded.push(ext.name || dir.name);
-        } catch (err: unknown) {
-          const message = err instanceof Error ? err.message : String(err);
-          log.warn(`⚠️ Failed to load extension ${dir.name} into session: ${message}`);
-        }
-      }
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : String(err);
-      log.warn(`⚠️ Could not read extensions directory for session loading: ${message}`);
-    }
-
-    if (loaded.length > 0) {
-      log.info(`🧩 Loaded ${loaded.length} extension(s) into session: ${loaded.join(', ')}`);
-    }
-
-    return loaded;
   }
 }

--- a/src/memory/form-memory.ts
+++ b/src/memory/form-memory.ts
@@ -4,6 +4,8 @@ import crypto from 'crypto';
 import { tandemDir } from '../utils/paths';
 import { resolvePathWithinRoot, tryParseUrl } from '../utils/security';
 
+// ─── Types ───────────────────────────────────────────────────────────────────
+
 export interface FormField {
   name: string;
   type: string;
@@ -27,17 +29,23 @@ export interface DomainFormData {
 // Sensitive field types that get encrypted
 const SENSITIVE_TYPES = ['password'];
 
+// ─── Manager ─────────────────────────────────────────────────────────────────
+
 /**
  * FormMemoryManager — Remembers every form the user fills in.
- * 
- * Stores form data per domain in ~/.tandem/forms/{domain}.json
+ *
+ * Stores form data per domain in ~/.tandem/forms/{domain}.json.
  * Sensitive fields (type=password) are AES-256-GCM encrypted.
- * Encryption key is stored/generated in ~/.tandem/config.json
  */
 export class FormMemoryManager {
+
+  // === 1. Private state ===
+
   private formsDir: string;
   private encryptionKey: Buffer | null = null;
   private configPath: string;
+
+  // === 2. Constructor ===
 
   constructor() {
     const baseDir = tandemDir();
@@ -51,92 +59,7 @@ export class FormMemoryManager {
     this.initEncryptionKey();
   }
 
-  /** Initialize or load the encryption key from config */
-  private initEncryptionKey(): void {
-    try {
-      let config: Record<string, unknown> = {};
-      if (fs.existsSync(this.configPath)) {
-        config = JSON.parse(fs.readFileSync(this.configPath, 'utf-8'));
-      }
-
-      if (config.formEncryptionKey && typeof config.formEncryptionKey === 'string') {
-        this.encryptionKey = Buffer.from(config.formEncryptionKey, 'hex');
-      } else {
-        // Generate new 256-bit key
-        this.encryptionKey = crypto.randomBytes(32);
-        config.formEncryptionKey = this.encryptionKey.toString('hex');
-        const configDir = path.dirname(this.configPath);
-        if (!fs.existsSync(configDir)) {
-          fs.mkdirSync(configDir, { recursive: true });
-        }
-        fs.writeFileSync(this.configPath, JSON.stringify(config, null, 2));
-      }
-    } catch {
-      // Fallback: generate ephemeral key (won't persist across restarts)
-      this.encryptionKey = crypto.randomBytes(32);
-    }
-  }
-
-  /** Encrypt a value with AES-256-GCM */
-  private encrypt(plaintext: string): string {
-    if (!this.encryptionKey) return plaintext;
-    const iv = crypto.randomBytes(12);
-    const cipher = crypto.createCipheriv('aes-256-gcm', this.encryptionKey, iv);
-    let encrypted = cipher.update(plaintext, 'utf8', 'hex');
-    encrypted += cipher.final('hex');
-    const authTag = cipher.getAuthTag().toString('hex');
-    return `${iv.toString('hex')}:${authTag}:${encrypted}`;
-  }
-
-  /** Decrypt a value with AES-256-GCM */
-  private decrypt(ciphertext: string): string {
-    if (!this.encryptionKey) return ciphertext;
-    try {
-      const parts = ciphertext.split(':');
-      if (parts.length !== 3) return ciphertext;
-      const iv = Buffer.from(parts[0], 'hex');
-      const authTag = Buffer.from(parts[1], 'hex');
-      const encrypted = parts[2];
-      const decipher = crypto.createDecipheriv('aes-256-gcm', this.encryptionKey, iv);
-      decipher.setAuthTag(authTag);
-      let decrypted = decipher.update(encrypted, 'hex', 'utf8');
-      decrypted += decipher.final('utf8');
-      return decrypted;
-    } catch {
-      return '[decryption failed]';
-    }
-  }
-
-  /** Extract domain from URL */
-  private getDomain(url: string): string {
-    const parsedUrl = tryParseUrl(url);
-    if (!parsedUrl) {
-      return 'unknown';
-    }
-    return parsedUrl.hostname;
-  }
-
-  /** Sanitize domain for filesystem */
-  private domainToFilename(domain: string): string {
-    return domain.replace(/[^a-zA-Z0-9.-]/g, '_') + '.json';
-  }
-
-  /** Load form data for a domain */
-  private loadDomain(domain: string): DomainFormData | null {
-    const filePath = resolvePathWithinRoot(this.formsDir, this.domainToFilename(domain));
-    if (!fs.existsSync(filePath)) return null;
-    try {
-      return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-    } catch {
-      return null;
-    }
-  }
-
-  /** Save form data for a domain */
-  private saveDomain(data: DomainFormData): void {
-    const filePath = resolvePathWithinRoot(this.formsDir, this.domainToFilename(data.domain));
-    fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
-  }
+  // === 4. Public methods ===
 
   /**
    * Record a form submission. Called when a form submit is detected.
@@ -257,5 +180,94 @@ export class FormMemoryManager {
   hasDataForUrl(url: string): boolean {
     const domain = this.getDomain(url);
     return this.loadDomain(domain) !== null;
+  }
+
+  // === 7. Private helpers ===
+
+  /** Initialize or load the encryption key from config */
+  private initEncryptionKey(): void {
+    try {
+      let config: Record<string, unknown> = {};
+      if (fs.existsSync(this.configPath)) {
+        config = JSON.parse(fs.readFileSync(this.configPath, 'utf-8'));
+      }
+
+      if (config.formEncryptionKey && typeof config.formEncryptionKey === 'string') {
+        this.encryptionKey = Buffer.from(config.formEncryptionKey, 'hex');
+      } else {
+        // Generate new 256-bit key
+        this.encryptionKey = crypto.randomBytes(32);
+        config.formEncryptionKey = this.encryptionKey.toString('hex');
+        const configDir = path.dirname(this.configPath);
+        if (!fs.existsSync(configDir)) {
+          fs.mkdirSync(configDir, { recursive: true });
+        }
+        fs.writeFileSync(this.configPath, JSON.stringify(config, null, 2));
+      }
+    } catch {
+      // Fallback: generate ephemeral key (won't persist across restarts)
+      this.encryptionKey = crypto.randomBytes(32);
+    }
+  }
+
+  /** Encrypt a value with AES-256-GCM */
+  private encrypt(plaintext: string): string {
+    if (!this.encryptionKey) return plaintext;
+    const iv = crypto.randomBytes(12);
+    const cipher = crypto.createCipheriv('aes-256-gcm', this.encryptionKey, iv);
+    let encrypted = cipher.update(plaintext, 'utf8', 'hex');
+    encrypted += cipher.final('hex');
+    const authTag = cipher.getAuthTag().toString('hex');
+    return `${iv.toString('hex')}:${authTag}:${encrypted}`;
+  }
+
+  /** Decrypt a value with AES-256-GCM */
+  private decrypt(ciphertext: string): string {
+    if (!this.encryptionKey) return ciphertext;
+    try {
+      const parts = ciphertext.split(':');
+      if (parts.length !== 3) return ciphertext;
+      const iv = Buffer.from(parts[0], 'hex');
+      const authTag = Buffer.from(parts[1], 'hex');
+      const encrypted = parts[2];
+      const decipher = crypto.createDecipheriv('aes-256-gcm', this.encryptionKey, iv);
+      decipher.setAuthTag(authTag);
+      let decrypted = decipher.update(encrypted, 'hex', 'utf8');
+      decrypted += decipher.final('utf8');
+      return decrypted;
+    } catch {
+      return '[decryption failed]';
+    }
+  }
+
+  /** Extract domain from URL */
+  private getDomain(url: string): string {
+    const parsedUrl = tryParseUrl(url);
+    if (!parsedUrl) {
+      return 'unknown';
+    }
+    return parsedUrl.hostname;
+  }
+
+  /** Sanitize domain for filesystem */
+  private domainToFilename(domain: string): string {
+    return domain.replace(/[^a-zA-Z0-9.-]/g, '_') + '.json';
+  }
+
+  /** Load form data for a domain */
+  private loadDomain(domain: string): DomainFormData | null {
+    const filePath = resolvePathWithinRoot(this.formsDir, this.domainToFilename(domain));
+    if (!fs.existsSync(filePath)) return null;
+    try {
+      return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    } catch {
+      return null;
+    }
+  }
+
+  /** Save form data for a domain */
+  private saveDomain(data: DomainFormData): void {
+    const filePath = resolvePathWithinRoot(this.formsDir, this.domainToFilename(data.domain));
+    fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
   }
 }

--- a/src/memory/site-memory.ts
+++ b/src/memory/site-memory.ts
@@ -6,6 +6,8 @@ import { resolvePathWithinRoot, tryParseUrl, urlHasProtocol } from '../utils/sec
 
 const log = createLogger('SiteMemory');
 
+// ─── Types ───────────────────────────────────────────────────────────────────
+
 export interface SiteVisit {
   url: string;
   title: string;
@@ -40,15 +42,19 @@ export interface SiteData {
   diffs: SiteDiff[];
 }
 
+// ─── Manager ─────────────────────────────────────────────────────────────────
+
 /**
- * SiteMemoryManager — Remembers every site the AI wingman & human visit.
- * 
- * Stores structured data per domain in ~/.tandem/site-memory/{domain}.json
- * Tracks changes between visits (diff detection).
+ * SiteMemoryManager — Remembers every site the AI wingman and human visit.
  */
 export class SiteMemoryManager {
+
+  // === 1. Private state ===
+
   private memoryDir: string;
   private visitStartTimes: Map<string, number> = new Map();
+
+  // === 2. Constructor ===
 
   constructor() {
     this.memoryDir = tandemDir('site-memory');
@@ -57,37 +63,7 @@ export class SiteMemoryManager {
     }
   }
 
-  /** Extract domain from URL */
-  private getDomain(url: string): string {
-    const parsedUrl = tryParseUrl(url);
-    if (!parsedUrl) {
-      return 'unknown';
-    }
-    return parsedUrl.hostname;
-  }
-
-  /** Sanitize domain for filesystem */
-  private domainToFilename(domain: string): string {
-    return domain.replace(/[^a-zA-Z0-9.-]/g, '_') + '.json';
-  }
-
-  /** Load site data from disk */
-  private loadSite(domain: string): SiteData | null {
-    const filePath = resolvePathWithinRoot(this.memoryDir, this.domainToFilename(domain));
-    if (!fs.existsSync(filePath)) return null;
-    try {
-      return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
-    } catch (e) {
-      log.warn('Site memory load failed for', domain + ':', e instanceof Error ? e.message : String(e));
-      return null;
-    }
-  }
-
-  /** Save site data to disk */
-  private saveSite(data: SiteData): void {
-    const filePath = resolvePathWithinRoot(this.memoryDir, this.domainToFilename(data.domain));
-    fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
-  }
+  // === 4. Public methods ===
 
   /** Record a page visit start (for time tracking) */
   trackVisitStart(url: string): void {
@@ -193,41 +169,6 @@ export class SiteMemoryManager {
     }
   }
 
-  /** Compute diff between two visits */
-  private computeDiff(prev: SiteVisit, curr: SiteVisit): SiteDiff | null {
-    const prevHeadingsSet = new Set(prev.headings);
-    const currHeadingsSet = new Set(curr.headings);
-
-    const newHeadings = curr.headings.filter(h => !prevHeadingsSet.has(h));
-    const removedHeadings = prev.headings.filter(h => !currHeadingsSet.has(h));
-
-    const titleChanged = prev.title !== curr.title;
-    const descriptionChanged = prev.description !== curr.description;
-    const textPreviewChanged = prev.textPreview !== curr.textPreview;
-    const linksCountDelta = curr.linksCount - prev.linksCount;
-    const formsCountDelta = curr.formsCount - prev.formsCount;
-
-    // Only create diff if something changed
-    if (!titleChanged && !descriptionChanged && newHeadings.length === 0 &&
-        removedHeadings.length === 0 && linksCountDelta === 0 &&
-        formsCountDelta === 0 && !textPreviewChanged) {
-      return null;
-    }
-
-    return {
-      timestamp: Date.now(),
-      changes: {
-        titleChanged,
-        descriptionChanged,
-        newHeadings,
-        removedHeadings,
-        linksCountDelta,
-        formsCountDelta,
-        textPreviewChanged,
-      },
-    };
-  }
-
   /** List all known domains */
   listSites(): { domain: string; lastVisit: number; visitCount: number }[] {
     try {
@@ -299,5 +240,74 @@ export class SiteMemoryManager {
     const site = this.loadSite(domain);
     if (!site || site.visitCount === 0) return 0;
     return Math.round(site.totalTimeMs / site.visitCount);
+  }
+
+  // === 7. Private helpers ===
+
+  /** Extract domain from URL */
+  private getDomain(url: string): string {
+    const parsedUrl = tryParseUrl(url);
+    if (!parsedUrl) {
+      return 'unknown';
+    }
+    return parsedUrl.hostname;
+  }
+
+  /** Sanitize domain for filesystem */
+  private domainToFilename(domain: string): string {
+    return domain.replace(/[^a-zA-Z0-9.-]/g, '_') + '.json';
+  }
+
+  /** Load site data from disk */
+  private loadSite(domain: string): SiteData | null {
+    const filePath = resolvePathWithinRoot(this.memoryDir, this.domainToFilename(domain));
+    if (!fs.existsSync(filePath)) return null;
+    try {
+      return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    } catch (e) {
+      log.warn('Site memory load failed for', domain + ':', e instanceof Error ? e.message : String(e));
+      return null;
+    }
+  }
+
+  /** Save site data to disk */
+  private saveSite(data: SiteData): void {
+    const filePath = resolvePathWithinRoot(this.memoryDir, this.domainToFilename(data.domain));
+    fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+  }
+
+  /** Compute diff between two visits */
+  private computeDiff(prev: SiteVisit, curr: SiteVisit): SiteDiff | null {
+    const prevHeadingsSet = new Set(prev.headings);
+    const currHeadingsSet = new Set(curr.headings);
+
+    const newHeadings = curr.headings.filter(h => !prevHeadingsSet.has(h));
+    const removedHeadings = prev.headings.filter(h => !currHeadingsSet.has(h));
+
+    const titleChanged = prev.title !== curr.title;
+    const descriptionChanged = prev.description !== curr.description;
+    const textPreviewChanged = prev.textPreview !== curr.textPreview;
+    const linksCountDelta = curr.linksCount - prev.linksCount;
+    const formsCountDelta = curr.formsCount - prev.formsCount;
+
+    // Only create diff if something changed
+    if (!titleChanged && !descriptionChanged && newHeadings.length === 0 &&
+        removedHeadings.length === 0 && linksCountDelta === 0 &&
+        formsCountDelta === 0 && !textPreviewChanged) {
+      return null;
+    }
+
+    return {
+      timestamp: Date.now(),
+      changes: {
+        titleChanged,
+        descriptionChanged,
+        newHeadings,
+        removedHeadings,
+        linksCountDelta,
+        formsCountDelta,
+        textPreviewChanged,
+      },
+    };
   }
 }

--- a/src/security/security-manager.ts
+++ b/src/security/security-manager.ts
@@ -21,6 +21,8 @@ import { createLogger } from '../utils/logger';
 
 const log = createLogger('SecurityManager');
 
+// ─── Types ───────────────────────────────────────────────────────────────────
+
 interface SecurityTabState {
   cdpAttached: boolean;
   monitorsInjected: boolean;
@@ -50,7 +52,15 @@ export interface SecurityContainmentIncident {
   evidence: ContainmentEvidence;
 }
 
+// ─── Manager ─────────────────────────────────────────────────────────────────
+
+/**
+ * SecurityManager — Orchestrates all security subsystems (network shield, guardian, script/content/behavior analysis).
+ */
 export class SecurityManager {
+
+  // === 1. Private state ===
+
   private db: SecurityDB;
   private shield: NetworkShield;
   private guardian: Guardian;
@@ -88,6 +98,8 @@ export class SecurityManager {
   private blocklistUpdateQueued: boolean = false;
   private tabStates: Map<number, SecurityTabState> = new Map();
   onContainmentIncident: ((incident: SecurityContainmentIncident) => void) | null = null;
+
+  // === 2. Constructor ===
 
   constructor() {
     this.db = new SecurityDB();
@@ -164,6 +176,8 @@ export class SecurityManager {
     log.info('Initialized (Phase 1-7)');
   }
 
+  // === 3. Dependency setters ===
+
   /**
    * Initialize SecurityManager with all external dependencies.
    * Consolidates the previously scattered init steps into one call.
@@ -232,6 +246,21 @@ export class SecurityManager {
   }
 
   /**
+   * Initialize the Gatekeeper WebSocket server on the existing HTTP server.
+   * Must be called after the Express server has started listening.
+   */
+  initGatekeeper(httpServer: HttpServer): void {
+    this.gatekeeperWs = new GatekeeperWebSocket(httpServer, this.guardian, this.db);
+    this.guardian.setGatekeeper(this.gatekeeperWs);
+
+    log.info('Phase 4: GatekeeperWebSocket initialized');
+  }
+
+  // === 4. Public methods ===
+
+  // ── Tab lifecycle ──
+
+  /**
    * Called when a tab is attached/focused in DevToolsManager.
    * Enables security CDP domains, injects monitors, starts resource monitoring.
    */
@@ -268,17 +297,6 @@ export class SecurityManager {
     this.devToolsManager?.detachFromTab(wcId);
     this.guardian.releaseWebContentsQuarantine(wcId);
     this.tabStates.delete(wcId);
-  }
-
-  /**
-   * Initialize the Gatekeeper WebSocket server on the existing HTTP server.
-   * Must be called after the Express server has started listening.
-   */
-  initGatekeeper(httpServer: HttpServer): void {
-    this.gatekeeperWs = new GatekeeperWebSocket(httpServer, this.guardian, this.db);
-    this.guardian.setGatekeeper(this.gatekeeperWs);
-
-    log.info('Phase 4: GatekeeperWebSocket initialized');
   }
 
   /**
@@ -365,6 +383,53 @@ export class SecurityManager {
     }
   }
 
+  // ── Public accessors for route handlers (src/security/routes.ts) ──
+
+  /** Get the security event/domain database. */
+  getDb(): SecurityDB { return this.db; }
+  /** Get the domain/URL blocklist shield. */
+  getShield(): NetworkShield { return this.shield; }
+  /** Get the request guardian (mode enforcement, blocking). */
+  getGuardian(): Guardian { return this.guardian; }
+  /** Get the outbound data exfiltration guard. */
+  getOutboundGuard(): OutboundGuard { return this.outboundGuard; }
+  /** Get the CDP-based script analysis guard (null until DevTools attached). */
+  getScriptGuard(): ScriptGuard | null { return this.scriptGuard; }
+  /** Get the page content analyzer (null until DevTools attached). */
+  getContentAnalyzer(): ContentAnalyzer | null { return this.contentAnalyzer; }
+  /** Get the runtime behavior monitor (null until DevTools attached). */
+  getBehaviorMonitor(): BehaviorMonitor | null { return this.behaviorMonitor; }
+  /** Get the DevTools CDP manager reference. */
+  getDevToolsManager(): DevToolsManager | null { return this.devToolsManager; }
+  /** Get the Gatekeeper WebSocket server (null until HTTP server starts). */
+  getGatekeeperWs(): GatekeeperWebSocket | null { return this.gatekeeperWs; }
+  /** Get the threat intelligence correlation engine. */
+  getThreatIntel(): ThreatIntel { return this.threatIntel; }
+  /** Get the blocklist source updater. */
+  getBlocklistUpdater(): BlocklistUpdater { return this.blocklistUpdater; }
+  /** Get the analyzer plugin manager. */
+  getAnalyzerManager(): AnalyzerManager { return this.analyzerManager; }
+  /** Get a snapshot of all containment incidents (most recent first). */
+  getContainmentIncidents(): SecurityContainmentIncident[] { return [...this.containmentIncidents]; }
+
+  // === 6. Cleanup ===
+
+  /** Tear down all security subsystems, clear timers, and close the database. */
+  destroy(): void {
+    if (this.correlationInterval) clearInterval(this.correlationInterval);
+    if (this.blocklistInterval) clearInterval(this.blocklistInterval);
+    this.analyzerManager.destroy().catch(e => log.warn('analyzerManager.destroy failed:', e instanceof Error ? e.message : e));
+    this.gatekeeperWs?.destroy();
+    this.scriptGuard?.destroy();
+    this.behaviorMonitor?.destroy();
+    this.containmentIncidents = [];
+    this.tabStates.clear();
+    this.db.close();
+    log.info('Destroyed');
+  }
+
+  // === 7. Private helpers ===
+
   /**
    * Run event correlation and log any detected threats.
    */
@@ -446,49 +511,6 @@ export class SecurityManager {
         void this.runBlocklistUpdate();
       }
     }
-  }
-
-  // --- Public accessors for route handlers (src/security/routes.ts) ---
-
-  /** Get the security event/domain database. */
-  getDb(): SecurityDB { return this.db; }
-  /** Get the domain/URL blocklist shield. */
-  getShield(): NetworkShield { return this.shield; }
-  /** Get the request guardian (mode enforcement, blocking). */
-  getGuardian(): Guardian { return this.guardian; }
-  /** Get the outbound data exfiltration guard. */
-  getOutboundGuard(): OutboundGuard { return this.outboundGuard; }
-  /** Get the CDP-based script analysis guard (null until DevTools attached). */
-  getScriptGuard(): ScriptGuard | null { return this.scriptGuard; }
-  /** Get the page content analyzer (null until DevTools attached). */
-  getContentAnalyzer(): ContentAnalyzer | null { return this.contentAnalyzer; }
-  /** Get the runtime behavior monitor (null until DevTools attached). */
-  getBehaviorMonitor(): BehaviorMonitor | null { return this.behaviorMonitor; }
-  /** Get the DevTools CDP manager reference. */
-  getDevToolsManager(): DevToolsManager | null { return this.devToolsManager; }
-  /** Get the Gatekeeper WebSocket server (null until HTTP server starts). */
-  getGatekeeperWs(): GatekeeperWebSocket | null { return this.gatekeeperWs; }
-  /** Get the threat intelligence correlation engine. */
-  getThreatIntel(): ThreatIntel { return this.threatIntel; }
-  /** Get the blocklist source updater. */
-  getBlocklistUpdater(): BlocklistUpdater { return this.blocklistUpdater; }
-  /** Get the analyzer plugin manager. */
-  getAnalyzerManager(): AnalyzerManager { return this.analyzerManager; }
-  /** Get a snapshot of all containment incidents (most recent first). */
-  getContainmentIncidents(): SecurityContainmentIncident[] { return [...this.containmentIncidents]; }
-
-  /** Tear down all security subsystems, clear timers, and close the database. */
-  destroy(): void {
-    if (this.correlationInterval) clearInterval(this.correlationInterval);
-    if (this.blocklistInterval) clearInterval(this.blocklistInterval);
-    this.analyzerManager.destroy().catch(e => log.warn('analyzerManager.destroy failed:', e instanceof Error ? e.message : e));
-    this.gatekeeperWs?.destroy();
-    this.scriptGuard?.destroy();
-    this.behaviorMonitor?.destroy();
-    this.containmentIncidents = [];
-    this.tabStates.clear();
-    this.db.close();
-    log.info('Destroyed');
   }
 
   private async handleScriptCriticalDetection(detection: ScriptCriticalDetection): Promise<void> {

--- a/src/snapshot/manager.ts
+++ b/src/snapshot/manager.ts
@@ -8,6 +8,8 @@ const INTERACTIVE_ROLES = new Set([
   'combobox', 'menuitem', 'tab', 'searchbox',
 ]);
 
+// ─── Types ───────────────────────────────────────────────────────────────────
+
 interface CDPAXValue {
   value?: string | number | boolean;
 }
@@ -53,6 +55,8 @@ interface RuntimeCallFunctionResponse {
   };
 }
 
+// ─── Manager ─────────────────────────────────────────────────────────────────
+
 /**
  * SnapshotManager — Provides accessibility tree snapshots via CDP.
  *
@@ -64,40 +68,23 @@ interface RuntimeCallFunctionResponse {
  * attach the debugger directly.
  */
 export class SnapshotManager {
+
+  // === 1. Private state ===
+
   private refMap: RefMap = {};
   private refTargets: Map<string, RefTarget> = new Map();
   private refCounter = 0;
   private devtools: DevToolsManager;
   private subscribedToNavigation = false;
 
+  // === 2. Constructor ===
+
   constructor(devtools: DevToolsManager) {
     this.devtools = devtools;
     this.setupNavigationReset();
   }
 
-  /**
-   * Subscribe to Page.frameNavigated to reset refs on navigation.
-   */
-  private setupNavigationReset(): void {
-    if (this.subscribedToNavigation) return;
-    this.devtools.subscribe({
-      name: 'snapshot-nav-reset',
-      events: ['Page.frameNavigated'],
-      handler: (_method: string, params: Record<string, unknown>) => {
-        // Only reset on top-level navigation (not iframes)
-        const frame = params.frame as Record<string, unknown> | undefined;
-        if (!frame?.parentId) {
-          const targetWcId = this.devtools.getDispatchWebContents()?.id;
-          if (targetWcId) {
-            this.clearRefsForTab(targetWcId);
-          } else {
-            this.clearAllRefs();
-          }
-        }
-      },
-    });
-    this.subscribedToNavigation = true;
-  }
+  // === 4. Public methods ===
 
   /**
    * Get an accessibility tree snapshot of the current page.
@@ -379,6 +366,44 @@ export class SnapshotManager {
     return this.refMap;
   }
 
+  // === 6. Cleanup ===
+
+  /**
+   * Cleanup — called from will-quit handler.
+   */
+  destroy(): void {
+    this.refMap = {};
+    this.refTargets.clear();
+    this.refCounter = 0;
+    this.devtools.unsubscribe('snapshot-nav-reset');
+  }
+
+  // === 7. Private helpers ===
+
+  /**
+   * Subscribe to Page.frameNavigated to reset refs on navigation.
+   */
+  private setupNavigationReset(): void {
+    if (this.subscribedToNavigation) return;
+    this.devtools.subscribe({
+      name: 'snapshot-nav-reset',
+      events: ['Page.frameNavigated'],
+      handler: (_method: string, params: Record<string, unknown>) => {
+        // Only reset on top-level navigation (not iframes)
+        const frame = params.frame as Record<string, unknown> | undefined;
+        if (!frame?.parentId) {
+          const targetWcId = this.devtools.getDispatchWebContents()?.id;
+          if (targetWcId) {
+            this.clearRefsForTab(targetWcId);
+          } else {
+            this.clearAllRefs();
+          }
+        }
+      },
+    });
+    this.subscribedToNavigation = true;
+  }
+
   private clearAllRefs(): void {
     this.refMap = {};
     this.refTargets.clear();
@@ -422,9 +447,7 @@ export class SnapshotManager {
     return wc;
   }
 
-  // ═══════════════════════════════════════════════
-  // Private — Tree building
-  // ═══════════════════════════════════════════════
+  // ── Tree building ──
 
   /**
    * Build a tree structure from CDP's flat AXNode list.
@@ -476,9 +499,7 @@ export class SnapshotManager {
     return [root];
   }
 
-  // ═══════════════════════════════════════════════
-  // Private — Filters
-  // ═══════════════════════════════════════════════
+  // ── Filters ──
 
   /**
    * Filter tree to only include interactive elements and their ancestors.
@@ -598,9 +619,7 @@ export class SnapshotManager {
     return null;
   }
 
-  // ═══════════════════════════════════════════════
-  // Private — Property extraction from CDP AXNodes
-  // ═══════════════════════════════════════════════
+  // ── Property extraction from CDP AXNodes ──
 
   private extractProperty(raw: CDPAXNode, propName: string): string {
     if (propName === 'role' && raw.role) {
@@ -649,9 +668,7 @@ export class SnapshotManager {
     return undefined;
   }
 
-  // ═══════════════════════════════════════════════
-  // Private — Ref assignment & formatting
-  // ═══════════════════════════════════════════════
+  // ── Ref assignment & formatting ──
 
   /**
    * Assign @refs (@e1, @e2, ...) to all nodes in the tree.
@@ -721,9 +738,7 @@ export class SnapshotManager {
     return count;
   }
 
-  // ═══════════════════════════════════════════════
-  // Private — Input helpers
-  // ═══════════════════════════════════════════════
+  // ── Input helpers ──
 
   /**
    * Perform a humanized click at (x, y) using sendInputEvent (Event.isTrusted = true).
@@ -775,15 +790,5 @@ export class SnapshotManager {
 
   private delay(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));
-  }
-
-  /**
-   * Cleanup — called from will-quit handler.
-   */
-  destroy(): void {
-    this.refMap = {};
-    this.refTargets.clear();
-    this.refCounter = 0;
-    this.devtools.unsubscribe('snapshot-nav-reset');
   }
 }

--- a/src/workflow/engine.ts
+++ b/src/workflow/engine.ts
@@ -9,6 +9,8 @@ import { assertSinglePathSegment, resolvePathWithinRoot } from '../utils/securit
 
 const log = createLogger('WorkflowEngine');
 
+// ─── Types ───────────────────────────────────────────────────────────────────
+
 type WorkflowVariables = Record<string, unknown>;
 type WorkflowStepResult = unknown;
 
@@ -136,9 +138,19 @@ interface WorkflowExecution {
   }>;
 }
 
+// ─── Manager ─────────────────────────────────────────────────────────────────
+
+/**
+ * WorkflowEngine — Runs multi-step browser automation workflows.
+ */
 export class WorkflowEngine {
+
+  // === 1. Private state ===
+
   private workflowsDir: string;
   private executions: Map<string, WorkflowExecution> = new Map();
+
+  // === 2. Constructor ===
 
   constructor() {
     this.workflowsDir = tandemDir('workflows');
@@ -146,20 +158,7 @@ export class WorkflowEngine {
     this.loadWorkflows();
   }
 
-  private ensureDirectories(): void {
-    if (!fs.existsSync(this.workflowsDir)) {
-      fs.mkdirSync(this.workflowsDir, { recursive: true });
-    }
-  }
-
-  private loadWorkflows(): void {
-    // Load any saved executions if needed
-  }
-
-  private getWorkflowPath(id: string): string {
-    const safeId = assertSinglePathSegment(id, 'workflow id');
-    return resolvePathWithinRoot(this.workflowsDir, `${safeId}.json`);
-  }
+  // === 4. Public methods ===
 
   /**
    * Get all workflow templates
@@ -191,7 +190,7 @@ export class WorkflowEngine {
   async saveWorkflow(workflow: Omit<WorkflowDefinition, 'id' | 'createdAt' | 'updatedAt'>): Promise<string> {
     const id = this.generateId();
     const now = new Date().toISOString();
-    
+
     const workflowDef: WorkflowDefinition = {
       ...workflow,
       id,
@@ -200,9 +199,9 @@ export class WorkflowEngine {
     };
 
     const filepath = this.getWorkflowPath(id);
-    
+
     fs.writeFileSync(filepath, JSON.stringify(workflowDef, null, 2));
-    
+
     return id;
   }
 
@@ -222,7 +221,7 @@ export class WorkflowEngine {
   async runWorkflow(workflowId: string, webview: BrowserWindow, initialVariables: WorkflowVariables = {}): Promise<string> {
     const workflows = await this.getWorkflows();
     const workflow = workflows.find(w => w.id === workflowId);
-    
+
     if (!workflow) {
       throw new Error(`Workflow ${workflowId} not found`);
     }
@@ -275,6 +274,23 @@ export class WorkflowEngine {
     return Array.from(this.executions.values()).filter(e => e.status === 'running');
   }
 
+  // === 7. Private helpers ===
+
+  private ensureDirectories(): void {
+    if (!fs.existsSync(this.workflowsDir)) {
+      fs.mkdirSync(this.workflowsDir, { recursive: true });
+    }
+  }
+
+  private loadWorkflows(): void {
+    // Load any saved executions if needed
+  }
+
+  private getWorkflowPath(id: string): string {
+    const safeId = assertSinglePathSegment(id, 'workflow id');
+    return resolvePathWithinRoot(this.workflowsDir, `${safeId}.json`);
+  }
+
   private async executeWorkflow(execution: WorkflowExecution, workflow: WorkflowDefinition, webview: BrowserWindow): Promise<void> {
     try {
       let stepIndex = execution.currentStep;
@@ -287,7 +303,7 @@ export class WorkflowEngine {
 
         try {
           const result = await this.executeStep(step, execution, webview);
-          
+
           execution.stepResults.push({
             stepId: step.id,
             status: 'completed',
@@ -298,7 +314,7 @@ export class WorkflowEngine {
           // Handle condition step results
           if (step.type === 'condition' && result) {
             const conditionResult = result as ConditionExecutionResult;
-            
+
             if (conditionResult.action === 'goto' && conditionResult.gotoStep) {
               const gotoIndex = workflow.steps.findIndex(s => s.id === conditionResult.gotoStep);
               if (gotoIndex !== -1) {
@@ -401,16 +417,16 @@ export class WorkflowEngine {
 
   private async executeNavigate(step: NavigateStep, webview: BrowserWindow): Promise<void> {
     await webview.webContents.loadURL(step.params.url);
-    
+
     if (step.params.waitForLoad !== false) {
       await new Promise((resolve, reject) => {
         const timeout = setTimeout(() => reject(new Error('Navigation timeout')), DEFAULT_TIMEOUT_MS);
-        
+
         webview.webContents.once('did-finish-load', () => {
           clearTimeout(timeout);
           resolve(void 0);
         });
-        
+
         webview.webContents.once('did-fail-load', (event, errorCode, errorDescription) => {
           clearTimeout(timeout);
           reject(new Error(`Navigation failed: ${errorDescription}`));
@@ -424,7 +440,7 @@ export class WorkflowEngine {
       // Wait for condition
       const startTime = Date.now();
       const maxWait = step.params.duration || 10000;
-      
+
       while (Date.now() - startTime < maxWait) {
         const conditionMet = await this.checkCondition(step.params, webview);
         if (conditionMet) {
@@ -432,7 +448,7 @@ export class WorkflowEngine {
         }
         await new Promise(resolve => setTimeout(resolve, 500));
       }
-      
+
       throw new Error(`Wait condition not met within ${maxWait}ms`);
     } else {
       // Simple wait
@@ -469,7 +485,7 @@ export class WorkflowEngine {
 
     // Use humanizedClick for isTrusted: true events via sendInputEvent
     await humanizedClick(webview.webContents, step.params.selector);
-    
+
     if (step.params.waitAfter) {
       await new Promise(resolve => setTimeout(resolve, step.params.waitAfter));
     }
@@ -491,10 +507,10 @@ export class WorkflowEngine {
       (() => {
         const selector = ${JSON.stringify(step.params.selector || 'body')};
         const attribute = ${JSON.stringify(step.params.attribute || '')};
-        
+
         const element = document.querySelector(selector);
         if (!element) return null;
-        
+
         if (attribute) {
           return element.getAttribute(attribute);
         } else {
@@ -511,21 +527,21 @@ export class WorkflowEngine {
   private async executeScreenshot(step: ScreenshotStep, webview: BrowserWindow): Promise<string> {
     const image = await webview.webContents.capturePage();
     const buffer = image.toPNG();
-    
+
     const filename = step.params.filename || `workflow-${Date.now()}.png`;
     const screenshotsDir = tandemDir('screenshots');
-    
+
     if (!fs.existsSync(screenshotsDir)) {
       fs.mkdirSync(screenshotsDir, { recursive: true });
     }
-    
+
     const filepath = path.join(screenshotsDir, filename);
     fs.writeFileSync(filepath, buffer);
-    
+
     if (step.params.saveAs) {
       // Store path in variables
     }
-    
+
     return filepath;
   }
 
@@ -533,7 +549,7 @@ export class WorkflowEngine {
     await webview.webContents.executeJavaScript(`
       const direction = ${JSON.stringify(step.params.direction)};
       const amount = ${JSON.stringify(step.params.amount || 300)};
-      
+
       switch (direction) {
         case 'up':
           window.scrollBy(0, -amount);
@@ -574,7 +590,7 @@ export class WorkflowEngine {
     }
 
     const action = conditionResult ? step.params.onTrue : step.params.onFalse;
-    
+
     return {
       condition: conditionResult,
       action,


### PR DESCRIPTION
## Summary
- Add 7-section comment headers (`Private state`, `Constructor`, `Dependency setters`, `Public methods`, `Sync integration`, `Cleanup`, `Private helpers`) to 10 manager files and reorder methods to match `docs/templates/manager-pattern.md`
- Files refactored: DevToolsManager, WorkflowEngine, ExtensionManager, SecurityManager, SnapshotManager, SiteMemoryManager, FormMemoryManager, TaskManager, TabLockManager, WingmanStream
- SidebarManager and WorkspaceManager already had the pattern applied (skipped)
- No logic, method signatures, or public API changes

## Test plan
- [x] `npm run compile` passes (TypeScript)
- [x] `npm run lint` passes (0 errors)
- [x] `npm test` passes (1871 tests, 87 suites)
- [x] `npm run check-consistency` passes