### PR TITLE
refactor: remove hardcoded 'kees', use 'wingman' consistently

### DIFF
--- a/shell/chat/claude-activity-backend.js
+++ b/shell/chat/claude-activity-backend.js
@@ -112,7 +112,7 @@ class ClaudeActivityBackend {
         if (m.id > this._lastSeenId) {
           this._lastSeenId = m.id;
           // Only emit Claude messages (not our own robin messages) during polling
-          if (m.from === 'claude' || m.from === 'kees') {
+          if (m.from === 'claude' || m.from === 'wingman') {
             this._emit('message', {
               id: m.id.toString(),
               role: 'assistant',

--- a/shell/js/wingman.js
+++ b/shell/js/wingman.js
@@ -190,8 +190,8 @@
         else if (event.data.title) text = `${event.type}: ${event.data.title}`;
 
         const rawSource = event.data.source || 'robin';
-        const source = ['kees', 'robin'].includes(rawSource) ? rawSource : 'robin';
-        const sourceEmoji = source === 'kees' ? '🤖' : '👤';
+        const source = ['wingman', 'robin'].includes(rawSource) ? rawSource : 'robin';
+        const sourceEmoji = source === 'wingman' ? '🤖' : '👤';
         const item = document.createElement('div');
         item.className = 'activity-item';
         item.innerHTML = `<span class="a-icon">${icon}</span><span class="a-source ${source}">${sourceEmoji}</span><span class="a-text">${escapeHtml(text)}</span><span class="a-time">${time}</span>`;
@@ -207,7 +207,7 @@
           if (id === data.tabId) {
             const sourceEl = entry.tabEl.querySelector('.tab-source');
             if (sourceEl) {
-              if (data.source === 'kees') {
+              if (data.source === 'wingman') {
                 sourceEl.textContent = '🤖';
                 sourceEl.title = 'AI controlled — click to take over';
                 sourceEl.style.display = '';
@@ -218,7 +218,7 @@
               }
             }
             // Visual indicator: purple bottom border for AI tabs
-            if (data.source === 'kees') {
+            if (data.source === 'wingman') {
               entry.tabEl.style.borderBottom = '2px solid #7c3aed';
             } else {
               entry.tabEl.style.borderBottom = '';
@@ -1019,7 +1019,7 @@
           // msg: {id, from, text, timestamp, image}
           // Skip robin messages — already shown optimistically in the UI
           if (msg.from === 'robin') return;
-          const source = msg.from; // 'kees' or 'claude'
+          const source = msg.from; // 'wingman' or 'claude'
           appendMessage('assistant', msg.text, msg.timestamp, source, msg.image);
           if (messagesEl) messagesEl.scrollTop = messagesEl.scrollHeight;
         });

--- a/src/api/routes/media.ts
+++ b/src/api/routes/media.ts
@@ -80,7 +80,7 @@ export function registerMediaRoutes(router: Router, ctx: RouteContext): void {
   router.post('/chat', (req: Request, res: Response) => {
     const { text, from, image } = req.body;
     if (!text && !image) { res.status(400).json({ error: 'text or image required' }); return; }
-    const sender: 'robin' | 'wingman' | 'kees' | 'claude' = (from === 'robin') ? 'robin' : (from === 'claude') ? 'claude' : 'wingman';
+    const sender: 'robin' | 'wingman' | 'claude' = (from === 'robin') ? 'robin' : (from === 'claude') ? 'claude' : 'wingman';
     try {
       let savedImage: string | undefined;
       if (image) {

--- a/src/api/routes/tabs.ts
+++ b/src/api/routes/tabs.ts
@@ -31,7 +31,7 @@ export function registerTabRoutes(router: Router, ctx: RouteContext): void {
       return;
     }
     try {
-      const tabSource = source === 'kees' || source === 'wingman' ? 'wingman' as const : 'robin' as const;
+      const tabSource = source === 'wingman' ? 'wingman' as const : 'robin' as const;
       const tab = await ctx.tabManager.openTab(
         url,
         groupId,

--- a/src/api/tests/routes/tabs.test.ts
+++ b/src/api/tests/routes/tabs.test.ts
@@ -85,15 +85,15 @@ describe('Tab Routes', () => {
       );
     });
 
-    it('maps "kees" source to wingman', async () => {
+    it('maps unknown source to robin', async () => {
       await request(app)
         .post('/tabs/open')
-        .send({ source: 'kees' });
+        .send({ source: 'unknown' });
 
       expect(ctx.tabManager.openTab).toHaveBeenCalledWith(
         'about:blank',
         undefined,
-        'wingman',
+        'robin',
         'persist:tandem',
         true,
         undefined,

--- a/src/context-menu/menu-builder.ts
+++ b/src/context-menu/menu-builder.ts
@@ -621,9 +621,9 @@ export class ContextMenuBuilder {
     }));
     const currentSource = this.deps.tabManager.getTabSource(tabId);
     menu.append(new MenuItem({
-      label: currentSource === 'kees' ? 'Take back from Wingman' : 'Let Wingman handle this tab',
+      label: currentSource === 'wingman' ? 'Take back from Wingman' : 'Let Wingman handle this tab',
       click: () => {
-        const newSource = this.deps.tabManager.getTabSource(tabId) === 'kees' ? 'robin' : 'kees';
+        const newSource = this.deps.tabManager.getTabSource(tabId) === 'wingman' ? 'robin' : 'wingman';
         this.deps.tabManager.setTabSource(tabId, newSource);
       },
     }));

--- a/src/context-menu/types.ts
+++ b/src/context-menu/types.ts
@@ -34,7 +34,7 @@ export interface ContextMenuParams {
   };
   // Tandem-specific
   tabId?: string;
-  tabSource?: 'robin' | 'kees' | 'wingman';
+  tabSource?: 'robin' | 'wingman';
 }
 
 /**

--- a/src/ipc/handlers.ts
+++ b/src/ipc/handlers.ts
@@ -153,7 +153,7 @@ export function registerIpcHandlers(deps: IpcDeps): void {
   });
 
   ipcMain.handle(IpcChannels.CHAT_PERSIST_MESSAGE, async (_event, data: {
-    from: 'robin' | 'wingman' | 'kees' | 'claude';
+    from: 'robin' | 'wingman' | 'claude';
     text?: string;
     image?: string;
     notifyWebhook?: boolean;

--- a/src/panel/manager.ts
+++ b/src/panel/manager.ts
@@ -20,7 +20,7 @@ export interface ActivityEvent {
 
 export interface ChatMessage {
   id: number;
-  from: 'robin' | 'wingman' | 'kees' | 'claude';
+  from: 'robin' | 'wingman' | 'claude';
   text: string;
   timestamp: number;
   image?: string;  // relative filename in ~/.tandem/chat-images/
@@ -114,7 +114,7 @@ export class PanelManager {
 
   /** Add a chat message */
   addChatMessage(
-    from: 'robin' | 'wingman' | 'kees' | 'claude',
+    from: 'robin' | 'wingman' | 'claude',
     text: string,
     image?: string,
     opts: AddChatMessageOptions = {},
@@ -132,7 +132,7 @@ export class PanelManager {
       this.win.webContents.send(IpcChannels.CHAT_MESSAGE, msg);
     }
     // Clear typing indicator when wingman sends a message
-    if ((from === 'wingman' || from === 'kees') && this.wingmanTyping) {
+    if (from === 'wingman' && this.wingmanTyping) {
       this.setWingmanTyping(false);
     }
 

--- a/src/panel/tests/manager.test.ts
+++ b/src/panel/tests/manager.test.ts
@@ -75,6 +75,20 @@ describe('PanelManager reply notifications', () => {
     expect(wingmanAlert).toHaveBeenCalledWith('Claude replied', 'I have another suggestion.');
   });
 
+  it('clears typing indicator when wingman sends a message', () => {
+    const win = createWindowStub();
+    const manager = new PanelManager(win as never);
+
+    manager.setWingmanTyping(true);
+    manager.addChatMessage('wingman', 'Done thinking.');
+
+    // Typing indicator should be cleared — verified by the IPC send
+    const typingCalls = (win.webContents.send as any).mock.calls
+      .filter((c: any[]) => c[0] === 'wingman-typing');
+    const lastTyping = typingCalls[typingCalls.length - 1];
+    expect(lastTyping[1]).toEqual({ typing: false });
+  });
+
   it('falls back to an image message when there is no text', () => {
     const win = createWindowStub();
     const manager = new PanelManager(win as never);

--- a/src/preload/panel.ts
+++ b/src/preload/panel.ts
@@ -28,7 +28,7 @@ export function createPanelApi() {
     },
     sendChatImage: (text: string, image: string) => ipcRenderer.invoke(IpcChannels.CHAT_SEND_IMAGE, { text, image }),
     persistChatMessage: (data: {
-      from: 'robin' | 'wingman' | 'kees' | 'claude';
+      from: 'robin' | 'wingman' | 'claude';
       text?: string;
       image?: string;
       notifyWebhook?: boolean;

--- a/src/tabs/manager.ts
+++ b/src/tabs/manager.ts
@@ -9,7 +9,7 @@ const log = createLogger('TabManager');
 
 // ─── Types ──────────────────────────────────────────────────────────
 
-export type TabSource = 'robin' | 'kees' | 'wingman';
+export type TabSource = 'robin' | 'wingman';
 
 export interface Tab {
   id: string;

--- a/src/tabs/tests/tabs.test.ts
+++ b/src/tabs/tests/tabs.test.ts
@@ -168,10 +168,10 @@ describe('TabManager', () => {
     });
 
     it('sends tab-source-changed IPC', async () => {
-      await tm.openTab('https://test.com', undefined, 'kees');
+      await tm.openTab('https://test.com', undefined, 'wingman');
       expect(win.webContents.send).toHaveBeenCalledWith(
         'tab-source-changed',
-        expect.objectContaining({ source: 'kees' })
+        expect.objectContaining({ source: 'wingman' })
       );
     });
   });
@@ -290,12 +290,12 @@ describe('TabManager', () => {
   describe('setTabSource()', () => {
     it('changes the tab source', async () => {
       const tab = await tm.openTab('https://test.com');
-      tm.setTabSource(tab.id, 'kees');
-      expect(tm.getTabSource(tab.id)).toBe('kees');
+      tm.setTabSource(tab.id, 'wingman');
+      expect(tm.getTabSource(tab.id)).toBe('wingman');
     });
 
     it('returns false for unknown tab', () => {
-      expect(tm.setTabSource('nope', 'kees')).toBe(false);
+      expect(tm.setTabSource('nope', 'wingman')).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary
- Replace all `'kees'` references with `'wingman'` across the codebase
- `TabSource` type simplified from `'robin' | 'kees' | 'wingman'` to `'robin' | 'wingman'`
- Chat message `from` type simplified from `'robin' | 'wingman' | 'kees' | 'claude'` to `'robin' | 'wingman' | 'claude'`
- Config migration code preserved for backward compatibility (existing users with `kees*` config keys)

## Why
`kees` was a personal name hardcoded in the public repo. All AI-related identifiers should use the generic `wingman`.

## Files changed (12)
- Type definitions: `tabs/manager.ts`, `context-menu/types.ts`, `panel/manager.ts`, `preload/panel.ts`, `ipc/handlers.ts`
- Logic: `api/routes/tabs.ts`, `api/routes/media.ts`, `context-menu/menu-builder.ts`
- Shell: `wingman.js`, `claude-activity-backend.js`
- Tests: `tabs.test.ts`, `tabs.test.ts` (api)

## Test plan
- [x] `npx vitest run` — 1976 tests passing
- [x] `npx tsc --noEmit` — 0 errors
- [x] Config migration tests still pass (backward compat preserved)