### PR TITLE
docs: integrate Discussions into issue templates, contributing guide, and README

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,14 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Ask a question
+    url: https://github.com/hydro13/tandem-browser/discussions/categories/q-a
+    about: Not sure it's a bug? Ask in Q&A Discussions first.
+  - name: Share an idea
+    url: https://github.com/hydro13/tandem-browser/discussions/categories/ideas
+    about: Have a rough idea that isn't a concrete feature request yet? Start a Discussion.
+  - name: Show what you built
+    url: https://github.com/hydro13/tandem-browser/discussions/categories/show-and-tell
+    about: Share your Tandem setup, workflows, or integrations with the community.
   - name: Security issue
     url: https://github.com/hydro13/tandem-browser/security
     about: Use private security reporting if available. Do not post exploit details publicly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,8 +54,10 @@ Useful contribution areas right now include:
 - UI polish in the shared human + Wingman workflow
 - docs cleanup where public setup or project status is confusing
 
-If you are unsure where to start, opening an issue with a concrete bug report,
-validation result, or implementation question is already useful.
+If you are unsure where to start, open a thread in
+[Discussions](https://github.com/hydro13/tandem-browser/discussions) — Q&A for
+questions, Ideas for proposals that need exploration. For concrete bugs and
+well-defined feature requests, open an issue.
 
 ## Development Workflow
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Version](https://img.shields.io/github/package-json/v/hydro13/tandem-browser)](package.json)
 [![Coverage](https://codecov.io/gh/hydro13/tandem-browser/branch/main/graph/badge.svg)](https://codecov.io/gh/hydro13/tandem-browser)
+[![Ask a question](https://img.shields.io/badge/discussions-Q%26A-blue)](https://github.com/hydro13/tandem-browser/discussions/categories/q-a)
 
 **236 MCP tools. Plug in any AI. No scraping. No API wrangling.**
 


### PR DESCRIPTION
## Summary

- Add 3 contact links to issue template chooser (Q&A, Ideas, Show & Tell) so users are guided to Discussions before opening an issue for non-bug topics
- Update CONTRIBUTING.md to mention Discussions as the place for questions and proposals
- Add Q&A Discussions badge to README badge row
- Created seed posts: Show & Tell (#111), Q&A (#112, #113)

## Test plan

- [x] `npm run verify` passes
- [ ] CI passes
- [ ] Issue template chooser shows Discussion links