### PR TITLE
fix: use lcov format and token for Codecov upload

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -32,5 +32,6 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
-          files: coverage/coverage-summary.json
+          files: coverage/lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     ],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'html', 'json-summary'],
+      reporter: ['text', 'html', 'json-summary', 'lcov'],
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.test.ts', 'src/**/tests/**', 'node_modules'],
       reportOnFailure: true,


### PR DESCRIPTION
## Summary

- Add `lcov` reporter to vitest coverage config — Codecov cannot parse `json-summary`, which is why the badge shows 0%
- Update `verify.yml` to upload `coverage/lcov.info` instead of `coverage-summary.json`
- Pass `CODECOV_TOKEN` secret to `codecov-action@v4` (required for authentication)

## Test plan

- [ ] CI verify.yml passes
- [ ] Codecov badge updates from 0% to ~44% after merge