### PR TITLE
test: add 6 missing route tests and refine coverage excludes

### DIFF
--- a/src/api/tests/helpers.ts
+++ b/src/api/tests/helpers.ts
@@ -524,6 +524,7 @@ export function createMockContext(): RouteContext {
       updateItem: vi.fn().mockReturnValue({ id: 'item-1', type: 'link', createdAt: '', position: 0 }),
       deleteItem: vi.fn().mockReturnValue(true),
       reorderItems: vi.fn().mockReturnValue(true),
+      updateBoardSettings: vi.fn().mockReturnValue({ id: 'pb-1', name: 'Test', emoji: '📌', createdAt: '', updatedAt: '', items: [], settings: {} }),
       destroy: vi.fn(),
     } as any,
 

--- a/src/api/tests/routes/awareness.test.ts
+++ b/src/api/tests/routes/awareness.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+
+vi.mock('electron', () => ({
+  BrowserWindow: vi.fn(),
+  session: {},
+}));
+
+import { registerAwarenessRoutes } from '../../routes/awareness';
+import { createMockContext, createTestApp } from '../helpers';
+import type { RouteContext } from '../../context';
+
+describe('Awareness Routes', () => {
+  let ctx: RouteContext;
+  let app: ReturnType<typeof createTestApp>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ctx = createMockContext();
+    app = createTestApp(registerAwarenessRoutes, ctx);
+  });
+
+  // ─── GET /awareness/digest ───────────────────────
+
+  describe('GET /awareness/digest', () => {
+    it('returns a digest with default 5 minutes', async () => {
+      const res = await request(app).get('/awareness/digest');
+
+      expect(res.status).toBe(200);
+      expect(res.body.period).toBeDefined();
+      expect(res.body.navigation).toBeDefined();
+      expect(res.body.interactions).toBeDefined();
+      expect(res.body.errors).toBeDefined();
+      expect(res.body.tabs).toBeDefined();
+      expect(res.body.downloads).toBeDefined();
+      expect(res.body.watches).toBeDefined();
+      expect(res.body.summary).toBeDefined();
+      expect(ctx.activityTracker.getLog).toHaveBeenCalled();
+      expect(ctx.eventStream.getRecent).toHaveBeenCalled();
+    });
+
+    it('respects minutes query param', async () => {
+      const res = await request(app).get('/awareness/digest?minutes=10');
+
+      expect(res.status).toBe(200);
+      expect(res.body.period).toBeDefined();
+    });
+
+    it('caps minutes at 60', async () => {
+      const res = await request(app).get('/awareness/digest?minutes=120');
+
+      expect(res.status).toBe(200);
+      // The period should be at most 60 minutes
+      const duration = res.body.period.to - res.body.period.from;
+      expect(duration).toBeLessThanOrEqual(60 * 60_000 + 1000); // 60 min + small tolerance
+    });
+
+    it('respects since query param', async () => {
+      const since = Date.now() - 30_000;
+      const res = await request(app).get(`/awareness/digest?since=${since}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.period.from).toBe(since);
+    });
+
+    it('includes navigation data from activity entries', async () => {
+      const now = Date.now();
+      vi.mocked(ctx.activityTracker.getLog).mockReturnValue([
+        { type: 'navigate', timestamp: now - 5000, data: { url: 'https://example.com', title: 'Example' } },
+        { type: 'navigate', timestamp: now - 2000, data: { url: 'https://test.com', title: 'Test' } },
+      ] as any);
+
+      const res = await request(app).get('/awareness/digest');
+
+      expect(res.status).toBe(200);
+      expect(res.body.navigation.total_navigations).toBe(2);
+      expect(res.body.navigation.sites_visited).toContain('example.com');
+    });
+
+    it('includes click count in interactions', async () => {
+      const now = Date.now();
+      vi.mocked(ctx.activityTracker.getLog).mockReturnValue([
+        { type: 'click', timestamp: now - 1000, data: {} },
+        { type: 'click', timestamp: now - 500, data: {} },
+      ] as any);
+
+      const res = await request(app).get('/awareness/digest');
+
+      expect(res.status).toBe(200);
+      expect(res.body.interactions.clicks).toBe(2);
+    });
+
+    it('includes console errors when available', async () => {
+      const now = Date.now();
+      vi.mocked(ctx.devToolsManager.getConsoleErrors).mockReturnValue([
+        { level: 'error', text: 'Uncaught TypeError', url: 'https://example.com/app.js', timestamp: now - 1000 },
+      ] as any);
+
+      const res = await request(app).get('/awareness/digest');
+
+      expect(res.status).toBe(200);
+      expect(res.body.errors.console_errors.length).toBe(1);
+      expect(res.body.errors.console_errors[0].message).toBe('Uncaught TypeError');
+    });
+
+    it('handles devtools not attached gracefully', async () => {
+      vi.mocked(ctx.devToolsManager.getConsoleErrors).mockImplementation(() => { throw new Error('CDP not attached'); });
+      vi.mocked(ctx.devToolsManager.getNetworkEntries).mockImplementation(() => { throw new Error('CDP not attached'); });
+
+      const res = await request(app).get('/awareness/digest');
+
+      expect(res.status).toBe(200);
+      expect(res.body.errors.console_errors).toEqual([]);
+      expect(res.body.errors.network_failures).toEqual([]);
+    });
+
+    it('includes completed downloads', async () => {
+      vi.mocked(ctx.downloadManager.list).mockReturnValue([
+        { status: 'completed', endTime: new Date().toISOString(), filename: 'file.pdf', savePath: '/tmp/file.pdf' },
+      ] as any);
+
+      const res = await request(app).get('/awareness/digest');
+
+      expect(res.status).toBe(200);
+      expect(res.body.downloads.completed.length).toBe(1);
+    });
+
+    it('includes watch changes', async () => {
+      const now = Date.now();
+      vi.mocked(ctx.watchManager.listWatches).mockReturnValue([
+        { id: 'w1', url: 'https://example.com', lastCheck: now - 1000, changeCount: 2 },
+      ] as any);
+
+      const res = await request(app).get('/awareness/digest');
+
+      expect(res.status).toBe(200);
+      expect(res.body.watches.changes_detected.length).toBe(1);
+    });
+  });
+
+  // ─── GET /awareness/focus ────────────────────────
+
+  describe('GET /awareness/focus', () => {
+    it('returns focus context with active tab', async () => {
+      const res = await request(app).get('/awareness/focus');
+
+      expect(res.status).toBe(200);
+      expect(res.body.tab).toBeDefined();
+      expect(res.body.tab.url).toBe('https://example.com');
+      expect(res.body.activity).toBeDefined();
+      expect(res.body.idle_seconds).toBeDefined();
+    });
+
+    it('returns idle when no recent activity', async () => {
+      const res = await request(app).get('/awareness/focus');
+
+      expect(res.status).toBe(200);
+      // No activity entries → idle_seconds will be large
+      expect(res.body.activity).toBe('idle');
+    });
+
+    it('detects typing activity', async () => {
+      const now = Date.now();
+      vi.mocked(ctx.activityTracker.getLog).mockReturnValue([
+        { type: 'input', timestamp: now - 2000, data: {} },
+      ] as any);
+
+      const res = await request(app).get('/awareness/focus');
+
+      expect(res.status).toBe(200);
+      expect(res.body.activity).toBe('typing');
+    });
+
+    it('detects navigating activity', async () => {
+      const now = Date.now();
+      vi.mocked(ctx.activityTracker.getLog).mockReturnValue([
+        { type: 'navigate', timestamp: now - 2000, data: {} },
+      ] as any);
+
+      const res = await request(app).get('/awareness/focus');
+
+      expect(res.status).toBe(200);
+      expect(res.body.activity).toBe('navigating');
+    });
+
+    it('returns null tab when no active tab', async () => {
+      vi.mocked(ctx.tabManager.getActiveTab).mockReturnValue(null);
+
+      const res = await request(app).get('/awareness/focus');
+
+      expect(res.status).toBe(200);
+      expect(res.body.tab).toBeNull();
+    });
+
+    it('checks for console and network errors', async () => {
+      const now = Date.now();
+      vi.mocked(ctx.devToolsManager.getConsoleErrors).mockReturnValue([
+        { level: 'error', text: 'err', url: '', timestamp: now - 1000 },
+      ] as any);
+
+      const res = await request(app).get('/awareness/focus');
+
+      expect(res.status).toBe(200);
+      expect(res.body.has_console_errors).toBe(true);
+    });
+
+    it('handles devtools errors gracefully', async () => {
+      vi.mocked(ctx.devToolsManager.getConsoleErrors).mockImplementation(() => { throw new Error('no CDP'); });
+      vi.mocked(ctx.devToolsManager.getNetworkEntries).mockImplementation(() => { throw new Error('no CDP'); });
+
+      const res = await request(app).get('/awareness/focus');
+
+      expect(res.status).toBe(200);
+      expect(res.body.has_console_errors).toBe(false);
+      expect(res.body.has_network_errors).toBe(false);
+    });
+  });
+});

--- a/src/api/tests/routes/clipboard.test.ts
+++ b/src/api/tests/routes/clipboard.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+
+vi.mock('electron', () => ({
+  BrowserWindow: vi.fn(),
+  session: {},
+}));
+
+import { registerClipboardRoutes } from '../../routes/clipboard';
+import { createMockContext, createTestApp } from '../helpers';
+import type { RouteContext } from '../../context';
+
+describe('Clipboard Routes', () => {
+  let ctx: RouteContext;
+  let app: ReturnType<typeof createTestApp>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ctx = createMockContext();
+    app = createTestApp(registerClipboardRoutes, ctx);
+  });
+
+  // ─── GET /clipboard ──────────────────────────────
+
+  describe('GET /clipboard', () => {
+    it('returns clipboard content', async () => {
+      vi.mocked(ctx.clipboardManager.read).mockReturnValue({
+        hasText: true, hasImage: false, hasHTML: false,
+        text: 'hello', formats: ['text/plain'],
+      } as any);
+
+      const res = await request(app).get('/clipboard');
+
+      expect(res.status).toBe(200);
+      expect(res.body.hasText).toBe(true);
+      expect(res.body.text).toBe('hello');
+    });
+
+    it('returns 500 when read throws', async () => {
+      vi.mocked(ctx.clipboardManager.read).mockImplementation(() => { throw new Error('fail'); });
+
+      const res = await request(app).get('/clipboard');
+
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe('fail');
+    });
+  });
+
+  // ─── POST /clipboard/text ────────────────────────
+
+  describe('POST /clipboard/text', () => {
+    it('writes text to clipboard', async () => {
+      const res = await request(app)
+        .post('/clipboard/text')
+        .send({ text: 'copied' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(ctx.clipboardManager.writeText).toHaveBeenCalledWith('copied');
+    });
+
+    it('returns 400 when text is missing', async () => {
+      const res = await request(app)
+        .post('/clipboard/text')
+        .send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('text is required (string)');
+    });
+
+    it('returns 400 when text is not a string', async () => {
+      const res = await request(app)
+        .post('/clipboard/text')
+        .send({ text: 42 });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ─── POST /clipboard/image ───────────────────────
+
+  describe('POST /clipboard/image', () => {
+    it('writes image to clipboard', async () => {
+      const res = await request(app)
+        .post('/clipboard/image')
+        .send({ base64: 'iVBORw0KGgo=' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(ctx.clipboardManager.writeImage).toHaveBeenCalledWith('iVBORw0KGgo=');
+    });
+
+    it('returns 400 when base64 is missing', async () => {
+      const res = await request(app)
+        .post('/clipboard/image')
+        .send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('base64 is required (string)');
+    });
+  });
+
+  // ─── POST /clipboard/save ────────────────────────
+
+  describe('POST /clipboard/save', () => {
+    it('saves clipboard to file', async () => {
+      const res = await request(app)
+        .post('/clipboard/save')
+        .send({ filename: 'clip.png' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.path).toBeDefined();
+      expect(ctx.clipboardManager.saveAs).toHaveBeenCalledWith({
+        filename: 'clip.png', format: undefined, quality: undefined,
+      });
+    });
+
+    it('passes valid format and quality', async () => {
+      const res = await request(app)
+        .post('/clipboard/save')
+        .send({ filename: 'clip.jpg', format: 'jpg', quality: 80 });
+
+      expect(res.status).toBe(200);
+      expect(ctx.clipboardManager.saveAs).toHaveBeenCalledWith({
+        filename: 'clip.jpg', format: 'jpg', quality: 80,
+      });
+    });
+
+    it('ignores invalid format', async () => {
+      await request(app)
+        .post('/clipboard/save')
+        .send({ filename: 'clip.bmp', format: 'bmp' });
+
+      expect(ctx.clipboardManager.saveAs).toHaveBeenCalledWith({
+        filename: 'clip.bmp', format: undefined, quality: undefined,
+      });
+    });
+
+    it('returns 400 when filename is missing', async () => {
+      const res = await request(app)
+        .post('/clipboard/save')
+        .send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('filename is required (string)');
+    });
+
+    it('returns 500 when saveAs throws', async () => {
+      vi.mocked(ctx.clipboardManager.saveAs).mockImplementation(() => { throw new Error('disk full'); });
+
+      const res = await request(app)
+        .post('/clipboard/save')
+        .send({ filename: 'clip.png' });
+
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe('disk full');
+    });
+  });
+});

--- a/src/api/tests/routes/pinboards.test.ts
+++ b/src/api/tests/routes/pinboards.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+
+vi.mock('electron', () => ({
+  BrowserWindow: vi.fn(),
+  session: {},
+}));
+
+import { registerPinboardRoutes } from '../../routes/pinboards';
+import { createMockContext, createTestApp } from '../helpers';
+import type { RouteContext } from '../../context';
+
+describe('Pinboard Routes', () => {
+  let ctx: RouteContext;
+  let app: ReturnType<typeof createTestApp>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ctx = createMockContext();
+    app = createTestApp(registerPinboardRoutes, ctx);
+  });
+
+  // ─── GET /pinboards ──────────────────────────────
+
+  describe('GET /pinboards', () => {
+    it('lists all boards', async () => {
+      const res = await request(app).get('/pinboards');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.boards).toEqual([]);
+    });
+  });
+
+  // ─── POST /pinboards ─────────────────────────────
+
+  describe('POST /pinboards', () => {
+    it('creates a board', async () => {
+      const res = await request(app)
+        .post('/pinboards')
+        .send({ name: 'Research', emoji: '🔬' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(ctx.pinboardManager.createBoard).toHaveBeenCalledWith('Research', '🔬');
+    });
+
+    it('returns 400 when name is missing', async () => {
+      const res = await request(app)
+        .post('/pinboards')
+        .send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('name required');
+    });
+  });
+
+  // ─── GET /pinboards/:id ──────────────────────────
+
+  describe('GET /pinboards/:id', () => {
+    it('returns board with items', async () => {
+      vi.mocked(ctx.pinboardManager.getBoard).mockReturnValue({
+        id: 'pb-1', name: 'Test', items: [],
+      } as any);
+
+      const res = await request(app).get('/pinboards/pb-1');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.board.id).toBe('pb-1');
+    });
+
+    it('returns 404 when board not found', async () => {
+      const res = await request(app).get('/pinboards/missing');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Board not found');
+    });
+  });
+
+  // ─── PUT /pinboards/:id ──────────────────────────
+
+  describe('PUT /pinboards/:id', () => {
+    it('updates a board', async () => {
+      const res = await request(app)
+        .put('/pinboards/pb-1')
+        .send({ name: 'Renamed' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(ctx.pinboardManager.updateBoard).toHaveBeenCalledWith('pb-1', { name: 'Renamed', emoji: undefined });
+    });
+
+    it('returns 404 when board not found', async () => {
+      vi.mocked(ctx.pinboardManager.updateBoard).mockReturnValue(null);
+
+      const res = await request(app)
+        .put('/pinboards/pb-1')
+        .send({ name: 'Renamed' });
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  // ─── PUT /pinboards/:id/settings ─────────────────
+
+  describe('PUT /pinboards/:id/settings', () => {
+    it('updates board settings', async () => {
+      const res = await request(app)
+        .put('/pinboards/pb-1/settings')
+        .send({ layout: 'grid', background: '#000' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(ctx.pinboardManager.updateBoardSettings).toHaveBeenCalledWith('pb-1', { layout: 'grid', background: '#000' });
+    });
+
+    it('returns 404 when board not found', async () => {
+      vi.mocked(ctx.pinboardManager.updateBoardSettings).mockReturnValue(null);
+
+      const res = await request(app)
+        .put('/pinboards/pb-1/settings')
+        .send({ layout: 'grid' });
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  // ─── DELETE /pinboards/:id ───────────────────────
+
+  describe('DELETE /pinboards/:id', () => {
+    it('deletes a board', async () => {
+      const res = await request(app).delete('/pinboards/pb-1');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+    });
+
+    it('returns 404 when board not found', async () => {
+      vi.mocked(ctx.pinboardManager.deleteBoard).mockReturnValue(false);
+
+      const res = await request(app).delete('/pinboards/missing');
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  // ─── GET /pinboards/:id/items ────────────────────
+
+  describe('GET /pinboards/:id/items', () => {
+    it('returns items for a board', async () => {
+      const res = await request(app).get('/pinboards/pb-1/items');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.items).toEqual([]);
+    });
+
+    it('returns 404 when board not found', async () => {
+      vi.mocked(ctx.pinboardManager.getItems).mockReturnValue(null as any);
+
+      const res = await request(app).get('/pinboards/missing/items');
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  // ─── POST /pinboards/:id/items ───────────────────
+
+  describe('POST /pinboards/:id/items', () => {
+    it('adds an item to a board', async () => {
+      const res = await request(app)
+        .post('/pinboards/pb-1/items')
+        .send({ type: 'link', url: 'https://example.com', title: 'Example' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.item).toBeDefined();
+    });
+
+    it('returns 400 when type is missing', async () => {
+      const res = await request(app)
+        .post('/pinboards/pb-1/items')
+        .send({ url: 'https://example.com' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('type required');
+    });
+
+    it('returns 400 for invalid type', async () => {
+      const res = await request(app)
+        .post('/pinboards/pb-1/items')
+        .send({ type: 'video' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('type must be link, image, text, or quote');
+    });
+
+    it('returns 404 when board not found', async () => {
+      vi.mocked(ctx.pinboardManager.addItem).mockResolvedValue(null as any);
+
+      const res = await request(app)
+        .post('/pinboards/missing/items')
+        .send({ type: 'link', url: 'https://example.com' });
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  // ─── PUT /pinboards/:id/items/:itemId ────────────
+
+  describe('PUT /pinboards/:id/items/:itemId', () => {
+    it('updates an item', async () => {
+      const res = await request(app)
+        .put('/pinboards/pb-1/items/item-1')
+        .send({ title: 'Updated' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+    });
+
+    it('returns 404 when item not found', async () => {
+      vi.mocked(ctx.pinboardManager.updateItem).mockReturnValue(null);
+
+      const res = await request(app)
+        .put('/pinboards/pb-1/items/missing')
+        .send({ title: 'Updated' });
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  // ─── DELETE /pinboards/:id/items/:itemId ─────────
+
+  describe('DELETE /pinboards/:id/items/:itemId', () => {
+    it('deletes an item', async () => {
+      const res = await request(app).delete('/pinboards/pb-1/items/item-1');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+    });
+
+    it('returns 404 when item not found', async () => {
+      vi.mocked(ctx.pinboardManager.deleteItem).mockReturnValue(false);
+
+      const res = await request(app).delete('/pinboards/pb-1/items/missing');
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  // ─── POST /pinboards/:id/items/reorder ───────────
+
+  describe('POST /pinboards/:id/items/reorder', () => {
+    it('reorders items', async () => {
+      const res = await request(app)
+        .post('/pinboards/pb-1/items/reorder')
+        .send({ itemIds: ['item-2', 'item-1'] });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(ctx.pinboardManager.reorderItems).toHaveBeenCalledWith('pb-1', ['item-2', 'item-1']);
+    });
+
+    it('returns 400 when itemIds is missing', async () => {
+      const res = await request(app)
+        .post('/pinboards/pb-1/items/reorder')
+        .send({});
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('itemIds array required');
+    });
+
+    it('returns 404 when board not found', async () => {
+      vi.mocked(ctx.pinboardManager.reorderItems).mockReturnValue(false);
+
+      const res = await request(app)
+        .post('/pinboards/missing/items/reorder')
+        .send({ itemIds: ['item-1'] });
+
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/src/api/tests/routes/previews.test.ts
+++ b/src/api/tests/routes/previews.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import fs from 'fs';
+
+vi.mock('electron', () => ({
+  BrowserWindow: vi.fn(),
+  session: {},
+}));
+
+vi.mock('fs', () => ({
+  default: {
+    existsSync: vi.fn().mockReturnValue(true),
+    mkdirSync: vi.fn(),
+    readFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    readdirSync: vi.fn().mockReturnValue([]),
+    unlinkSync: vi.fn(),
+  },
+  existsSync: vi.fn().mockReturnValue(true),
+  mkdirSync: vi.fn(),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  readdirSync: vi.fn().mockReturnValue([]),
+  unlinkSync: vi.fn(),
+}));
+
+vi.mock('../../utils/paths', () => ({
+  tandemDir: () => '/tmp/tandem-test',
+}));
+
+import { registerPreviewRoutes } from '../../routes/previews';
+import { createMockContext, createTestApp } from '../helpers';
+import type { RouteContext } from '../../context';
+
+const samplePreview = {
+  id: 'my-preview',
+  title: 'My Preview',
+  html: '<h1>Hello</h1>',
+  createdAt: '2025-01-01T00:00:00.000Z',
+  updatedAt: '2025-01-01T00:00:00.000Z',
+  version: 1,
+};
+
+describe('Preview Routes', () => {
+  let ctx: RouteContext;
+  let app: ReturnType<typeof createTestApp>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ctx = createMockContext();
+    app = createTestApp(registerPreviewRoutes, ctx);
+
+    // Default: no files on disk
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readdirSync).mockReturnValue([] as any);
+  });
+
+  // ─── GET /previews ───────────────────────────────
+
+  describe('GET /previews', () => {
+    it('returns empty list when no previews', async () => {
+      const res = await request(app).get('/previews');
+
+      expect(res.status).toBe(200);
+      expect(res.body.previews).toEqual([]);
+    });
+
+    it('returns list of previews', async () => {
+      vi.mocked(fs.readdirSync).mockReturnValue(['my-preview.json'] as any);
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(samplePreview));
+
+      const res = await request(app).get('/previews');
+
+      expect(res.status).toBe(200);
+      expect(res.body.previews.length).toBe(1);
+      expect(res.body.previews[0].id).toBe('my-preview');
+      // Should not include html in the list
+      expect(res.body.previews[0].html).toBeUndefined();
+    });
+  });
+
+  // ─── POST /preview ───────────────────────────────
+
+  describe('POST /preview', () => {
+    it('creates a new preview', async () => {
+      // First existsSync for previewsDir, second for uniqueSlug check
+      vi.mocked(fs.existsSync)
+        .mockReturnValueOnce(true)   // previewsDir exists
+        .mockReturnValueOnce(false); // slug not taken
+
+      const res = await request(app)
+        .post('/preview')
+        .send({ html: '<h1>Test</h1>', title: 'Test Preview' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.id).toBeDefined();
+      expect(res.body.url).toContain('/preview/');
+      expect(fs.writeFileSync).toHaveBeenCalled();
+    });
+
+    it('returns 400 when html is missing', async () => {
+      const res = await request(app)
+        .post('/preview')
+        .send({ title: 'No HTML' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('html is required');
+    });
+
+    it('opens tab by default', async () => {
+      vi.mocked(fs.existsSync)
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(false);
+
+      await request(app)
+        .post('/preview')
+        .send({ html: '<h1>Test</h1>' });
+
+      expect(ctx.tabManager.openTab).toHaveBeenCalled();
+    });
+
+    it('skips opening tab when openTab is false', async () => {
+      vi.mocked(fs.existsSync)
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(false);
+
+      await request(app)
+        .post('/preview')
+        .send({ html: '<h1>Test</h1>', openTab: false });
+
+      expect(ctx.tabManager.openTab).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── PUT /preview/:id ────────────────────────────
+
+  describe('PUT /preview/:id', () => {
+    it('updates an existing preview', async () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(samplePreview));
+
+      const res = await request(app)
+        .put('/preview/my-preview')
+        .send({ html: '<h1>Updated</h1>' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.version).toBe(2);
+      expect(fs.writeFileSync).toHaveBeenCalled();
+    });
+
+    it('returns 404 when preview not found', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const res = await request(app)
+        .put('/preview/nonexistent')
+        .send({ html: '<h1>Test</h1>' });
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  // ─── GET /preview/:id/meta ───────────────────────
+
+  describe('GET /preview/:id/meta', () => {
+    it('returns preview metadata', async () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(samplePreview));
+
+      const res = await request(app).get('/preview/my-preview/meta');
+
+      expect(res.status).toBe(200);
+      expect(res.body.id).toBe('my-preview');
+      expect(res.body.version).toBe(1);
+      expect(res.body.html).toBeUndefined();
+    });
+
+    it('returns 404 when not found', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const res = await request(app).get('/preview/missing/meta');
+
+      expect(res.status).toBe(404);
+    });
+  });
+
+  // ─── GET /preview/:id ────────────────────────────
+
+  describe('GET /preview/:id', () => {
+    it('serves preview HTML with live-reload script', async () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(samplePreview));
+
+      const res = await request(app).get('/preview/my-preview');
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('html');
+      expect(res.text).toContain('<h1>Hello</h1>');
+      expect(res.text).toContain('setInterval'); // live-reload script
+    });
+
+    it('returns 404 HTML when not found', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const res = await request(app).get('/preview/missing');
+
+      expect(res.status).toBe(404);
+      expect(res.text).toContain('Preview not found');
+    });
+  });
+
+  // ─── DELETE /preview/:id ─────────────────────────
+
+  describe('DELETE /preview/:id', () => {
+    it('deletes a preview', async () => {
+      const res = await request(app).delete('/preview/my-preview');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(fs.unlinkSync).toHaveBeenCalled();
+    });
+
+    it('returns 404 when preview not found', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const res = await request(app).delete('/preview/missing');
+
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/src/api/tests/routes/sidebar.test.ts
+++ b/src/api/tests/routes/sidebar.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+
+vi.mock('electron', () => ({
+  BrowserWindow: vi.fn(),
+  session: {},
+}));
+
+import { registerSidebarRoutes } from '../../routes/sidebar';
+import { createMockContext, createTestApp } from '../helpers';
+import type { RouteContext } from '../../context';
+
+describe('Sidebar Routes', () => {
+  let ctx: RouteContext;
+  let app: ReturnType<typeof createTestApp>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ctx = createMockContext();
+    app = createTestApp(registerSidebarRoutes, ctx);
+  });
+
+  // ─── GET /sidebar/config ─────────────────────────
+
+  describe('GET /sidebar/config', () => {
+    it('returns sidebar config', async () => {
+      const res = await request(app).get('/sidebar/config');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.config).toBeDefined();
+      expect(ctx.sidebarManager.getConfig).toHaveBeenCalled();
+    });
+  });
+
+  // ─── POST /sidebar/config ────────────────────────
+
+  describe('POST /sidebar/config', () => {
+    it('updates sidebar config', async () => {
+      const res = await request(app)
+        .post('/sidebar/config')
+        .send({ state: 'wide' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(ctx.sidebarManager.updateConfig).toHaveBeenCalledWith({ state: 'wide' });
+    });
+  });
+
+  // ─── POST /sidebar/items/:id/toggle ──────────────
+
+  describe('POST /sidebar/items/:id/toggle', () => {
+    it('toggles an item', async () => {
+      const res = await request(app)
+        .post('/sidebar/items/bookmarks/toggle');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(ctx.sidebarManager.toggleItem).toHaveBeenCalledWith('bookmarks');
+    });
+
+    it('returns 404 when item not found', async () => {
+      vi.mocked(ctx.sidebarManager.toggleItem).mockReturnValue(null);
+
+      const res = await request(app)
+        .post('/sidebar/items/nonexistent/toggle');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Item not found');
+    });
+  });
+
+  // ─── POST /sidebar/items/:id/activate ────────────
+
+  describe('POST /sidebar/items/:id/activate', () => {
+    it('activates an item when not already active', async () => {
+      vi.mocked(ctx.sidebarManager.getConfig).mockReturnValue({
+        state: 'narrow', activeItemId: null, items: [],
+      } as any);
+
+      const res = await request(app)
+        .post('/sidebar/items/bookmarks/activate');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.activeItemId).toBe('bookmarks');
+      expect(ctx.sidebarManager.setActiveItem).toHaveBeenCalledWith('bookmarks');
+    });
+
+    it('deactivates an item when already active', async () => {
+      vi.mocked(ctx.sidebarManager.getConfig).mockReturnValue({
+        state: 'narrow', activeItemId: 'bookmarks', items: [],
+      } as any);
+
+      const res = await request(app)
+        .post('/sidebar/items/bookmarks/activate');
+
+      expect(res.status).toBe(200);
+      expect(res.body.activeItemId).toBeNull();
+      expect(ctx.sidebarManager.setActiveItem).toHaveBeenCalledWith(null);
+    });
+  });
+
+  // ─── POST /sidebar/reorder ───────────────────────
+
+  describe('POST /sidebar/reorder', () => {
+    it('reorders items', async () => {
+      const res = await request(app)
+        .post('/sidebar/reorder')
+        .send({ orderedIds: ['history', 'bookmarks'] });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(ctx.sidebarManager.reorderItems).toHaveBeenCalledWith(['history', 'bookmarks']);
+    });
+
+    it('returns 400 when orderedIds is not an array', async () => {
+      const res = await request(app)
+        .post('/sidebar/reorder')
+        .send({ orderedIds: 'bookmarks' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('orderedIds must be array');
+    });
+  });
+
+  // ─── POST /sidebar/state ─────────────────────────
+
+  describe('POST /sidebar/state', () => {
+    it('sets state to wide', async () => {
+      const res = await request(app)
+        .post('/sidebar/state')
+        .send({ state: 'wide' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.state).toBe('wide');
+      expect(ctx.sidebarManager.setState).toHaveBeenCalledWith('wide');
+    });
+
+    it('returns 400 for invalid state', async () => {
+      const res = await request(app)
+        .post('/sidebar/state')
+        .send({ state: 'huge' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('state must be hidden|narrow|wide');
+    });
+  });
+});

--- a/src/api/tests/routes/sync.test.ts
+++ b/src/api/tests/routes/sync.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+
+vi.mock('electron', () => ({
+  BrowserWindow: vi.fn(),
+  session: {},
+}));
+
+import { registerSyncRoutes } from '../../routes/sync';
+import { createMockContext, createTestApp } from '../helpers';
+import type { RouteContext } from '../../context';
+
+describe('Sync Routes', () => {
+  let ctx: RouteContext;
+  let app: ReturnType<typeof createTestApp>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ctx = createMockContext();
+    app = createTestApp(registerSyncRoutes, ctx);
+  });
+
+  // ─── GET /sync/status ────────────────────────────
+
+  describe('GET /sync/status', () => {
+    it('returns unconfigured status by default', async () => {
+      const res = await request(app).get('/sync/status');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.enabled).toBe(false);
+      expect(res.body.devicesFound).toEqual([]);
+    });
+
+    it('returns configured status with devices', async () => {
+      vi.mocked(ctx.syncManager.getConfig).mockReturnValue({
+        enabled: true, syncRoot: '/shared', deviceName: 'MacBook',
+      } as any);
+      vi.mocked(ctx.syncManager.isConfigured).mockReturnValue(true);
+      vi.mocked(ctx.syncManager.getRemoteDevices).mockReturnValue([
+        { name: 'iPad' }, { name: 'iMac' },
+      ] as any);
+
+      const res = await request(app).get('/sync/status');
+
+      expect(res.status).toBe(200);
+      expect(res.body.enabled).toBe(true);
+      expect(res.body.syncRoot).toBe('/shared');
+      expect(res.body.devicesFound).toEqual(['iPad', 'iMac']);
+    });
+
+    it('returns 500 when syncManager throws', async () => {
+      vi.mocked(ctx.syncManager.getConfig).mockImplementation(() => { throw new Error('fail'); });
+
+      const res = await request(app).get('/sync/status');
+
+      expect(res.status).toBe(500);
+    });
+  });
+
+  // ─── GET /sync/devices ───────────────────────────
+
+  describe('GET /sync/devices', () => {
+    it('returns remote devices', async () => {
+      vi.mocked(ctx.syncManager.getRemoteDevices).mockReturnValue([
+        { name: 'iPad', lastSeen: Date.now() },
+      ] as any);
+
+      const res = await request(app).get('/sync/devices');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.devices.length).toBe(1);
+    });
+  });
+
+  // ─── POST /sync/config ───────────────────────────
+
+  describe('POST /sync/config', () => {
+    it('updates sync configuration', async () => {
+      vi.mocked(ctx.configManager.updateConfig).mockReturnValue({
+        deviceSync: { enabled: true, syncRoot: '/shared', deviceName: 'MacBook' },
+      } as any);
+
+      const res = await request(app)
+        .post('/sync/config')
+        .send({ enabled: true, deviceName: 'MacBook' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(ctx.configManager.updateConfig).toHaveBeenCalled();
+    });
+
+    it('returns 400 when syncRoot is not a string', async () => {
+      const res = await request(app)
+        .post('/sync/config')
+        .send({ syncRoot: 42 });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('syncRoot must be a string');
+    });
+
+    it('re-inits sync manager when enabled with syncRoot', async () => {
+      vi.mocked(ctx.configManager.updateConfig).mockReturnValue({
+        deviceSync: { enabled: true, syncRoot: '/shared', deviceName: 'Mac' },
+      } as any);
+
+      // Only send enabled + deviceName — syncRoot goes through
+      // normalizeExistingDirectoryPath which validates the path on disk.
+      // The configManager mock returns a config with syncRoot set,
+      // so the re-init branch is reached.
+      await request(app)
+        .post('/sync/config')
+        .send({ enabled: true, deviceName: 'Mac' });
+
+      expect(ctx.syncManager.init).toHaveBeenCalled();
+    });
+  });
+
+  // ─── POST /sync/trigger ──────────────────────────
+
+  describe('POST /sync/trigger', () => {
+    it('publishes tabs and history', async () => {
+      vi.mocked(ctx.syncManager.isConfigured).mockReturnValue(true);
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([
+        { id: 'tab-1', url: 'https://example.com', title: 'Example', favicon: '' },
+      ] as any);
+      vi.mocked(ctx.historyManager.getHistory).mockReturnValue([
+        { url: 'https://example.com', title: 'Example' },
+      ] as any);
+
+      const res = await request(app).post('/sync/trigger');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.tabsPublished).toBe(1);
+      expect(res.body.historyPublished).toBe(1);
+      expect(ctx.syncManager.publishTabs).toHaveBeenCalled();
+      expect(ctx.syncManager.publishHistory).toHaveBeenCalled();
+    });
+
+    it('returns 400 when sync is not configured', async () => {
+      const res = await request(app).post('/sync/trigger');
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Sync is not configured or disabled');
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -44,6 +44,12 @@ export default defineConfig({
         'src/events/**',
         'src/notifications/**',
         'src/claronote/**',
+        // Electron-dependent modules missed in first pass
+        'src/behavior/observer.ts',
+        'src/extensions/toolbar.ts',
+        'src/mcp/server.ts',
+        'src/mcp/api-client.ts',
+        'src/agents/x-scout.ts',
         // Security modules that need CDP, webContents, or SQLite at runtime
         'src/security/behavior-monitor.ts',
         'src/security/content-analyzer.ts',


### PR DESCRIPTION
## Summary

- Add route tests for 6 untested route files: **clipboard**, **sidebar**, **pinboards**, **awareness**, **previews**, **sync** (86 new test cases)
- Exclude 5 more Electron-dependent modules from coverage that always report 0% (behavior/observer, extensions/toolbar, mcp/server, mcp/api-client, agents/x-scout)
- Add `updateBoardSettings` mock to test helpers

**Results:** 93 test files, 1957 tests, coverage **~68%** (up from ~54% on Codecov)

## Test plan

- [x] `npm run verify` passes locally (93 test files, 1957 tests)
- [ ] CI verify.yml passes
- [ ] Codecov badge updates to ~68% after merge