### PR TITLE
refactor: eliminate any types across codebase (P3-02)

### DIFF
--- a/src/agents/tests/task-manager.test.ts
+++ b/src/agents/tests/task-manager.test.ts
@@ -170,7 +170,7 @@ describe('TaskManager', () => {
 
       // Mock getTask to return running task
       const storedJson = JSON.stringify({ ...task, status: 'running', steps: [{ ...task.steps[0], status: 'running' }] });
-      vi.mocked(fs.readdirSync).mockReturnValue([`${task.id}.json`] as any);
+      vi.mocked(fs.readdirSync).mockReturnValue([`${task.id}.json`] as unknown as fs.Dirent[]);
       vi.mocked(fs.readFileSync).mockReturnValue(storedJson);
       vi.mocked(fs.existsSync).mockReturnValue(true);
 

--- a/src/auth/tests/login-manager.test.ts
+++ b/src/auth/tests/login-manager.test.ts
@@ -3,7 +3,7 @@ import type { BrowserWindow } from 'electron';
 
 // Mock dependencies before importing
 vi.mock('fs', async () => {
-  const actual = await vi.importActual('fs') as any;
+  const actual = await vi.importActual('fs') as Record<string, unknown>;
   return {
     ...actual,
     default: {

--- a/src/clipboard/tests/clipboard.test.ts
+++ b/src/clipboard/tests/clipboard.test.ts
@@ -17,7 +17,7 @@ vi.mock('electron', () => ({
 }));
 
 vi.mock('fs', async () => {
-  const actual = await vi.importActual('fs') as any;
+  const actual = await vi.importActual('fs') as Record<string, unknown>;
   return {
     ...actual,
     default: {

--- a/src/extensions/native-messaging.ts
+++ b/src/extensions/native-messaging.ts
@@ -212,8 +212,7 @@ export class NativeMessagingSetup {
 
       try {
         // Try the API at runtime — it may exist even if not in TypeScript defs
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const ses = session as any;
+        const ses = session as unknown as Record<string, unknown> & { setNativeMessagingHostDirectory?: (path: string) => void };
         if (typeof ses.setNativeMessagingHostDirectory === 'function') {
           ses.setNativeMessagingHostDirectory(dir.path);
           configured.push(dir.path);

--- a/src/mcp/coerce.ts
+++ b/src/mcp/coerce.ts
@@ -7,10 +7,8 @@ import { z } from 'zod';
  * This must happen at the schema level because the MCP SDK validates arguments
  * against the Zod schema BEFORE calling the tool handler.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function coerceShape(shape: Record<string, any>): Record<string, any> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const result: Record<string, any> = {};
+export function coerceShape<T extends Record<string, z.ZodTypeAny>>(shape: T): T {
+  const result: Record<string, z.ZodTypeAny> = {};
   for (const [key, field] of Object.entries(shape)) {
     const inner = unwrapType(field);
     if (inner instanceof z.ZodBoolean) {
@@ -23,7 +21,7 @@ export function coerceShape(shape: Record<string, any>): Record<string, any> {
       result[key] = field;
     }
   }
-  return result;
+  return result as T;
 }
 
 /** Unwrap ZodOptional / ZodDefault / ZodNullable wrappers to find the base type. */
@@ -34,8 +32,8 @@ function unwrapType(schema: z.ZodTypeAny): z.ZodTypeAny {
     s instanceof z.ZodDefault ||
     s instanceof z.ZodNullable
   ) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    s = (s._def as any).innerType as z.ZodTypeAny;
+    // Zod internal: Optional/Default/Nullable all store wrapped type as innerType
+    s = (s._def as unknown as { innerType: z.ZodTypeAny }).innerType;
   }
   return s;
 }

--- a/src/mcp/tests/mcp-test-helper.ts
+++ b/src/mcp/tests/mcp-test-helper.ts
@@ -10,8 +10,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 export interface RegisteredTool {
   name: string;
   description: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  handler: (params: any) => Promise<any>;
+  handler: (params: Record<string, unknown>) => Promise<{ content: Array<{ type: string; text?: string; data?: string; mimeType?: string }> }>;
 }
 
 /**
@@ -43,8 +42,7 @@ export function getHandler(tools: Map<string, RegisteredTool>, name: string) {
 
 /** Assert the standard MCP text response shape. */
 export function expectTextContent(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  result: any,
+  result: { content: Array<{ type: string; text?: string }> },
   substring?: string,
 ) {
   expect(result).toHaveProperty('content');
@@ -59,8 +57,7 @@ export function expectTextContent(
 
 /** Assert the standard MCP image response shape. */
 export function expectImageContent(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  result: any,
+  result: { content: Array<{ type: string; data?: string; mimeType?: string }> },
   mimeType = 'image/png',
 ) {
   expect(result).toHaveProperty('content');

--- a/src/mcp/tools/awareness.ts
+++ b/src/mcp/tools/awareness.ts
@@ -16,7 +16,7 @@ export function registerAwarenessTools(server: McpServer): void {
         'How many minutes of activity to include (default: 5, max: 60)'
       ),
     }),
-    async ({ minutes }: any) => {
+    async ({ minutes }) => {
       const params = new URLSearchParams();
       if (minutes) params.set('minutes', String(minutes));
       const qs = params.toString();

--- a/src/mcp/tools/chat.ts
+++ b/src/mcp/tools/chat.ts
@@ -22,7 +22,7 @@ export function registerChatTools(server: McpServer): void {
     coerceShape({
       limit: z.number().optional().default(20).describe('Number of messages to return (default: 20)'),
     }),
-    async ({ limit }: any) => {
+    async ({ limit }) => {
       const data = await apiCall('GET', `/chat?limit=${limit}`);
       const messages: Array<{ from: string; text: string; timestamp: number }> = data.messages || [];
 

--- a/src/mcp/tools/context.ts
+++ b/src/mcp/tools/context.ts
@@ -10,7 +10,7 @@ export function registerContextTools(server: McpServer): void {
     coerceShape({
       limit: z.number().optional().describe('Maximum number of pages to return (default: 50)'),
     }),
-    async ({ limit }: any) => {
+    async ({ limit }) => {
       const params = limit ? `?limit=${limit}` : '';
       const data = await apiCall('GET', `/context/recent${params}`);
       await logActivity('context_recent');

--- a/src/mcp/tools/devices.ts
+++ b/src/mcp/tools/devices.ts
@@ -35,7 +35,7 @@ export function registerDeviceTools(server: McpServer): void {
       mobile: z.boolean().optional().describe('Whether to emulate a mobile device'),
       userAgent: z.string().optional().describe('Custom user agent string'),
     }),
-    async ({ device, width, height, deviceScaleFactor, mobile, userAgent }: any) => {
+    async ({ device, width, height, deviceScaleFactor, mobile, userAgent }) => {
       const body: Record<string, unknown> = {};
       if (device) body.device = device;
       if (width !== undefined) body.width = width;

--- a/src/mcp/tools/devtools.ts
+++ b/src/mcp/tools/devtools.ts
@@ -13,7 +13,7 @@ export function registerDevtoolsTools(server: McpServer): void {
       limit: z.number().optional().describe('Maximum entries to return (default: 100)'),
       tabId: z.string().optional().describe('Optional tab ID to target a background tab instead of the active tab'),
     }),
-    async ({ level, search, limit, tabId }: any) => {
+    async ({ level, search, limit, tabId }) => {
       const params = new URLSearchParams();
       if (level) params.set('level', level);
       if (search) params.set('search', search);
@@ -32,7 +32,7 @@ export function registerDevtoolsTools(server: McpServer): void {
       limit: z.number().optional().describe('Maximum errors to return (default: 50)'),
       tabId: z.string().optional().describe('Optional tab ID to target a background tab instead of the active tab'),
     }),
-    async ({ limit, tabId }: any) => {
+    async ({ limit, tabId }) => {
       const params = new URLSearchParams();
       if (limit !== undefined) params.set('limit', String(limit));
       const qs = params.toString();
@@ -61,7 +61,7 @@ export function registerDevtoolsTools(server: McpServer): void {
       limit: z.number().optional().describe('Maximum entries to return (default: 100)'),
       tabId: z.string().optional().describe('Optional tab ID to target a background tab instead of the active tab'),
     }),
-    async ({ domain, type, failed, limit, tabId }: any) => {
+    async ({ domain, type, failed, limit, tabId }) => {
       const params = new URLSearchParams();
       if (domain) params.set('domain', domain);
       if (type) params.set('type', type);

--- a/src/mcp/tools/events.ts
+++ b/src/mcp/tools/events.ts
@@ -12,7 +12,7 @@ export function registerEventTools(server: McpServer): void {
     coerceShape({
       limit: z.number().optional().describe('Maximum number of events to return (default: 50)'),
     }),
-    async ({ limit }: any) => {
+    async ({ limit }) => {
       const params = new URLSearchParams();
       if (limit) params.set('limit', String(limit));
       const qs = params.toString();
@@ -39,7 +39,7 @@ export function registerEventTools(server: McpServer): void {
     coerceShape({
       enabled: z.boolean().optional().describe('Set live mode on (true) or off (false). Omit to toggle.'),
     }),
-    async ({ enabled }: any) => {
+    async ({ enabled }) => {
       const body: Record<string, unknown> = {};
       if (enabled !== undefined) body.enabled = enabled;
       const data = await apiCall('POST', '/live/toggle', body);

--- a/src/mcp/tools/extensions.ts
+++ b/src/mcp/tools/extensions.ts
@@ -30,7 +30,7 @@ export function registerExtensionTools(server: McpServer): void {
       all: z.boolean().optional().describe('Import all Chrome extensions'),
       profile: z.string().optional().describe('Chrome profile name (default: "Default")'),
     }),
-    async ({ extensionId, all, profile }: any) => {
+    async ({ extensionId, all, profile }) => {
       const body: Record<string, unknown> = {};
       if (extensionId) body.extensionId = extensionId;
       if (all) body.all = true;

--- a/src/mcp/tools/history.ts
+++ b/src/mcp/tools/history.ts
@@ -11,7 +11,7 @@ export function registerHistoryTools(server: McpServer): void {
       limit: z.number().optional().describe('Max entries to return (default 100)'),
       offset: z.number().optional().describe('Offset for pagination (default 0)'),
     }),
-    async ({ limit, offset }: any) => {
+    async ({ limit, offset }) => {
       const params = new URLSearchParams();
       if (limit !== undefined) params.set('limit', String(limit));
       if (offset !== undefined) params.set('offset', String(offset));
@@ -71,7 +71,7 @@ export function registerHistoryTools(server: McpServer): void {
     coerceShape({
       limit: z.number().optional().describe('Max entries to return (default 100)'),
     }),
-    async ({ limit }: any) => {
+    async ({ limit }) => {
       const params = new URLSearchParams();
       if (limit !== undefined) params.set('limit', String(limit));
       const qs = params.toString();

--- a/src/mcp/tools/media.ts
+++ b/src/mcp/tools/media.ts
@@ -109,7 +109,7 @@ export function registerMediaTools(server: McpServer): void {
     coerceShape({
       limit: z.number().optional().describe('Maximum number of screenshots to return (default: 10)'),
     }),
-    async ({ limit }: any) => {
+    async ({ limit }) => {
       const params = new URLSearchParams();
       if (limit) params.set('limit', String(limit));
       const qs = params.toString();
@@ -127,7 +127,7 @@ export function registerMediaTools(server: McpServer): void {
     coerceShape({
       enabled: z.boolean().optional().describe('Set draw mode on (true) or off (false). Omit to toggle.'),
     }),
-    async ({ enabled }: any) => {
+    async ({ enabled }) => {
       const body: Record<string, unknown> = {};
       if (enabled !== undefined) body.enabled = enabled;
       const data = await apiCall('POST', '/draw/toggle', body);
@@ -144,7 +144,7 @@ export function registerMediaTools(server: McpServer): void {
     coerceShape({
       open: z.boolean().optional().describe('Set panel open (true) or closed (false). Omit to toggle.'),
     }),
-    async ({ open }: any) => {
+    async ({ open }) => {
       const body: Record<string, unknown> = {};
       if (open !== undefined) body.open = open;
       const data = await apiCall('POST', '/panel/toggle', body);
@@ -161,7 +161,7 @@ export function registerMediaTools(server: McpServer): void {
     coerceShape({
       enabled: z.boolean().describe('Enable (true) or disable (false) the wingman stream'),
     }),
-    async ({ enabled }: any) => {
+    async ({ enabled }) => {
       const data = await apiCall('POST', '/wingman-stream/toggle', { enabled });
       await logActivity('wingman_stream_toggle', `enabled: ${data.enabled}`);
       return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };

--- a/src/mcp/tools/navigation.ts
+++ b/src/mcp/tools/navigation.ts
@@ -55,7 +55,7 @@ export function registerNavigationTools(server: McpServer): void {
       timeout: z.number().optional().default(10000).describe('Timeout in milliseconds (default: 10000)'),
       tabId: z.string().optional().describe('Optional tab ID to target a background tab instead of the active tab'),
     }),
-    async ({ timeout, tabId }: any) => {
+    async ({ timeout, tabId }) => {
       const result = await apiCall('POST', '/wait', { timeout }, tabHeaders(tabId));
       await logActivity('wait_for_load');
 
@@ -89,7 +89,7 @@ export function registerNavigationTools(server: McpServer): void {
       clear: z.boolean().optional().default(false).describe('Clear the field before typing'),
       tabId: z.string().optional().describe('Optional tab ID to target a background tab instead of the active tab'),
     }),
-    async ({ selector, text, clear, tabId }: any) => {
+    async ({ selector, text, clear, tabId }) => {
       await apiCall('POST', '/type', { selector, text, clear }, tabHeaders(tabId));
       await logActivity('type', `${selector}: "${text.substring(0, 50)}"`);
       return { content: [{ type: 'text', text: `Typed "${text}" into ${selector}` }] };
@@ -106,7 +106,7 @@ export function registerNavigationTools(server: McpServer): void {
       selector: z.string().optional().describe('CSS selector of element to scroll into view'),
       tabId: z.string().optional().describe('Optional tab ID to target a background tab instead of the active tab'),
     }),
-    async ({ direction, amount, target, selector, tabId }: any) => {
+    async ({ direction, amount, target, selector, tabId }) => {
       const body: Record<string, unknown> = { direction, amount };
       if (target) body.target = target;
       if (selector) body.selector = selector;
@@ -125,7 +125,7 @@ export function registerNavigationTools(server: McpServer): void {
       modifiers: z.array(z.string()).optional().describe('Optional modifier keys: "control", "shift", "alt", "meta" (e.g. ["control", "shift"])'),
       tabId: z.string().optional().describe('Optional tab ID to target a background tab instead of the active tab'),
     }),
-    async ({ key, modifiers, tabId }: any) => {
+    async ({ key, modifiers, tabId }) => {
       const body: Record<string, unknown> = { key };
       if (modifiers && modifiers.length > 0) body.modifiers = modifiers;
       const result = await apiCall('POST', '/press-key', body, tabHeaders(tabId));
@@ -142,7 +142,7 @@ export function registerNavigationTools(server: McpServer): void {
       keys: z.array(z.string()).describe('Array of key names to press in sequence (e.g. ["Tab", "Tab", "Tab", "Enter"])'),
       tabId: z.string().optional().describe('Optional tab ID to target a background tab instead of the active tab'),
     }),
-    async ({ keys, tabId }: any) => {
+    async ({ keys, tabId }) => {
       const result = await apiCall('POST', '/press-key-combo', { keys }, tabHeaders(tabId));
       const detail = keys.join(' → ');
       await logActivity('press_key_combo', detail);

--- a/src/mcp/tools/network.ts
+++ b/src/mcp/tools/network.ts
@@ -13,7 +13,7 @@ export function registerNetworkTools(server: McpServer): void {
       limit: z.number().optional().describe('Maximum entries to return (default: 100)'),
       tabId: z.string().optional().describe('Optional tab ID to target a background tab instead of the active tab'),
     }),
-    async ({ domain, type, limit, tabId }: any) => {
+    async ({ domain, type, limit, tabId }) => {
       const params = new URLSearchParams();
       if (domain) params.set('domain', domain);
       if (type) params.set('type', type);
@@ -67,7 +67,7 @@ export function registerNetworkTools(server: McpServer): void {
       readOnlyHint: false,
       openWorldHint: false,
     },
-    async ({ url, method, status, body, headers }: any) => {
+    async ({ url, method, status, body, headers }) => {
       const payload: Record<string, unknown> = { pattern: url };
       if (method) payload.method = method;
       if (status !== undefined) payload.status = status;

--- a/src/mcp/tools/passwords.ts
+++ b/src/mcp/tools/passwords.ts
@@ -44,7 +44,7 @@ export function registerPasswordTools(server: McpServer): void {
     coerceShape({
       length: z.number().optional().describe('Password length (default: 24)'),
     }),
-    async ({ length }: any) => {
+    async ({ length }) => {
       const query = length ? `?length=${length}` : '';
       const data = await apiCall('GET', `/passwords/generate${query}`);
       return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };

--- a/src/mcp/tools/pinboards.ts
+++ b/src/mcp/tools/pinboards.ts
@@ -153,7 +153,7 @@ export function registerPinboardTools(server: McpServer): void {
       id: z.string().describe('Pinboard ID'),
       itemIds: z.array(z.string()).describe('Ordered array of item IDs representing the new order'),
     }),
-    async ({ id, itemIds }: any) => {
+    async ({ id, itemIds }) => {
       const data = await apiCall('POST', `/pinboards/${encodeURIComponent(id)}/items/reorder`, { itemIds });
       await logActivity('pinboard_reorder_items', id);
       return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };

--- a/src/mcp/tools/sidebar.ts
+++ b/src/mcp/tools/sidebar.ts
@@ -59,7 +59,7 @@ export function registerSidebarTools(server: McpServer): void {
     coerceShape({
       orderedIds: z.array(z.string()).describe('Array of sidebar item IDs in desired order'),
     }),
-    async ({ orderedIds }: any) => {
+    async ({ orderedIds }) => {
       const data = await apiCall('POST', '/sidebar/reorder', { orderedIds });
       await logActivity('sidebar_reorder');
       return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };

--- a/src/mcp/tools/snapshots.ts
+++ b/src/mcp/tools/snapshots.ts
@@ -13,7 +13,7 @@ export function registerSnapshotTools(server: McpServer): void {
       interactive: z.boolean().optional().describe('Only include interactive elements'),
       selector: z.string().optional().describe('CSS selector to scope the snapshot to a subtree'),
     }),
-    async ({ tabId, compact, interactive, selector }: any) => {
+    async ({ tabId, compact, interactive, selector }) => {
       const params = new URLSearchParams();
       if (compact) params.set('compact', 'true');
       if (interactive) params.set('interactive', 'true');

--- a/src/mcp/tools/tasks.ts
+++ b/src/mcp/tools/tasks.ts
@@ -15,8 +15,8 @@ export function registerTaskTools(server: McpServer): void {
         params: z.record(z.string(), z.string()).optional().describe('Action parameters as key-value pairs'),
       })).describe('Steps to execute'),
     }),
-    async ({ description, steps }: any) => {
-      const formattedSteps = steps.map((s: any) => ({
+    async ({ description, steps }) => {
+      const formattedSteps = steps.map((s: { description: string; actionType: string; params?: Record<string, string> }) => ({
         description: s.description,
         action: { type: s.actionType, params: s.params || {} },
         riskLevel: 'low' as const,
@@ -113,7 +113,7 @@ export function registerTaskTools(server: McpServer): void {
       agent: z.string().optional().describe('Agent identifier claiming the lock'),
       timeout: z.number().optional().describe('Lock timeout in milliseconds'),
     }),
-    async ({ tabId, agent, timeout }: any) => {
+    async ({ tabId, agent, timeout }) => {
       const body: Record<string, unknown> = { tabId };
       if (agent) body.agent = agent;
       if (timeout !== undefined) body.timeout = timeout;
@@ -189,7 +189,7 @@ export function registerTaskTools(server: McpServer): void {
     coerceShape({
       limit: z.number().optional().describe('Maximum entries to return (default: 50)'),
     }),
-    async ({ limit }: any) => {
+    async ({ limit }) => {
       const params = new URLSearchParams();
       if (limit !== undefined) params.set('limit', String(limit));
       const qs = params.toString();

--- a/src/mcp/tools/watches.ts
+++ b/src/mcp/tools/watches.ts
@@ -21,7 +21,7 @@ export function registerWatchTools(server: McpServer): void {
       url: z.string().describe('URL to monitor'),
       intervalMinutes: z.number().optional().describe('Check interval in minutes (default: 30)'),
     }),
-    async ({ url, intervalMinutes }: any) => {
+    async ({ url, intervalMinutes }) => {
       const data = await apiCall('POST', '/watch/add', { url, intervalMinutes });
       await logActivity('watch_add', url);
       return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };

--- a/src/mcp/tools/window.ts
+++ b/src/mcp/tools/window.ts
@@ -32,7 +32,7 @@ export function registerWindowTools(server: McpServer): void {
       maxPages: z.number().optional().default(5).describe('Maximum number of pages to visit (1-10)'),
       searchEngine: z.enum(['google', 'duckduckgo']).optional().default('duckduckgo').describe('Search engine to use'),
     }),
-    async ({ query, maxPages, searchEngine }: any) => {
+    async ({ query, maxPages, searchEngine }) => {
       const clampedMax = Math.min(Math.max(maxPages || 5, 1), 10);
       await logActivity('research_start', `"${query}" (max ${clampedMax} pages via ${searchEngine})`);
 

--- a/src/mcp/tools/workflows.ts
+++ b/src/mcp/tools/workflows.ts
@@ -28,7 +28,7 @@ export function registerWorkflowTools(server: McpServer): void {
       description: z.string().optional().describe('Optional workflow description'),
       variables: z.record(z.string(), z.any()).optional().describe('Optional default variable values'),
     }),
-    async ({ name, steps, description, variables }: any) => {
+    async ({ name, steps, description, variables }) => {
       const body: Record<string, unknown> = { name, steps };
       if (description) body.description = description;
       if (variables) body.variables = variables;

--- a/src/memory/tests/site-memory.test.ts
+++ b/src/memory/tests/site-memory.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { WebContents } from 'electron';
 
 vi.mock('fs', async () => {
-  const actual = await vi.importActual('fs') as any;
+  const actual = await vi.importActual('fs') as Record<string, unknown>;
   return {
     ...actual,
     default: {
@@ -210,7 +210,7 @@ describe('SiteMemoryManager', () => {
 
     it('returns domain summaries from disk', () => {
       const siteData = { domain: 'example.com', lastVisit: 3000, visitCount: 5 };
-      vi.mocked(fs.readdirSync).mockReturnValue(['example.com.json' as any]);
+      vi.mocked(fs.readdirSync).mockReturnValue(['example.com.json' as unknown as fs.Dirent]);
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(siteData));
 
       const sites = smm.listSites();
@@ -220,7 +220,7 @@ describe('SiteMemoryManager', () => {
     });
 
     it('skips corrupt files', () => {
-      vi.mocked(fs.readdirSync).mockReturnValue(['bad.json' as any]);
+      vi.mocked(fs.readdirSync).mockReturnValue(['bad.json' as unknown as fs.Dirent]);
       vi.mocked(fs.readFileSync).mockReturnValue('not json');
 
       const sites = smm.listSites();
@@ -271,7 +271,7 @@ describe('SiteMemoryManager', () => {
         }],
         diffs: [],
       };
-      vi.mocked(fs.readdirSync).mockReturnValue(['example.com.json' as any]);
+      vi.mocked(fs.readdirSync).mockReturnValue(['example.com.json' as unknown as fs.Dirent]);
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(siteData));
 
       const results = smm.search('searchterm');

--- a/src/passwords/tests/passwords.test.ts
+++ b/src/passwords/tests/passwords.test.ts
@@ -17,7 +17,7 @@ vi.mock('better-sqlite3', () => {
 });
 
 vi.mock('fs', async () => {
-  const actual = await vi.importActual('fs') as any;
+  const actual = await vi.importActual('fs') as Record<string, unknown>;
   return {
     ...actual,
     default: {

--- a/src/watch/tests/watcher.test.ts
+++ b/src/watch/tests/watcher.test.ts
@@ -19,7 +19,7 @@ vi.mock('electron', () => ({
 }));
 
 vi.mock('fs', async () => {
-  const actual = await vi.importActual('fs') as any;
+  const actual = await vi.importActual('fs') as Record<string, unknown>;
   return {
     ...actual,
     default: {

--- a/src/workflow/tests/engine.test.ts
+++ b/src/workflow/tests/engine.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { BrowserWindow } from 'electron';
 
 vi.mock('fs', async () => {
-  const actual = await vi.importActual('fs') as any;
+  const actual = await vi.importActual('fs') as Record<string, unknown>;
   return {
     ...actual,
     existsSync: vi.fn().mockReturnValue(false),
@@ -85,7 +85,7 @@ describe('WorkflowEngine', () => {
 
     it('reads and parses workflow JSON files', async () => {
       const workflow = { id: 'w1', name: 'Test', steps: [], createdAt: '2024-01-01', updatedAt: '2024-01-01' };
-      vi.mocked(fs.readdirSync).mockReturnValue(['w1.json' as any]);
+      vi.mocked(fs.readdirSync).mockReturnValue(['w1.json' as unknown as fs.Dirent]);
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(workflow));
 
       const workflows = await engine.getWorkflows();
@@ -94,7 +94,7 @@ describe('WorkflowEngine', () => {
     });
 
     it('skips non-json files', async () => {
-      vi.mocked(fs.readdirSync).mockReturnValue(['readme.md' as any, 'w1.json' as any]);
+      vi.mocked(fs.readdirSync).mockReturnValue(['readme.md' as unknown as fs.Dirent, 'w1.json' as unknown as fs.Dirent]);
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({ id: 'w1', name: 'Test', steps: [] }));
 
       const workflows = await engine.getWorkflows();
@@ -145,7 +145,7 @@ describe('WorkflowEngine', () => {
           { id: 's1', type: 'wait', params: { duration: 60000 } }, // long wait
         ], createdAt: '2024-01-01', updatedAt: '2024-01-01',
       };
-      vi.mocked(fs.readdirSync).mockReturnValue(['w1.json' as any]);
+      vi.mocked(fs.readdirSync).mockReturnValue(['w1.json' as unknown as fs.Dirent]);
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(workflow));
 
       const webview = createMockWebview();
@@ -181,7 +181,7 @@ describe('WorkflowEngine', () => {
       const workflow = {
         id: 'w1', name: 'Simple', steps: [], createdAt: '2024-01-01', updatedAt: '2024-01-01',
       };
-      vi.mocked(fs.readdirSync).mockReturnValue(['w1.json' as any]);
+      vi.mocked(fs.readdirSync).mockReturnValue(['w1.json' as unknown as fs.Dirent]);
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(workflow));
 
       const webview = createMockWebview();
@@ -195,7 +195,7 @@ describe('WorkflowEngine', () => {
         variables: { a: 1 },
         createdAt: '2024-01-01', updatedAt: '2024-01-01',
       };
-      vi.mocked(fs.readdirSync).mockReturnValue(['w1.json' as any]);
+      vi.mocked(fs.readdirSync).mockReturnValue(['w1.json' as unknown as fs.Dirent]);
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(workflow));
 
       const webview = createMockWebview();
@@ -221,7 +221,7 @@ describe('WorkflowEngine', () => {
           { id: 'after', type: 'wait', params: { duration: 1 } },
         ], variables: { flag: true }, createdAt: '2024-01-01', updatedAt: '2024-01-01',
       };
-      vi.mocked(fs.readdirSync).mockReturnValue(['w1.json' as any]);
+      vi.mocked(fs.readdirSync).mockReturnValue(['w1.json' as unknown as fs.Dirent]);
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(workflow));
 
       const webview = createMockWebview();


### PR DESCRIPTION
## Summary

- **Made `coerceShape` generic** to preserve Zod schema types through the MCP SDK, enabling TypeScript to automatically infer tool handler parameter types — this is the root fix that eliminates all 34 `: any` annotations on MCP tool handlers at once
- **Replaced `as any` casts** in source files (`native-messaging.ts`, `coerce.ts`) with properly typed assertions using `unknown` intermediaries
- **Improved test type safety**: replaced `vi.importActual('fs') as any` with `as Record<string, unknown>`, string-to-Dirent casts with `as unknown as fs.Dirent`, and removed unnecessary eslint-disable directives

### Changes by file count
- 20 MCP tool files: removed `: any` parameter annotations (now inferred)
- 1 core file: `coerce.ts` — generic `coerceShape<T>` + typed Zod internal cast
- 1 source file: `native-messaging.ts` — typed Electron session API probing
- 1 test helper: `mcp-test-helper.ts` — concrete types replacing `any`
- 7 test files: safer mock patterns

### What's NOT changed
- No runtime logic changes — types only
- Test mock objects using `as any` in `helpers.ts` and similar test utilities are left as-is (eslint `no-explicit-any` is intentionally `off` for test files)
- `z.any()` in Zod schemas (e.g. workflow variables) — these are intentional schema definitions, not TypeScript `any`

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `npm run verify` — lint + compile + tests + consistency all pass
- [x] `npm test` — 87 test files, 1871 tests passed
- [ ] CI checks (verify.yml + codeql.yml) pass on PR