### PR TITLE
docs: add community links for GitHub Discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,18 @@ contributors, not yet a polished mass-user release.
 - Binaries: not published yet (source-only)
 - Current version: see [package.json](package.json)
 
+## Community
+
+Have a question, idea, or want to show what you've built with Tandem?
+Join [GitHub Discussions](https://github.com/hydro13/tandem-browser/discussions).
+
+- **Q&A** — troubleshooting, "how do I…" questions
+- **Ideas** — feature proposals before they become issues
+- **Show and Tell** — your setups, workflows, and screenshots
+
+For bugs and concrete feature requests, open an
+[issue](https://github.com/hydro13/tandem-browser/issues).
+
 ## Contributing
 
 Good contribution areas:
@@ -205,6 +217,7 @@ Start with [CONTRIBUTING.md](CONTRIBUTING.md) and [PROJECT.md](PROJECT.md).
 | [CONTRIBUTING.md](CONTRIBUTING.md) | How to contribute |
 | [skill/SKILL.md](skill/SKILL.md) | Agent instruction manual |
 | [SECURITY.md](SECURITY.md) | Vulnerability reporting |
+| [Discussions](https://github.com/hydro13/tandem-browser/discussions) | Community Q&A, ideas, show & tell |
 | [docs/](docs/) | Full documentation |
 
 ## License

--- a/docs/index.html
+++ b/docs/index.html
@@ -122,6 +122,7 @@ footer a:hover{color:var(--text2)}
 <a href="/api">API</a>
 <a href="#start">Get started</a>
 <a href="https://github.com/hydro13/tandem-browser">GitHub</a>
+<a href="https://github.com/hydro13/tandem-browser/discussions">Community</a>
 <a href="https://github.com/sponsors/hydro13" style="color:var(--accent)">Sponsor</a>
 </div>
 </nav>
@@ -307,6 +308,7 @@ The browser opens. The API starts on <code>localhost:8765</code>.</p>
 <div>&copy; 2026 Tandem Browser &middot; MIT License &middot; tandembrowser.org</div>
 <div>
 <a href="https://github.com/hydro13/tandem-browser">GitHub</a> &middot;
+<a href="https://github.com/hydro13/tandem-browser/discussions">Community</a> &middot;
 <a href="https://github.com/sponsors/hydro13">Sponsor</a> &middot;
 <a href="https://github.com/hydro13/tandem-browser/issues">Issues</a>
 </div>


### PR DESCRIPTION
## Summary

- Enable GitHub Discussions (done via API)
- Add "Community" link to tandembrowser.org nav bar and footer
- Add new **Community** section to README explaining Discussions categories
- Add Discussions to the Repository Guide table
- Created welcome post: #109

## Test plan

- [x] `npm run verify` passes
- [ ] CI passes
- [ ] Links on tandembrowser.org work after merge