### PR TITLE
fix: multi-actor workspace consistency and ownership context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Tandem Browser will be documented in this file.
 
+## [v0.71.1] - 2026-04-13
+
+- fix: stabilize multi-actor workspace, tab, SSE, and MCP ownership context
+
+### Fixed
+
+- Active workspace selection and active tab ownership now reconcile deterministically instead of drifting apart during focus changes, workspace switches, or agent-opened tabs
+- `GET /workspaces` now reports whether the active workspace comes from a focused tab or an explicit workspace selection
+- `GET /active-tab/context` now includes trustworthy workspace/source/actor ownership data for the active tab and the global tab list
+- `/events/stream` now attaches workspace and actor/source context to tab-driven events when known
+- Workspace activation no longer forces a focus churn when the target workspace already has a live tab; empty-workspace activation remains explicit as a `selection`
+- MCP tab/chat actions now use a single configurable actor source (`TANDEM_SOURCE` / `TANDEM_MCP_SOURCE` / `TANDEM_ACTOR_SOURCE`) instead of a hardcoded `wingman`/`claude` split
+- MCP resources (`tandem://tabs/list`, `tandem://context`) now surface workspace/source ownership details instead of hiding them behind older global summaries
+
 ## [v0.71.0] - 2026-04-11
 
 - feat: tab emoji badges — assign emoji to tabs for quick visual identification

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@
 > Historical release summaries belong in `CHANGELOG.md`.
 > Architecture and product context belong in `PROJECT.md`.
 
-Last updated: April 9, 2026
+Last updated: April 13, 2026
 
 ## Purpose
 
@@ -59,6 +59,7 @@ Last updated: April 9, 2026
 - [x] Replace the last mixed shell entrypoint with dedicated `shell/js/window-chrome.js` and `shell/js/shortcut-router.js` modules so `main.js` is no longer needed as a catch-all shell loader
 - [ ] Investigate strict Gatekeeper fallback blocking mainstream site scripts when the local agent bridge is unavailable; manual startup checks on March 14, 2026 showed GitHub asset scripts being denied under `strict_low_trust_script`
 - [ ] Investigate the remaining 1Password MV3 service-worker startup noise (`DidStartWorkerFail ...: 5` and policy calculation errors) and determine whether it affects any real user-facing behavior; the old `__tandemExtensionHeaders` background error is fixed, and current manual checks indicate the extension still works for normal use
+- [ ] Make `ContextBridge` summaries natively actor/workspace-aware so `/context/summary` and other non-MCP consumers stop relying on MCP-side enrichment for ownership context
 - [x] Add GitHub Actions verification for `npm run verify` on pushes and pull requests
 
 ## Later
@@ -102,6 +103,7 @@ Last updated: April 9, 2026
 - [x] Preload sandbox fix: added esbuild bundling step so the split preload modules work with Electron's `sandbox: true`
 - [x] Security dependency updates: resolved all 28 Dependabot alerts (electron, hono, lodash, brace-expansion, path-to-regexp)
 - [x] Workspace API handoff for OpenClaw: `/tabs/open` now honors `workspaceId`, `/workspaces/:id/activate` and `/workspaces/:id/tabs` exist, and `/wingman-alert` can bring the requested workspace into view before notifying the user
+- [x] Multi-actor workspace consistency: focused tab ownership, workspace selection, and SSE context now stay explicit across HTTP and MCP surfaces
 - [x] API `X-Tab-Id` targeting for `/snapshot`, `/page-content`, `/page-html`, and `/execute-js`, with background-tab-safe CDP evaluation and tab-scoped snapshot refs
 - [x] Password manager: local SQLite + AES-256-GCM vault, master password, autofill, password generator, and `GET /passwords/suggest`
 - [x] Behavioral learning models: profile compiler, typing timing model, mouse trajectory replay, and fallback humanization behavior

--- a/shell/js/tabs.js
+++ b/shell/js/tabs.js
@@ -13,6 +13,7 @@
     /** Map of tabId -> { webview, tabEl } */
     const tabs = new Map();
     let activeTabId = null;
+    let nextFocusClaimsOwnership = false;
     let updateTabMeta = baseUpdateTabMeta;
     const activeTabListeners = new Set();
     const tabZoomLevels = new Map();
@@ -99,6 +100,7 @@
         if (event.target.classList.contains('tab-close')) return;
         const currentTabId = tabEl.dataset.tabId;
         if (currentTabId && window.tandem) {
+          nextFocusClaimsOwnership = true;
           window.tandem.focusTab(currentTabId);
         }
       });
@@ -345,6 +347,12 @@
 
       focusTab(tabId) {
         focusRendererTab(tabId);
+      },
+
+      consumeUserOwnershipClaim() {
+        const shouldClaim = nextFocusClaimsOwnership;
+        nextFocusClaimsOwnership = false;
+        return shouldClaim;
       },
 
       setEmoji(tabId, emoji, flash) {

--- a/shell/js/wingman.js
+++ b/shell/js/wingman.js
@@ -189,9 +189,10 @@
         else if (event.data.selector) text = `${event.type}: ${event.data.selector}`;
         else if (event.data.title) text = `${event.type}: ${event.data.title}`;
 
-        const rawSource = event.data.source || 'user';
-        const source = ['wingman', 'user'].includes(rawSource) ? rawSource : 'user';
-        const sourceEmoji = source === 'wingman' ? '🤖' : '👤';
+        const source = typeof event.data.source === 'string' && event.data.source.trim()
+          ? event.data.source.trim()
+          : 'user';
+        const sourceEmoji = source === 'user' ? '👤' : '🤖';
         const item = document.createElement('div');
         item.className = 'activity-item';
         item.innerHTML = `<span class="a-icon">${icon}</span><span class="a-source ${source}">${sourceEmoji}</span><span class="a-text">${escapeHtml(text)}</span><span class="a-time">${time}</span>`;
@@ -207,9 +208,9 @@
           if (id === data.tabId) {
             const sourceEl = entry.tabEl.querySelector('.tab-source');
             if (sourceEl) {
-              if (data.source === 'wingman') {
+              if (data.source && data.source !== 'user') {
                 sourceEl.textContent = '🤖';
-                sourceEl.title = 'AI controlled — click to take over';
+                sourceEl.title = `${data.source} controls this tab — click to take over`;
                 sourceEl.style.display = '';
               } else {
                 sourceEl.textContent = '';
@@ -218,7 +219,7 @@
               }
             }
             // Visual indicator: purple bottom border for AI tabs
-            if (data.source === 'wingman') {
+            if (data.source && data.source !== 'user') {
               entry.tabEl.style.borderBottom = '2px solid #7c3aed';
             } else {
               entry.tabEl.style.borderBottom = '';
@@ -247,7 +248,12 @@
       // Hook into existing tab click by patching focusTab handler
       const _origFocusTab = window.__tandemTabs.focusTab;
       window.__tandemTabs.focusTab = function (tabId) {
-        origTabClickHandler(tabId);
+        const shouldClaim = typeof window.__tandemTabs.consumeUserOwnershipClaim === 'function'
+          ? window.__tandemTabs.consumeUserOwnershipClaim()
+          : false;
+        if (shouldClaim) {
+          origTabClickHandler(tabId);
+        }
         return _origFocusTab.call(window.__tandemTabs, tabId);
       };
 

--- a/src/api/routes/misc.ts
+++ b/src/api/routes/misc.ts
@@ -8,6 +8,8 @@ import { getPasswordManager } from '../../passwords/manager';
 import { tandemDir } from '../../utils/paths';
 import { handleRouteError } from '../../utils/errors';
 import { createRateLimitMiddleware } from '../rate-limit';
+import { getActorContext, normalizeTabSource } from '../../tabs/context';
+import { buildOwnershipContextForTab } from '../../tabs/runtime-context';
 
 // Module-level live mode state (was a closure variable in server.ts)
 let liveMode = false;
@@ -186,8 +188,22 @@ export function registerMiscRoutes(router: Router, ctx: RouteContext): void {
   router.get('/active-tab/context', async (_req: Request, res: Response) => {
     try {
       const tab = ctx.tabManager.getActiveTab();
+      const trackedTabIds = ctx.tabManager.listTabs().map(currentTab => currentTab.webContentsId);
+      ctx.workspaceManager.reconcileTabState(trackedTabIds, tab?.webContentsId ?? null);
+      const selectedWorkspace = ctx.workspaceManager.getActive();
+
       if (!tab) {
-        res.json({ ready: false, activeTab: null, tabs: [] });
+      res.json({
+        ready: false,
+        scope: { activeTab: 'tab', tabs: 'global' },
+        activeWorkspace: {
+          id: selectedWorkspace?.id ?? null,
+          name: selectedWorkspace?.name ?? null,
+          derivedFrom: ctx.workspaceManager.getActiveSource(),
+        },
+        activeTab: null,
+        tabs: [],
+      });
         return;
       }
 
@@ -215,15 +231,32 @@ export function registerMiscRoutes(router: Router, ctx: RouteContext): void {
         } catch { /* best-effort */ }
       }
 
+      const activeContext = buildOwnershipContextForTab(ctx.workspaceManager, tab);
       const allTabs = ctx.tabManager.listTabs().map(t => ({
         id: t.id,
         url: t.url,
         title: t.title,
         active: t.id === tab.id,
+        workspaceId: ctx.workspaceManager.getWorkspaceIdForTab(t.webContentsId),
+        workspaceName: (() => {
+          const workspaceId = ctx.workspaceManager.getWorkspaceIdForTab(t.webContentsId);
+          return workspaceId ? ctx.workspaceManager.get(workspaceId)?.name ?? null : null;
+        })(),
+        source: normalizeTabSource(t.source),
+        actor: getActorContext(t.source),
       }));
 
       res.json({
         ready: !!wc,
+        scope: { activeTab: 'tab', tabs: 'global' },
+        activeWorkspace: {
+          id: selectedWorkspace?.id ?? null,
+          name: selectedWorkspace?.name ?? null,
+          derivedFrom: ctx.workspaceManager.getActiveSource(),
+          matchesFocusedTab: selectedWorkspace?.id
+            ? selectedWorkspace.id === activeContext.workspace.id
+            : activeContext.workspace.matchesSelection,
+        },
         activeTab: {
           id: tab.id,
           url: tab.url,
@@ -231,6 +264,11 @@ export function registerMiscRoutes(router: Router, ctx: RouteContext): void {
           loading: wc ? wc.isLoading() : false,
           viewport,
           pageTextExcerpt,
+          workspaceId: activeContext.workspace.id,
+          workspaceName: activeContext.workspace.name,
+          source: activeContext.source,
+          actor: activeContext.actor,
+          context: activeContext,
         },
         tabs: allTabs,
       });

--- a/src/api/routes/tabs.ts
+++ b/src/api/routes/tabs.ts
@@ -2,6 +2,7 @@ import type { Router, Request, Response } from 'express';
 import { webContents } from 'electron';
 import type { RouteContext } from '../context';
 import { handleRouteError } from '../../utils/errors';
+import { normalizeTabSource } from '../../tabs/context';
 
 /**
  * Register all tab-related API routes (open, close, list, focus, group, source, reconcile, cleanup).
@@ -31,17 +32,21 @@ export function registerTabRoutes(router: Router, ctx: RouteContext): void {
       return;
     }
     try {
-      const tabSource = source === 'wingman' ? 'wingman' as const : 'user' as const;
+      const tabSource = normalizeTabSource(source) ?? 'user';
+      const shouldFocusAfterWorkspaceMove = Boolean(workspaceId) && focus !== false;
       const tab = await ctx.tabManager.openTab(
         url,
         groupId,
         tabSource,
         'persist:tandem',
-        focus,
+        shouldFocusAfterWorkspaceMove ? false : focus,
         inheritSessionFrom ? { inheritSessionFrom } : undefined,
       );
       if (workspaceId) {
         ctx.workspaceManager.moveTab(tab.webContentsId, workspaceId);
+        if (shouldFocusAfterWorkspaceMove) {
+          await ctx.tabManager.focusTab(tab.id);
+        }
       }
       ctx.panelManager.logActivity('tab-open', {
         url,
@@ -108,7 +113,11 @@ export function registerTabRoutes(router: Router, ctx: RouteContext): void {
       if (!tabId || !source) {
         return res.status(400).json({ error: 'tabId and source required' });
       }
-      const ok = ctx.tabManager.setTabSource(tabId, source);
+      const tabSource = normalizeTabSource(source);
+      if (!tabSource) {
+        return res.status(400).json({ error: 'source must be a non-empty string' });
+      }
+      const ok = ctx.tabManager.setTabSource(tabId, tabSource);
       res.json({ ok });
     } catch (e) {
       handleRouteError(res, e);

--- a/src/api/routes/workspaces.ts
+++ b/src/api/routes/workspaces.ts
@@ -29,9 +29,25 @@ export function registerWorkspaceRoutes(router: Router, ctx: RouteContext): void
 
   router.get('/workspaces', (_req: Request, res: Response) => {
     try {
+      const tabs = ctx.tabManager.listTabs();
+      const activeTab = ctx.tabManager.getActiveTab();
+      ctx.workspaceManager.reconcileTabState(
+        tabs.map(tab => tab.webContentsId),
+        activeTab?.webContentsId ?? null,
+      );
       const workspaces = ctx.workspaceManager.list();
       const activeId = ctx.workspaceManager.getActiveId();
-      res.json({ ok: true, workspaces, activeId });
+      res.json({
+        ok: true,
+        scope: 'global',
+        workspaces,
+        activeId,
+        activeTabId: activeTab?.id ?? null,
+        activeTabWorkspaceId: activeTab
+          ? ctx.workspaceManager.getWorkspaceIdForTab(activeTab.webContentsId)
+          : null,
+        activeWorkspaceSource: ctx.workspaceManager.getActiveSource(),
+      });
     } catch (e: unknown) {
       handleRouteError(res, e);
     }
@@ -57,10 +73,50 @@ export function registerWorkspaceRoutes(router: Router, ctx: RouteContext): void
     }
   });
 
-  const activateWorkspace = (req: Request<IdParams>, res: Response) => {
+  const activateWorkspace = async (req: Request<IdParams>, res: Response) => {
     try {
-      const workspace = ctx.workspaceManager.switch(req.params.id);
-      res.json({ ok: true, workspace });
+      const tabs = ctx.tabManager.listTabs();
+      const tabByWebContentsId = new Map(tabs.map(tab => [tab.webContentsId, tab]));
+      const activeTabBeforeSwitch = ctx.tabManager.getActiveTab();
+      ctx.workspaceManager.reconcileTabState(
+        tabs.map(tab => tab.webContentsId),
+        activeTabBeforeSwitch?.webContentsId ?? null,
+      );
+
+      const workspace = ctx.workspaceManager.get(req.params.id);
+      if (!workspace) {
+        throw new Error(`Workspace ${req.params.id} not found`);
+      }
+
+      let focusedTabId: string | null = null;
+
+      if (workspace.tabIds.length > 0) {
+        const targetTab = workspace.tabIds
+          .map(tabId => tabByWebContentsId.get(tabId))
+          .find((tab): tab is NonNullable<typeof tab> => Boolean(tab));
+        if (targetTab) {
+          await ctx.tabManager.focusTab(targetTab.id);
+          focusedTabId = targetTab.id;
+        } else {
+          ctx.workspaceManager.switch(req.params.id);
+        }
+      } else {
+        ctx.workspaceManager.switch(req.params.id);
+      }
+
+      const activeTab = ctx.tabManager.getActiveTab();
+      ctx.workspaceManager.reconcileTabState(
+        tabs.map(tab => tab.webContentsId),
+        activeTab?.webContentsId ?? null,
+      );
+
+      res.json({
+        ok: true,
+        scope: 'global',
+        workspace: ctx.workspaceManager.get(workspace.id) ?? workspace,
+        focusedTabId,
+        activeId: ctx.workspaceManager.getActiveId(),
+      });
     } catch (e: unknown) {
       handleRouteError(res, e);
     }

--- a/src/api/tests/helpers.ts
+++ b/src/api/tests/helpers.ts
@@ -67,6 +67,7 @@ export function createMockContext(): RouteContext {
       setGroup: vi.fn().mockReturnValue({ groupId: 'g1', name: 'Test', color: '#4285f4', tabIds: [] }),
       setTabSource: vi.fn().mockReturnValue(true),
       getActiveWebContents: vi.fn().mockResolvedValue(mockWC),
+      getActiveWebContentsId: vi.fn().mockReturnValue(100),
       getWebContents: vi.fn().mockReturnValue(mockWC),
       getActiveTab: vi.fn().mockReturnValue({
         id: 'tab-1',
@@ -77,6 +78,21 @@ export function createMockContext(): RouteContext {
         source: 'user',
         partition: 'persist:tandem',
       }),
+      getTab: vi.fn().mockImplementation((tabId: string) => {
+        if (tabId === 'tab-1') {
+          return {
+            id: 'tab-1',
+            webContentsId: 100,
+            url: 'https://example.com',
+            title: 'Example',
+            active: true,
+            source: 'user',
+            partition: 'persist:tandem',
+          };
+        }
+        return null;
+      }),
+      listWebContentsIds: vi.fn().mockReturnValue([100]),
       setEmoji: vi.fn().mockReturnValue(true),
       clearEmoji: vi.fn().mockReturnValue(true),
       flashEmoji: vi.fn().mockReturnValue(true),
@@ -495,11 +511,14 @@ export function createMockContext(): RouteContext {
       switch: vi.fn().mockReturnValue({ id: 'ws-1', name: 'Test', icon: 'briefcase', color: '#4285f4', order: 0, isDefault: false, tabIds: [] }),
       getActive: vi.fn().mockReturnValue({ id: 'ws-default', name: 'Default', icon: 'home', color: '#4285f4', order: 0, isDefault: true, tabIds: [] }),
       getActiveId: vi.fn().mockReturnValue('ws-default'),
+      getActiveSource: vi.fn().mockReturnValue('focused-tab'),
       get: vi.fn().mockReturnValue(null),
+      getWorkspaceIdForTab: vi.fn().mockReturnValue('ws-default'),
       update: vi.fn().mockReturnValue({ id: 'ws-1', name: 'Test', icon: 'briefcase', color: '#4285f4', order: 0, isDefault: false, tabIds: [] }),
       assignTab: vi.fn(),
       removeTab: vi.fn(),
       moveTab: vi.fn(),
+      reconcileTabState: vi.fn().mockReturnValue({ changed: false, activeId: 'ws-default' }),
       destroy: vi.fn(),
     } as any,
 

--- a/src/api/tests/routes/misc.test.ts
+++ b/src/api/tests/routes/misc.test.ts
@@ -167,6 +167,35 @@ describe('misc routes', () => {
   // ═══════════════════════════════════════════════
 
   describe('GET /active-tab/context', () => {
+    it('returns enriched no-tab response with activeWorkspace when there is no active tab', async () => {
+      vi.mocked(ctx.tabManager.getActiveTab).mockReturnValue(null as any);
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([]);
+      vi.mocked(ctx.workspaceManager.getActive).mockReturnValue({
+        id: 'ws-default',
+        name: 'Default',
+        icon: 'home',
+        color: '#4285f4',
+        order: 0,
+        isDefault: true,
+        tabIds: [],
+      } as any);
+      vi.mocked(ctx.workspaceManager.getActiveSource).mockReturnValue('selection');
+
+      const res = await request(app).get('/active-tab/context');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ready).toBe(false);
+      expect(res.body.activeTab).toBeNull();
+      expect(res.body.tabs).toEqual([]);
+      expect(res.body.scope).toEqual({ activeTab: 'tab', tabs: 'global' });
+      expect(res.body.activeWorkspace).toEqual({
+        id: 'ws-default',
+        name: 'Default',
+        derivedFrom: 'selection',
+      });
+      expect(ctx.workspaceManager.reconcileTabState).toHaveBeenCalledWith([], null);
+    });
+
     it('includes workspace and actor context for the focused tab and the global tab list', async () => {
       const activeTab = {
         id: 'tab-1',

--- a/src/api/tests/routes/misc.test.ts
+++ b/src/api/tests/routes/misc.test.ts
@@ -163,6 +163,91 @@ describe('misc routes', () => {
   });
 
   // ═══════════════════════════════════════════════
+  // ACTIVE TAB CONTEXT
+  // ═══════════════════════════════════════════════
+
+  describe('GET /active-tab/context', () => {
+    it('includes workspace and actor context for the focused tab and the global tab list', async () => {
+      const activeTab = {
+        id: 'tab-1',
+        webContentsId: 100,
+        url: 'https://example.com',
+        title: 'Example',
+        active: true,
+        source: 'claude',
+        partition: 'persist:tandem',
+      };
+      const otherTab = {
+        id: 'tab-2',
+        webContentsId: 101,
+        url: 'https://openai.com',
+        title: 'OpenAI',
+        active: false,
+        source: 'user',
+        partition: 'persist:tandem',
+      };
+      const workspaces = {
+        'ws-agent': { id: 'ws-agent', name: 'Codex', icon: 'cpu-chip', color: '#2563eb', order: 1, isDefault: false, tabIds: [100] },
+        'ws-default': { id: 'ws-default', name: 'Default', icon: 'home', color: '#4285f4', order: 0, isDefault: true, tabIds: [101] },
+      };
+
+      vi.mocked(ctx.tabManager.getActiveTab).mockReturnValue(activeTab as any);
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([activeTab, otherTab] as any);
+      vi.mocked(ctx.workspaceManager.getActive).mockReturnValue(workspaces['ws-agent'] as any);
+      vi.mocked(ctx.workspaceManager.get).mockImplementation((id: string) => (workspaces as Record<string, unknown>)[id] as any ?? null);
+      vi.mocked(ctx.workspaceManager.getWorkspaceIdForTab).mockImplementation((webContentsId: number) => {
+        if (webContentsId === 100) return 'ws-agent';
+        if (webContentsId === 101) return 'ws-default';
+        return null;
+      });
+
+      const mockWC = createMockWebContents(100);
+      mockWC.executeJavaScript
+        .mockResolvedValueOnce(JSON.stringify({
+          innerWidth: 1280,
+          innerHeight: 720,
+          scrollTop: 10,
+          scrollHeight: 2000,
+          clientHeight: 720,
+        }))
+        .mockResolvedValueOnce('Example page text');
+      mockGetActiveWC.mockResolvedValue(mockWC as any);
+
+      const res = await request(app).get('/active-tab/context');
+
+      expect(res.status).toBe(200);
+      expect(ctx.workspaceManager.reconcileTabState).toHaveBeenCalledWith([100, 101], 100);
+      expect(res.body.scope).toEqual({ activeTab: 'tab', tabs: 'global' });
+      expect(res.body.activeWorkspace).toEqual({
+        id: 'ws-agent',
+        name: 'Codex',
+        derivedFrom: 'focused-tab',
+        matchesFocusedTab: true,
+      });
+      expect(res.body.activeTab.source).toBe('claude');
+      expect(res.body.activeTab.actor).toEqual({ id: 'claude', kind: 'agent' });
+      expect(res.body.activeTab.workspaceId).toBe('ws-agent');
+      expect(res.body.activeTab.workspaceName).toBe('Codex');
+      expect(res.body.tabs).toEqual([
+        expect.objectContaining({
+          id: 'tab-1',
+          workspaceId: 'ws-agent',
+          workspaceName: 'Codex',
+          source: 'claude',
+          actor: { id: 'claude', kind: 'agent' },
+        }),
+        expect.objectContaining({
+          id: 'tab-2',
+          workspaceId: 'ws-default',
+          workspaceName: 'Default',
+          source: 'user',
+          actor: { id: 'user', kind: 'human' },
+        }),
+      ]);
+    });
+  });
+
+  // ═══════════════════════════════════════════════
   // PASSWORD MANAGER
   // ═══════════════════════════════════════════════
 

--- a/src/api/tests/routes/tabs.test.ts
+++ b/src/api/tests/routes/tabs.test.ts
@@ -85,15 +85,15 @@ describe('Tab Routes', () => {
       );
     });
 
-    it('maps unknown source to robin', async () => {
+    it('passes through non-empty custom actor sources', async () => {
       await request(app)
         .post('/tabs/open')
-        .send({ source: 'unknown' });
+        .send({ source: 'codex' });
 
       expect(ctx.tabManager.openTab).toHaveBeenCalledWith(
         'about:blank',
         undefined,
-        'user',
+        'codex',
         'persist:tandem',
         true,
         undefined,
@@ -151,7 +151,16 @@ describe('Tab Routes', () => {
         .send({ url: 'https://example.com', workspaceId: 'ws-ai' });
 
       expect(res.status).toBe(200);
+      expect(ctx.tabManager.openTab).toHaveBeenCalledWith(
+        'https://example.com',
+        undefined,
+        'user',
+        'persist:tandem',
+        false,
+        undefined,
+      );
       expect(ctx.workspaceManager.moveTab).toHaveBeenCalledWith(100, 'ws-ai');
+      expect(ctx.tabManager.focusTab).toHaveBeenCalledWith('tab-1');
       expect(ctx.panelManager.logActivity).toHaveBeenCalledWith(
         'tab-open',
         {
@@ -317,11 +326,11 @@ describe('Tab Routes', () => {
     it('sets the tab source', async () => {
       const res = await request(app)
         .post('/tabs/source')
-        .send({ tabId: 'tab-1', source: 'wingman' });
+        .send({ tabId: 'tab-1', source: 'codex' });
 
       expect(res.status).toBe(200);
       expect(res.body.ok).toBe(true);
-      expect(ctx.tabManager.setTabSource).toHaveBeenCalledWith('tab-1', 'wingman');
+      expect(ctx.tabManager.setTabSource).toHaveBeenCalledWith('tab-1', 'codex');
     });
 
     it('returns 400 when tabId is missing', async () => {
@@ -340,6 +349,15 @@ describe('Tab Routes', () => {
 
       expect(res.status).toBe(400);
       expect(res.body.error).toBe('tabId and source required');
+    });
+
+    it('returns 400 when source is empty', async () => {
+      const res = await request(app)
+        .post('/tabs/source')
+        .send({ tabId: 'tab-1', source: '   ' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('source must be a non-empty string');
     });
   });
 

--- a/src/api/tests/routes/workspaces.test.ts
+++ b/src/api/tests/routes/workspaces.test.ts
@@ -15,14 +15,81 @@ describe('Workspace Routes', () => {
     app = createTestApp(registerWorkspaceRoutes, ctx);
   });
 
+  describe('GET /workspaces', () => {
+    it('returns the reconciled active workspace together with focused-tab ownership info', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([
+        { id: 'tab-1', webContentsId: 321, url: 'https://example.com', title: 'Example' },
+      ] as any);
+      vi.mocked(ctx.tabManager.getActiveTab).mockReturnValue({
+        id: 'tab-1',
+        webContentsId: 321,
+        url: 'https://example.com',
+        title: 'Example',
+      } as any);
+      vi.mocked(ctx.workspaceManager.list).mockReturnValue([
+        { id: 'ws-1', name: 'Test', icon: 'briefcase', color: '#4285f4', order: 0, isDefault: false, tabIds: [321] },
+      ] as any);
+      vi.mocked(ctx.workspaceManager.getActiveId).mockReturnValue('ws-1');
+      vi.mocked(ctx.workspaceManager.getWorkspaceIdForTab).mockReturnValue('ws-1');
+
+      const res = await request(app).get('/workspaces');
+
+      expect(res.status).toBe(200);
+      expect(ctx.workspaceManager.reconcileTabState).toHaveBeenCalledWith([321], 321);
+      expect(res.body).toEqual({
+        ok: true,
+        scope: 'global',
+        workspaces: [
+          { id: 'ws-1', name: 'Test', icon: 'briefcase', color: '#4285f4', order: 0, isDefault: false, tabIds: [321] },
+        ],
+        activeId: 'ws-1',
+        activeTabId: 'tab-1',
+        activeTabWorkspaceId: 'ws-1',
+        activeWorkspaceSource: 'focused-tab',
+      });
+    });
+  });
+
   describe('POST /workspaces/:id/activate', () => {
-    it('switches to the requested workspace', async () => {
+    it('focuses one of the requested workspace tabs instead of forcing a workspace switch when a live tab exists', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([
+        { id: 'tab-1', webContentsId: 111, url: 'https://example.com', title: 'Example' },
+        { id: 'tab-2', webContentsId: 222, url: 'https://openai.com', title: 'OpenAI' },
+      ] as any);
+      vi.mocked(ctx.tabManager.getActiveTab)
+        .mockReturnValueOnce({ id: 'tab-1', webContentsId: 111, url: 'https://example.com', title: 'Example' } as any)
+        .mockReturnValueOnce({ id: 'tab-2', webContentsId: 222, url: 'https://openai.com', title: 'OpenAI' } as any);
+      vi.mocked(ctx.workspaceManager.getWorkspaceIdForTab)
+        .mockReturnValueOnce('ws-default')
+        .mockReturnValueOnce('ws-1');
+      vi.mocked(ctx.workspaceManager.switch).mockReturnValue({
+        id: 'ws-1',
+        name: 'Test',
+        icon: 'briefcase',
+        color: '#4285f4',
+        order: 0,
+        isDefault: false,
+        tabIds: [222],
+      } as any);
+      vi.mocked(ctx.workspaceManager.get).mockReturnValue({
+        id: 'ws-1',
+        name: 'Test',
+        icon: 'briefcase',
+        color: '#4285f4',
+        order: 0,
+        isDefault: false,
+        tabIds: [222],
+      } as any);
+      vi.mocked(ctx.workspaceManager.getActiveId).mockReturnValue('ws-1');
+
       const res = await request(app).post('/workspaces/ws-1/activate').send({});
 
       expect(res.status).toBe(200);
-      expect(ctx.workspaceManager.switch).toHaveBeenCalledWith('ws-1');
+      expect(ctx.workspaceManager.switch).not.toHaveBeenCalled();
+      expect(ctx.tabManager.focusTab).toHaveBeenCalledWith('tab-2');
       expect(res.body).toEqual({
         ok: true,
+        scope: 'global',
         workspace: {
           id: 'ws-1',
           name: 'Test',
@@ -30,9 +97,48 @@ describe('Workspace Routes', () => {
           color: '#4285f4',
           order: 0,
           isDefault: false,
-          tabIds: [],
+          tabIds: [222],
         },
+        focusedTabId: 'tab-2',
+        activeId: 'ws-1',
       });
+    });
+
+    it('falls back to an explicit workspace switch when the target workspace has no live tab', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([
+        { id: 'tab-1', webContentsId: 111, url: 'https://example.com', title: 'Example' },
+      ] as any);
+      vi.mocked(ctx.tabManager.getActiveTab)
+        .mockReturnValueOnce({ id: 'tab-1', webContentsId: 111, url: 'https://example.com', title: 'Example' } as any)
+        .mockReturnValueOnce({ id: 'tab-1', webContentsId: 111, url: 'https://example.com', title: 'Example' } as any);
+      vi.mocked(ctx.workspaceManager.get).mockReturnValue({
+        id: 'ws-1',
+        name: 'Test',
+        icon: 'briefcase',
+        color: '#4285f4',
+        order: 0,
+        isDefault: false,
+        tabIds: [222],
+      } as any);
+      vi.mocked(ctx.workspaceManager.switch).mockReturnValue({
+        id: 'ws-1',
+        name: 'Test',
+        icon: 'briefcase',
+        color: '#4285f4',
+        order: 0,
+        isDefault: false,
+        tabIds: [222],
+      } as any);
+      vi.mocked(ctx.workspaceManager.getActiveId).mockReturnValue('ws-1');
+      vi.mocked(ctx.workspaceManager.getActiveSource).mockReturnValue('selection');
+
+      const res = await request(app).post('/workspaces/ws-1/activate').send({});
+
+      expect(res.status).toBe(200);
+      expect(ctx.workspaceManager.switch).toHaveBeenCalledWith('ws-1');
+      expect(ctx.tabManager.focusTab).not.toHaveBeenCalled();
+      expect(res.body.focusedTabId).toBeNull();
+      expect(ctx.workspaceManager.reconcileTabState).toHaveBeenLastCalledWith([111], 111);
     });
   });
 

--- a/src/api/tests/routes/workspaces.test.ts
+++ b/src/api/tests/routes/workspaces.test.ts
@@ -142,6 +142,73 @@ describe('Workspace Routes', () => {
     });
   });
 
+  describe('GET /workspaces — no active tab', () => {
+    it('returns null for activeTabId and activeTabWorkspaceId when there is no active tab', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([]);
+      vi.mocked(ctx.tabManager.getActiveTab).mockReturnValue(null as any);
+      vi.mocked(ctx.workspaceManager.list).mockReturnValue([
+        { id: 'ws-default', name: 'Default', icon: 'home', color: '#4285f4', order: 0, isDefault: true, tabIds: [] },
+      ] as any);
+      vi.mocked(ctx.workspaceManager.getActiveId).mockReturnValue('ws-default');
+
+      const res = await request(app).get('/workspaces');
+
+      expect(res.status).toBe(200);
+      expect(ctx.workspaceManager.reconcileTabState).toHaveBeenCalledWith([], null);
+      expect(res.body.activeTabId).toBeNull();
+      expect(res.body.activeTabWorkspaceId).toBeNull();
+      expect(res.body.scope).toBe('global');
+    });
+  });
+
+  describe('POST /workspaces/:id/activate — error paths', () => {
+    it('returns 500 when the target workspace does not exist', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([]);
+      vi.mocked(ctx.tabManager.getActiveTab).mockReturnValue(null as any);
+      vi.mocked(ctx.workspaceManager.get).mockReturnValue(undefined as any);
+
+      const res = await request(app).post('/workspaces/nonexistent/activate').send({});
+
+      expect(res.status).toBe(500);
+      expect(res.body.error).toContain('nonexistent');
+    });
+
+    it('falls back to workspace switch when target workspace has no tabIds', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([
+        { id: 'tab-1', webContentsId: 111, url: 'https://example.com', title: 'Example' },
+      ] as any);
+      vi.mocked(ctx.tabManager.getActiveTab)
+        .mockReturnValue({ id: 'tab-1', webContentsId: 111, url: 'https://example.com', title: 'Example' } as any);
+      vi.mocked(ctx.workspaceManager.get).mockReturnValue({
+        id: 'ws-empty',
+        name: 'Empty',
+        icon: 'star',
+        color: '#ff0000',
+        order: 1,
+        isDefault: false,
+        tabIds: [],
+      } as any);
+      vi.mocked(ctx.workspaceManager.switch).mockReturnValue({
+        id: 'ws-empty',
+        name: 'Empty',
+        icon: 'star',
+        color: '#ff0000',
+        order: 1,
+        isDefault: false,
+        tabIds: [],
+      } as any);
+      vi.mocked(ctx.workspaceManager.getActiveId).mockReturnValue('ws-empty');
+      vi.mocked(ctx.workspaceManager.getActiveSource).mockReturnValue('selection');
+
+      const res = await request(app).post('/workspaces/ws-empty/activate').send({});
+
+      expect(res.status).toBe(200);
+      expect(ctx.workspaceManager.switch).toHaveBeenCalledWith('ws-empty');
+      expect(ctx.tabManager.focusTab).not.toHaveBeenCalled();
+      expect(res.body.focusedTabId).toBeNull();
+    });
+  });
+
   describe('POST /workspaces/:id/tabs', () => {
     it('moves a tab into the requested workspace', async () => {
       const res = await request(app)

--- a/src/bootstrap/runtime.ts
+++ b/src/bootstrap/runtime.ts
@@ -8,6 +8,7 @@ import { TabLockManager } from '../agents/tab-lock-manager';
 import { LoginManager } from '../auth/login-manager';
 import { GooglePhotosManager } from '../integrations/google-photos';
 import { ContextBridge } from '../bridge/context-bridge';
+import { buildOwnershipContextForTabId } from '../tabs/runtime-context';
 import { ClaroNoteManager } from '../claronote/manager';
 import { ConfigManager } from '../config/manager';
 import { ContentExtractor } from '../content/extractor';
@@ -188,8 +189,27 @@ export async function initializeRuntimeManagers(opts: InitializeRuntimeOptions):
   runtime.tabManager.setSyncManager(runtime.syncManager);
   runtime.tabManager.setSessionRestore(runtime.sessionRestoreManager);
   runtime.tabManager.setWorkspaceIdResolver((webContentsId) => runtime.workspaceManager.getWorkspaceIdForTab(webContentsId) ?? null);
+  runtime.tabManager.setActiveTabChangedHandler((tab) => {
+    runtime.workspaceManager.reconcileTabState(
+      runtime.tabManager.listWebContentsIds(),
+      tab?.webContentsId ?? null,
+      { notify: true, followFocusedTab: true },
+    );
+  });
   runtime.historyManager.setSyncManager(runtime.syncManager);
   runtime.workspaceManager.setSyncManager(runtime.syncManager);
+  runtime.workspaceManager.setTabStateResolvers({
+    listTrackedTabIds: () => runtime.tabManager.listWebContentsIds(),
+    getActiveTabId: () => runtime.tabManager.getActiveWebContentsId(),
+  });
+  runtime.eventStream.setContextResolver(({ tabId }) =>
+    buildOwnershipContextForTabId(
+      runtime.tabManager,
+      runtime.workspaceManager,
+      tabId,
+      tabId ? 'tab' : 'global',
+    )
+  );
   runtime.devToolsManager.setWingmanStream(runtime.wingmanStream);
   runtime.devToolsManager.setActivityTracker(runtime.activityTracker);
 
@@ -346,6 +366,7 @@ export function registerRuntimeIpcHandlers(win: BrowserWindow, runtime: RuntimeM
     wingmanStream: runtime.wingmanStream,
     snapshotManager: runtime.snapshotManager,
     videoRecorderManager: runtime.videoRecorderManager,
+    workspaceManager: runtime.workspaceManager,
   });
 }
 

--- a/src/context-menu/menu-builder.ts
+++ b/src/context-menu/menu-builder.ts
@@ -620,10 +620,14 @@ export class ContextMenuBuilder {
       },
     }));
     const currentSource = this.deps.tabManager.getTabSource(tabId);
+    const isAgentControlled = currentSource !== null && currentSource !== 'user';
     menu.append(new MenuItem({
-      label: currentSource === 'wingman' ? 'Take back from Wingman' : 'Let Wingman handle this tab',
+      label: isAgentControlled
+        ? `Take back from ${currentSource === 'wingman' ? 'Wingman' : currentSource}`
+        : 'Let Wingman handle this tab',
       click: () => {
-        const newSource = this.deps.tabManager.getTabSource(tabId) === 'wingman' ? 'user' : 'wingman';
+        const nextSource = this.deps.tabManager.getTabSource(tabId);
+        const newSource = nextSource !== null && nextSource !== 'user' ? 'user' : 'wingman';
         this.deps.tabManager.setTabSource(tabId, newSource);
       },
     }));

--- a/src/context-menu/types.ts
+++ b/src/context-menu/types.ts
@@ -6,6 +6,7 @@ import type { PanelManager } from '../panel/manager';
 import type { DownloadManager } from '../downloads/manager';
 import type { PinboardManager } from '../pinboards/manager';
 import type { ConfigManager } from '../config/manager';
+import type { TabSource } from '../tabs/context';
 
 /**
  * Context info passed from Electron's context-menu event on webContents.
@@ -34,7 +35,7 @@ export interface ContextMenuParams {
   };
   // Tandem-specific
   tabId?: string;
-  tabSource?: 'user' | 'wingman';
+  tabSource?: TabSource;
 }
 
 /**

--- a/src/events/stream.ts
+++ b/src/events/stream.ts
@@ -1,4 +1,5 @@
 import type { Request, Response } from 'express';
+import { buildTabOwnershipContext, type TabOwnershipContext } from '../tabs/context';
 
 // ─── Types ──────────────────────────────────────────────────────────
 
@@ -16,6 +17,7 @@ export interface BrowserEvent {
   url?: string;
   title?: string;
   data?: Record<string, unknown>;
+  context: TabOwnershipContext;
 }
 
 // ─── Constants ──────────────────────────────────────────────────────
@@ -36,13 +38,29 @@ export class EventStreamManager {
   private recentEvents: BrowserEvent[] = [];
   private eventCounter = 0;
   private lastScrollTime = 0;
+  private contextResolver: ((opts: {
+    type: BrowserEventType;
+    tabId?: string;
+    url?: string;
+    title?: string;
+  }) => TabOwnershipContext) | null = null;
 
   // === 4. Public methods ===
+
+  /** Wire a resolver that enriches emitted events with workspace/source ownership context. */
+  setContextResolver(resolver: ((opts: {
+    type: BrowserEventType;
+    tabId?: string;
+    url?: string;
+    title?: string;
+  }) => TabOwnershipContext) | null): void {
+    this.contextResolver = resolver;
+  }
 
   // --- IPC Handlers ---
 
   /** Handle webview events from IPC (activity-webview-event) */
-  handleWebviewEvent(data: { type: string; url?: string; tabId?: string; title?: string }): void {
+  handleWebviewEvent(data: { type: string; url?: string; tabId?: string; title?: string; context?: TabOwnershipContext }): void {
     switch (data.type) {
       case 'did-navigate':
       case 'did-navigate-in-page':
@@ -50,6 +68,7 @@ export class EventStreamManager {
           tabId: data.tabId,
           url: data.url,
           title: data.title,
+          context: data.context,
         }));
         break;
 
@@ -58,6 +77,7 @@ export class EventStreamManager {
           tabId: data.tabId,
           url: data.url,
           title: data.title,
+          context: data.context,
         }));
         break;
 
@@ -68,7 +88,7 @@ export class EventStreamManager {
   }
 
   /** Handle tab lifecycle events from IPC (tab-update, tab-register) */
-  handleTabEvent(eventType: 'tab-opened' | 'tab-closed' | 'tab-focused' | 'tab-updated', data: { tabId?: string; url?: string; title?: string }): void {
+  handleTabEvent(eventType: 'tab-opened' | 'tab-closed' | 'tab-focused' | 'tab-updated', data: { tabId?: string; url?: string; title?: string; context?: TabOwnershipContext }): void {
     switch (eventType) {
       case 'tab-opened':
         this.emit(this.createEvent('tab-opened', data));
@@ -90,11 +110,12 @@ export class EventStreamManager {
   }
 
   /** Handle form submission events */
-  handleFormSubmit(data: { url?: string; tabId?: string; fields?: unknown }): void {
+  handleFormSubmit(data: { url?: string; tabId?: string; fields?: unknown; context?: TabOwnershipContext }): void {
     this.emit(this.createEvent('form-submit', {
       url: data.url,
       tabId: data.tabId,
       data: { fieldCount: Array.isArray(data.fields) ? data.fields.length : 0 },
+      context: data.context,
     }));
   }
 
@@ -114,7 +135,7 @@ export class EventStreamManager {
   }
 
   /** Handle scroll events — debounced to max 1 per 5 seconds */
-  handleScroll(data: { tabId?: string; url?: string }): void {
+  handleScroll(data: { tabId?: string; url?: string; context?: TabOwnershipContext }): void {
     const now = Date.now();
     if (now - this.lastScrollTime < SCROLL_DEBOUNCE_MS) return;
     this.lastScrollTime = now;
@@ -122,13 +143,15 @@ export class EventStreamManager {
     this.emit(this.createEvent('scroll', {
       tabId: data.tabId,
       url: data.url,
+      context: data.context,
     }));
   }
 
   /** Emit an error event */
-  handleError(message: string, data?: Record<string, unknown>): void {
+  handleError(message: string, data?: Record<string, unknown>, context?: TabOwnershipContext): void {
     this.emit(this.createEvent('error', {
       data: { message, ...data },
+      context,
     }));
   }
 
@@ -215,7 +238,22 @@ export class EventStreamManager {
     }
   }
 
-  private createEvent(type: BrowserEventType, opts: { tabId?: string; url?: string; title?: string; data?: Record<string, unknown> } = {}): BrowserEvent {
+  private createEvent(type: BrowserEventType, opts: {
+    tabId?: string;
+    url?: string;
+    title?: string;
+    data?: Record<string, unknown>;
+    context?: TabOwnershipContext;
+  } = {}): BrowserEvent {
+    const context = opts.context
+      ?? this.contextResolver?.({
+        type,
+        tabId: opts.tabId,
+        url: opts.url,
+        title: opts.title,
+      })
+      ?? buildTabOwnershipContext({ scope: opts.tabId ? 'tab' : 'global' });
+
     return {
       id: ++this.eventCounter,
       type,
@@ -224,6 +262,7 @@ export class EventStreamManager {
       url: opts.url,
       title: opts.title,
       data: opts.data,
+      context,
     };
   }
 }

--- a/src/events/tests/stream.test.ts
+++ b/src/events/tests/stream.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { EventStreamManager } from '../stream';
 import { buildTabOwnershipContext } from '../../tabs/context';
 

--- a/src/events/tests/stream.test.ts
+++ b/src/events/tests/stream.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { EventStreamManager } from '../stream';
+import { buildTabOwnershipContext } from '../../tabs/context';
+
+describe('EventStreamManager', () => {
+  it('enriches tab events with resolved workspace and actor context', () => {
+    const manager = new EventStreamManager();
+    manager.setContextResolver(({ tabId }) => buildTabOwnershipContext({
+      source: tabId === 'tab-1' ? 'codex' : null,
+      workspaceId: 'ws-codex',
+      workspaceName: 'Codex',
+      selectedWorkspaceId: 'ws-codex',
+      selectedWorkspaceName: 'Codex',
+      scope: tabId ? 'tab' : 'global',
+    }));
+
+    manager.handleTabEvent('tab-focused', {
+      tabId: 'tab-1',
+      url: 'https://example.com',
+      title: 'Example',
+    });
+
+    expect(manager.getRecent(1)[0]).toEqual(expect.objectContaining({
+      type: 'tab-focused',
+      tabId: 'tab-1',
+      context: {
+        scope: 'tab',
+        source: 'codex',
+        actor: { id: 'codex', kind: 'agent' },
+        workspace: {
+          id: 'ws-codex',
+          name: 'Codex',
+          selectedId: 'ws-codex',
+          selectedName: 'Codex',
+          matchesSelection: true,
+        },
+      },
+    }));
+  });
+
+  it('keeps explicit event context when a caller passes a snapshot', () => {
+    const manager = new EventStreamManager();
+    manager.setContextResolver(() => buildTabOwnershipContext({
+      source: 'resolver-source',
+      workspaceId: 'ws-resolver',
+      workspaceName: 'Resolver',
+      selectedWorkspaceId: 'ws-resolver',
+      selectedWorkspaceName: 'Resolver',
+      scope: 'tab',
+    }));
+
+    manager.handleTabEvent('tab-closed', {
+      tabId: 'tab-1',
+      context: buildTabOwnershipContext({
+        source: 'claude',
+        workspaceId: 'ws-claude',
+        workspaceName: 'Claude',
+        selectedWorkspaceId: 'ws-codex',
+        selectedWorkspaceName: 'Codex',
+        scope: 'tab',
+      }),
+    });
+
+    expect(manager.getRecent(1)[0].context).toEqual({
+      scope: 'tab',
+      source: 'claude',
+      actor: { id: 'claude', kind: 'agent' },
+      workspace: {
+        id: 'ws-claude',
+        name: 'Claude',
+        selectedId: 'ws-codex',
+        selectedName: 'Codex',
+        matchesSelection: false,
+      },
+    });
+  });
+});

--- a/src/events/tests/stream.test.ts
+++ b/src/events/tests/stream.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { EventStreamManager } from '../stream';
 import { buildTabOwnershipContext } from '../../tabs/context';
 
@@ -36,6 +36,209 @@ describe('EventStreamManager', () => {
         },
       },
     }));
+  });
+
+  it('uses default global context when no resolver is set and no context is passed', () => {
+    const manager = new EventStreamManager();
+
+    manager.handleTabEvent('tab-opened', { tabId: undefined });
+
+    const event = manager.getRecent(1)[0];
+    expect(event.context).toBeDefined();
+    expect(event.context.scope).toBe('global');
+    expect(event.context.source).toBeNull();
+    expect(event.context.actor.kind).toBe('unknown');
+  });
+
+  it('uses tab scope default context when tabId is present and no resolver is set', () => {
+    const manager = new EventStreamManager();
+
+    manager.handleTabEvent('tab-opened', { tabId: 'tab-99' });
+
+    const event = manager.getRecent(1)[0];
+    expect(event.context.scope).toBe('tab');
+  });
+
+  it('clears the context resolver when null is passed to setContextResolver', () => {
+    const manager = new EventStreamManager();
+    manager.setContextResolver(() => buildTabOwnershipContext({
+      source: 'agent-x',
+      scope: 'tab',
+    }));
+    manager.setContextResolver(null);
+
+    manager.handleTabEvent('tab-focused', { tabId: 'tab-1' });
+
+    const event = manager.getRecent(1)[0];
+    // With no resolver the default fallback is used
+    expect(event.context.source).toBeNull();
+  });
+
+  it('handleWebviewEvent emits navigation event for did-navigate', () => {
+    const manager = new EventStreamManager();
+
+    manager.handleWebviewEvent({
+      type: 'did-navigate',
+      tabId: 'tab-1',
+      url: 'https://example.com',
+      title: 'Example',
+    });
+
+    const event = manager.getRecent(1)[0];
+    expect(event.type).toBe('navigation');
+    expect(event.tabId).toBe('tab-1');
+    expect(event.url).toBe('https://example.com');
+  });
+
+  it('handleWebviewEvent emits page-loaded event for did-finish-load', () => {
+    const manager = new EventStreamManager();
+
+    manager.handleWebviewEvent({
+      type: 'did-finish-load',
+      tabId: 'tab-2',
+      url: 'https://example.com',
+    });
+
+    const event = manager.getRecent(1)[0];
+    expect(event.type).toBe('page-loaded');
+  });
+
+  it('handleWebviewEvent emits navigation for did-navigate-in-page', () => {
+    const manager = new EventStreamManager();
+
+    manager.handleWebviewEvent({
+      type: 'did-navigate-in-page',
+      tabId: 'tab-3',
+      url: 'https://example.com/#section',
+    });
+
+    const event = manager.getRecent(1)[0];
+    expect(event.type).toBe('navigation');
+    expect(event.url).toBe('https://example.com/#section');
+  });
+
+  it('handleWebviewEvent ignores did-start-navigation', () => {
+    const manager = new EventStreamManager();
+
+    manager.handleWebviewEvent({ type: 'did-start-navigation', tabId: 'tab-1' });
+
+    expect(manager.getRecent(1)).toHaveLength(0);
+  });
+
+  it('handleWebviewEvent preserves explicit context snapshot', () => {
+    const manager = new EventStreamManager();
+    const snapshot = buildTabOwnershipContext({
+      source: 'claude',
+      workspaceId: 'ws-1',
+      workspaceName: 'Dev',
+      selectedWorkspaceId: 'ws-1',
+      selectedWorkspaceName: 'Dev',
+      scope: 'tab',
+    });
+
+    manager.handleWebviewEvent({
+      type: 'did-navigate',
+      tabId: 'tab-1',
+      url: 'https://example.com',
+      context: snapshot,
+    });
+
+    expect(manager.getRecent(1)[0].context).toEqual(snapshot);
+  });
+
+  it('handleFormSubmit emits form-submit with correct field count', () => {
+    const manager = new EventStreamManager();
+
+    manager.handleFormSubmit({
+      url: 'https://example.com/login',
+      tabId: 'tab-5',
+      fields: ['username', 'password'],
+    });
+
+    const event = manager.getRecent(1)[0];
+    expect(event.type).toBe('form-submit');
+    expect(event.data).toEqual({ fieldCount: 2 });
+    expect(event.tabId).toBe('tab-5');
+  });
+
+  it('handleFormSubmit sets fieldCount to 0 for non-array fields', () => {
+    const manager = new EventStreamManager();
+
+    manager.handleFormSubmit({ url: 'https://example.com', tabId: 'tab-6', fields: 'notanarray' });
+
+    const event = manager.getRecent(1)[0];
+    expect(event.data).toEqual({ fieldCount: 0 });
+  });
+
+  it('handleFormSubmit preserves explicit context', () => {
+    const manager = new EventStreamManager();
+    const ctx = buildTabOwnershipContext({ source: 'user', scope: 'tab' });
+
+    manager.handleFormSubmit({ tabId: 'tab-7', context: ctx });
+
+    expect(manager.getRecent(1)[0].context).toEqual(ctx);
+  });
+
+  it('handleScroll emits scroll event', () => {
+    const manager = new EventStreamManager();
+
+    manager.handleScroll({ tabId: 'tab-1', url: 'https://example.com' });
+
+    const event = manager.getRecent(1)[0];
+    expect(event.type).toBe('scroll');
+    expect(event.tabId).toBe('tab-1');
+  });
+
+  it('handleScroll is debounced — second call within 5s is ignored', () => {
+    const manager = new EventStreamManager();
+
+    manager.handleScroll({ tabId: 'tab-1', url: 'https://example.com' });
+    manager.handleScroll({ tabId: 'tab-1', url: 'https://example.com' });
+
+    expect(manager.getRecent(10)).toHaveLength(1);
+  });
+
+  it('handleScroll preserves explicit context', () => {
+    const manager = new EventStreamManager();
+    const ctx = buildTabOwnershipContext({ source: 'user', scope: 'tab' });
+
+    manager.handleScroll({ tabId: 'tab-1', context: ctx });
+
+    expect(manager.getRecent(1)[0].context).toEqual(ctx);
+  });
+
+  it('handleError emits error event with message and extra data', () => {
+    const manager = new EventStreamManager();
+
+    manager.handleError('Something went wrong', { code: 42 });
+
+    const event = manager.getRecent(1)[0];
+    expect(event.type).toBe('error');
+    expect(event.data).toEqual({ message: 'Something went wrong', code: 42 });
+  });
+
+  it('handleError attaches context when provided', () => {
+    const manager = new EventStreamManager();
+    const ctx = buildTabOwnershipContext({ source: 'claude', scope: 'tab' });
+
+    manager.handleError('oops', undefined, ctx);
+
+    expect(manager.getRecent(1)[0].context).toEqual(ctx);
+  });
+
+  it('handleError falls back to resolver when no context is passed', () => {
+    const manager = new EventStreamManager();
+    manager.setContextResolver(() => buildTabOwnershipContext({
+      source: 'codex',
+      workspaceId: 'ws-2',
+      selectedWorkspaceId: 'ws-2',
+      scope: 'global',
+    }));
+
+    manager.handleError('something broke');
+
+    const event = manager.getRecent(1)[0];
+    expect(event.context.source).toBe('codex');
   });
 
   it('keeps explicit event context when a caller passes a snapshot', () => {

--- a/src/ipc/handlers.ts
+++ b/src/ipc/handlers.ts
@@ -24,9 +24,11 @@ import type { DeviceEmulator } from '../device/emulator';
 import type { WingmanStream } from '../activity/wingman-stream';
 import type { SnapshotManager } from '../snapshot/manager';
 import type { VideoRecorderManager } from '../video/recorder';
+import type { WorkspaceManager } from '../workspaces/manager';
 import { tandemDir } from '../utils/paths';
 import { createLogger } from '../utils/logger';
 import { IpcChannels } from '../shared/ipc-channels';
+import { buildOwnershipContextForTab, buildOwnershipContextForTabId } from '../tabs/runtime-context';
 
 const log = createLogger('IpcHandlers');
 
@@ -54,6 +56,7 @@ export interface IpcDeps {
   wingmanStream: WingmanStream;
   snapshotManager: SnapshotManager;
   videoRecorderManager: VideoRecorderManager;
+  workspaceManager: WorkspaceManager;
 }
 
 /** Sync tab list into ContextBridge for live context summary */
@@ -69,7 +72,7 @@ export function registerIpcHandlers(deps: IpcDeps): void {
     taskManager, contextMenuManager, devToolsManager, activityTracker,
     securityManager, scriptInjector, deviceEmulator, wingmanStream: _wingmanStream,
     snapshotManager: _snapshotManager,
-    videoRecorderManager,
+    videoRecorderManager, workspaceManager,
   } = deps;
 
   // ═══ IPC Handler Cleanup — prevent duplicates on macOS reactivation ═══
@@ -371,8 +374,12 @@ export function registerIpcHandlers(deps: IpcDeps): void {
   // ═══ Activity tracking: webview events from renderer ═══
   ipcMain.on(IpcChannels.ACTIVITY_WEBVIEW_EVENT, (_event, data: { type: string; url?: string; tabId?: string }) => {
     // Feed into EventStreamManager for SSE
-    const activeTab = tabManager.getActiveTab();
-    eventStream.handleWebviewEvent({ ...data, title: activeTab?.title });
+    const eventTab = data.tabId ? tabManager.getTab(data.tabId) : tabManager.getActiveTab();
+    eventStream.handleWebviewEvent({
+      ...data,
+      title: eventTab?.title,
+      context: buildOwnershipContextForTab(workspaceManager, eventTab),
+    });
 
     activityTracker.onWebviewEvent(data);
 
@@ -508,10 +515,16 @@ export function registerIpcHandlers(deps: IpcDeps): void {
   ipcMain.handle(IpcChannels.TAB_CLOSE, async (_event, tabId: string) => {
     // Capture tab info before closing
     const closingTab = tabManager.getTab(tabId);
+    const closingContext = buildOwnershipContextForTab(workspaceManager, closingTab);
     const result = await tabManager.closeTab(tabId);
     if (result) {
       // Normal close — emit events only for tabs that were actually tracked.
-      eventStream.handleTabEvent('tab-closed', { tabId });
+      eventStream.handleTabEvent('tab-closed', {
+        tabId,
+        url: closingTab?.url,
+        title: closingTab?.title,
+        context: closingContext,
+      });
       activityTracker.onWebviewEvent({ type: 'tab-close', tabId, url: closingTab?.url, title: closingTab?.title });
     } else {
       // Tab not in main-process Map → possible renderer orphan.
@@ -526,9 +539,16 @@ export function registerIpcHandlers(deps: IpcDeps): void {
     behaviorObserver.recordTabSwitch(tabId);
     const tabs = tabManager.listTabs();
     const tab = tabs.find(t => t.id === tabId);
-    eventStream.handleTabEvent('tab-focused', { tabId, url: tab?.url, title: tab?.title });
-    activityTracker.onWebviewEvent({ type: 'tab-switch', tabId, url: tab?.url, title: tab?.title });
     const result = await tabManager.focusTab(tabId);
+    if (result) {
+      eventStream.handleTabEvent('tab-focused', {
+        tabId,
+        url: tab?.url,
+        title: tab?.title,
+        context: buildOwnershipContextForTabId(tabManager, workspaceManager, tabId),
+      });
+      activityTracker.onWebviewEvent({ type: 'tab-switch', tabId, url: tab?.url, title: tab?.title });
+    }
     syncTabsToContext(tabManager, contextBridge);
     // Attach CDP to the focused tab directly (avoids race with TabManager active tab state)
     if (tab?.webContentsId) {

--- a/src/mcp/api-client.ts
+++ b/src/mcp/api-client.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import { tandemDir } from '../utils/paths';
 import { API_PORT } from '../utils/constants';
+import { normalizeTabSource } from '../tabs/context';
 
 const API_BASE = `http://localhost:${API_PORT}`;
 
@@ -51,6 +52,23 @@ export function tabHeaders(tabId?: string): Record<string, string> | undefined {
   return tabId ? { 'X-Tab-Id': tabId } : undefined;
 }
 
+export function getMcpSource(): string {
+  const candidates = [
+    process.env.TANDEM_SOURCE,
+    process.env.TANDEM_MCP_SOURCE,
+    process.env.TANDEM_ACTOR_SOURCE,
+  ];
+
+  for (const candidate of candidates) {
+    const source = normalizeTabSource(candidate);
+    if (source) {
+      return source;
+    }
+  }
+
+  return 'wingman';
+}
+
 /** Truncate text to a maximum number of words */
 export function truncateToWords(text: string, maxWords: number): string {
   const words = text.split(/\s+/);
@@ -62,7 +80,7 @@ export function truncateToWords(text: string, maxWords: number): string {
 export async function logActivity(toolName: string, details?: string): Promise<void> {
   const text = details ? `🤖 ${toolName}: ${details}` : `🤖 ${toolName}`;
   try {
-    await apiCall('POST', '/chat', { text, from: 'claude' });
+    await apiCall('POST', '/chat', { text, from: getMcpSource() });
   } catch {
     // Don't fail the tool call if activity logging fails
   }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -111,15 +111,26 @@ server.resource(
 server.resource(
   'tabs-list',
   'tandem://tabs/list',
-  { description: 'All open browser tabs' },
+  { description: 'All open browser tabs with workspace/source context when known' },
   async () => {
-    const data = await apiCall('GET', '/tabs/list');
-    const tabs: Array<{ id: string; title: string; url: string; active: boolean }> = data.tabs || [];
+    const data = await apiCall('GET', '/active-tab/context');
+    const tabs: Array<{
+      id: string;
+      title: string;
+      url: string;
+      active?: boolean;
+      workspaceName?: string | null;
+      source?: string | null;
+    }> = data.tabs || [];
 
     let text = `Open tabs (${tabs.length}):\n\n`;
     for (const tab of tabs) {
-      const marker = tab.active ? '→ ' : '  ';
-      text += `${marker}[${tab.id}] ${tab.title || '(untitled)'} — ${tab.url}\n`;
+      const marker = tab.active ? '-> ' : '   ';
+      const details: string[] = [];
+      if (tab.workspaceName) details.push(`workspace: ${tab.workspaceName}`);
+      if (tab.source) details.push(`source: ${tab.source}`);
+      const suffix = details.length > 0 ? ` [${details.join(', ')}]` : '';
+      text += `${marker}[${tab.id}] ${tab.title || '(untitled)'} — ${tab.url}${suffix}\n`;
     }
     return { contents: [{ uri: 'tandem://tabs/list', mimeType: 'text/plain', text }] };
   }
@@ -145,10 +156,58 @@ server.resource(
 server.resource(
   'context',
   'tandem://context',
-  { description: 'Live browser context: active tab, open tabs, recent events, voice status' },
+  { description: 'Live browser context including active workspace/tab ownership and recent events' },
   async () => {
-    const summary = await apiCall('GET', '/context/summary');
-    return { contents: [{ uri: 'tandem://context', mimeType: 'text/plain', text: summary.text || '' }] };
+    const [summary, activeTabContext, recentEventsData] = await Promise.all([
+      apiCall('GET', '/context/summary'),
+      apiCall('GET', '/active-tab/context'),
+      apiCall('GET', '/events/recent?limit=5'),
+    ]);
+
+    const lines: string[] = [];
+    const activeWorkspace = activeTabContext.activeWorkspace;
+    const activeTab = activeTabContext.activeTab;
+    if (activeWorkspace) {
+      lines.push(`Active workspace: ${activeWorkspace.name} (${activeWorkspace.id})`);
+    }
+
+    if (activeTab) {
+      const parts = [
+        `Active tab: ${activeTab.title || 'Untitled'} — ${activeTab.url || ''} (${activeTab.id})`,
+        `workspace=${activeTab.workspaceName || activeTab.workspaceId || 'unknown'}`,
+        `source=${activeTab.source ?? 'unknown'}`,
+      ];
+      if (activeTab.actor?.id) {
+        parts.push(`actor=${activeTab.actor.id}`);
+      }
+      lines.push(parts.join(' | '));
+    } else {
+      lines.push('Active tab: none');
+    }
+
+    if (Array.isArray(recentEventsData.events) && recentEventsData.events.length > 0) {
+      const eventLines = recentEventsData.events.slice(0, 5).map((event: {
+        type?: string;
+        tabId?: string | null;
+        context?: {
+          source?: string | null;
+          workspace?: { id?: string | null; name?: string | null } | null;
+        } | null;
+      }) => {
+        const workspace = event.context?.workspace?.name || event.context?.workspace?.id || 'unknown';
+        const source = event.context?.source ?? 'unknown';
+        return `- ${event.type} | tab=${event.tabId || 'none'} | workspace=${workspace} | source=${source}`;
+      });
+      lines.push('Recent events:');
+      lines.push(...eventLines);
+    }
+
+    if (summary.text) {
+      lines.push('');
+      lines.push(summary.text);
+    }
+
+    return { contents: [{ uri: 'tandem://context', mimeType: 'text/plain', text: lines.join('\n') }] };
   }
 );
 

--- a/src/mcp/tests/api-client.test.ts
+++ b/src/mcp/tests/api-client.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { getMcpSource } from '../api-client.js';
+
+describe('MCP api client helpers', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('defaults to wingman when no MCP source env is configured', () => {
+    delete process.env.TANDEM_SOURCE;
+    delete process.env.TANDEM_MCP_SOURCE;
+    delete process.env.TANDEM_ACTOR_SOURCE;
+
+    expect(getMcpSource()).toBe('wingman');
+  });
+
+  it('prefers TANDEM_SOURCE when configured', () => {
+    process.env.TANDEM_SOURCE = 'claude';
+    process.env.TANDEM_MCP_SOURCE = 'openclaw';
+
+    expect(getMcpSource()).toBe('claude');
+  });
+
+  it('falls back to TANDEM_MCP_SOURCE and normalizes whitespace', () => {
+    delete process.env.TANDEM_SOURCE;
+    process.env.TANDEM_MCP_SOURCE = '  codex  ';
+
+    expect(getMcpSource()).toBe('codex');
+  });
+});

--- a/src/mcp/tests/chat.test.ts
+++ b/src/mcp/tests/chat.test.ts
@@ -2,24 +2,29 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../api-client.js', () => ({
   apiCall: vi.fn(),
+  getMcpSource: vi.fn(() => 'wingman'),
   tabHeaders: vi.fn(),
   logActivity: vi.fn(),
 }));
 
 vi.mock('../coerce.js', async (importOriginal) => importOriginal());
 
-import { apiCall, logActivity } from '../api-client.js';
+import { apiCall, getMcpSource, logActivity } from '../api-client.js';
 import { registerChatTools } from '../tools/chat.js';
 import { createMockServer, getHandler, expectTextContent } from './mcp-test-helper.js';
 
 const mockApiCall = vi.mocked(apiCall);
+const mockGetMcpSource = vi.mocked(getMcpSource);
 const mockLogActivity = vi.mocked(logActivity);
 
 describe('MCP chat tools', () => {
   const { server, tools } = createMockServer();
   registerChatTools(server);
 
-  beforeEach(() => { vi.clearAllMocks(); });
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetMcpSource.mockReturnValue('wingman');
+  });
 
   describe('tandem_send_message', () => {
     const handler = getHandler(tools, 'tandem_send_message');
@@ -28,6 +33,14 @@ describe('MCP chat tools', () => {
       mockApiCall.mockResolvedValueOnce({});
       const result = await handler({ text: 'Hello Robin' });
       expectTextContent(result, 'Message sent: "Hello Robin"');
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/chat', { text: 'Hello Robin', from: 'wingman' });
+    });
+
+    it('uses the MCP connector source in chat messages', async () => {
+      mockGetMcpSource.mockReturnValue('claude');
+      mockApiCall.mockResolvedValueOnce({});
+
+      await handler({ text: 'Hello Robin' });
       expect(mockApiCall).toHaveBeenCalledWith('POST', '/chat', { text: 'Hello Robin', from: 'claude' });
     });
   });

--- a/src/mcp/tests/tabs.test.ts
+++ b/src/mcp/tests/tabs.test.ts
@@ -2,15 +2,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../api-client.js', () => ({
   apiCall: vi.fn(),
+  getMcpSource: vi.fn(() => 'wingman'),
   tabHeaders: vi.fn((tabId?: string) => (tabId ? { 'X-Tab-Id': tabId } : undefined)),
   logActivity: vi.fn(),
 }));
 
-import { apiCall, logActivity } from '../api-client.js';
+import { apiCall, getMcpSource, logActivity } from '../api-client.js';
 import { registerTabTools } from '../tools/tabs.js';
 import { createMockServer, getHandler, expectTextContent } from './mcp-test-helper.js';
 
 const mockApiCall = vi.mocked(apiCall);
+const mockGetMcpSource = vi.mocked(getMcpSource);
 const mockLogActivity = vi.mocked(logActivity);
 
 describe('MCP tab tools', () => {
@@ -19,6 +21,7 @@ describe('MCP tab tools', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetMcpSource.mockReturnValue('wingman');
   });
 
   // ── tandem_list_tabs ──────────────────────────────────────────────
@@ -28,16 +31,16 @@ describe('MCP tab tools', () => {
     it('lists open tabs with formatted text', async () => {
       mockApiCall.mockResolvedValueOnce({
         tabs: [
-          { id: 't1', title: 'Google', url: 'https://google.com', active: true },
-          { id: 't2', title: 'GitHub', url: 'https://github.com', active: false },
+          { id: 't1', title: 'Google', url: 'https://google.com', active: true, workspaceName: 'Default', source: 'user' },
+          { id: 't2', title: 'GitHub', url: 'https://github.com', active: false, workspaceName: 'Claude', source: 'claude' },
         ],
       });
 
       const result = await handler({});
       const text = expectTextContent(result, 'Open tabs (2)');
-      expect(text).toContain('→ [t1] Google');
-      expect(text).toContain('  [t2] GitHub');
-      expect(mockApiCall).toHaveBeenCalledWith('GET', '/tabs/list');
+      expect(text).toContain('-> [t1] Google');
+      expect(text).toContain('[workspace: Claude, source: claude]');
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/active-tab/context');
     });
 
     it('handles empty tab list', async () => {
@@ -62,7 +65,7 @@ describe('MCP tab tools', () => {
     it('includes emoji in tab listing', async () => {
       mockApiCall.mockResolvedValueOnce({
         tabs: [
-          { id: 't1', title: 'Project', url: 'https://github.com', active: true, emoji: '🔥' },
+          { id: 't1', title: 'Project', url: 'https://github.com', active: true, emoji: '🔥', source: 'codex' },
           { id: 't2', title: 'Docs', url: 'https://docs.com', active: false, emoji: null },
         ],
       });
@@ -108,6 +111,29 @@ describe('MCP tab tools', () => {
         url: 'https://a.com',
         source: 'wingman',
         workspaceId: 'w1',
+      });
+    });
+
+    it('uses the MCP connector source override when provided by the environment helper', async () => {
+      mockGetMcpSource.mockReturnValue('claude');
+      mockApiCall.mockResolvedValueOnce({ tab: { id: 't6' } });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      await handler({ url: 'https://example.com' });
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/tabs/open', {
+        url: 'https://example.com',
+        source: 'claude',
+      });
+    });
+
+    it('allows per-call source overrides', async () => {
+      mockApiCall.mockResolvedValueOnce({ tab: { id: 't7' } });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+
+      await handler({ url: 'https://example.com', source: 'openclaw' });
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/tabs/open', {
+        url: 'https://example.com',
+        source: 'openclaw',
       });
     });
   });

--- a/src/mcp/tests/window.test.ts
+++ b/src/mcp/tests/window.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  getMcpSource: vi.fn(() => 'wingman'),
+  truncateToWords: vi.fn((text: string) => text),
+  logActivity: vi.fn(),
+}));
+
+import { apiCall, getMcpSource, logActivity } from '../api-client.js';
+import { registerWindowTools } from '../tools/window.js';
+import { createMockServer, getHandler } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+const mockGetMcpSource = vi.mocked(getMcpSource);
+const mockLogActivity = vi.mocked(logActivity);
+
+describe('MCP window tools', () => {
+  const { server, tools } = createMockServer();
+  registerWindowTools(server);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockGetMcpSource.mockReturnValue('wingman');
+    mockLogActivity.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('tandem_research', () => {
+    const handler = getHandler(tools, 'tandem_research');
+
+    /** Helper: run handler and advance all fake timers while the promise is pending. */
+    async function runHandler(args: Record<string, unknown>) {
+      const promise = handler(args);
+      // Drain all setTimeout calls (humanDelay uses setTimeout)
+      await vi.runAllTimersAsync();
+      return promise;
+    }
+
+    it('opens the research tab using getMcpSource() rather than a hardcoded source', async () => {
+      mockGetMcpSource.mockReturnValue('codex');
+
+      mockApiCall
+        .mockResolvedValueOnce(undefined)                          // /tasks/check-approval
+        .mockResolvedValueOnce({ id: 'task-1' })                   // POST /tasks
+        .mockResolvedValueOnce(undefined)                          // POST /tasks/task-1/status running
+        .mockResolvedValueOnce({ tab: { id: 'research-tab-1' } }) // POST /tabs/open
+        .mockResolvedValueOnce(undefined)                          // POST /navigate (search)
+        .mockResolvedValueOnce({ text: '' })                       // GET /page-content
+        .mockResolvedValueOnce({ links: [] })                      // GET /links
+        .mockResolvedValueOnce(undefined)                          // POST /tabs/close
+        .mockResolvedValueOnce(undefined);                         // POST /tasks/task-1/status done
+
+      const result = await runHandler({ query: 'vitest coverage', maxPages: 1, searchEngine: 'duckduckgo' });
+
+      // The research tab must be opened with the source from getMcpSource()
+      const openTabCall = mockApiCall.mock.calls.find(
+        ([method, path]) => method === 'POST' && path === '/tabs/open',
+      );
+      expect(openTabCall).toBeDefined();
+      expect(openTabCall![2]).toEqual(expect.objectContaining({ source: 'codex' }));
+
+      expect(result.content[0].type).toBe('text');
+    });
+
+    it('returns a research summary when no result pages are found', async () => {
+      mockApiCall
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce({ id: 'task-2' })
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce({ tab: { id: 'research-tab-2' } })
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce({ text: '' })
+        .mockResolvedValueOnce({ links: [] })
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(undefined);
+
+      const result = await runHandler({ query: 'test query', maxPages: 1, searchEngine: 'google' });
+
+      expect(result.content[0].text).toContain('Research: "test query"');
+      expect(result.content[0].text).toContain('Found 0 sources');
+    });
+
+    it('returns error text and partial findings on failure', async () => {
+      mockApiCall
+        .mockResolvedValueOnce(undefined)                 // check-approval
+        .mockResolvedValueOnce({ id: 'task-3' })          // create task
+        .mockResolvedValueOnce(undefined)                 // set running
+        .mockRejectedValueOnce(new Error('network fail')) // /tabs/open throws
+        .mockResolvedValueOnce(undefined);                // task status failed
+
+      const result = await runHandler({ query: 'broken query', maxPages: 1, searchEngine: 'duckduckgo' });
+
+      expect(result.content[0].text).toContain('Research failed');
+      expect(result.content[0].text).toContain('network fail');
+    });
+  });
+});

--- a/src/mcp/tools/chat.ts
+++ b/src/mcp/tools/chat.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { apiCall, logActivity } from '../api-client.js';
+import { apiCall, getMcpSource, logActivity } from '../api-client.js';
 import { coerceShape } from '../coerce.js';
 
 export function registerChatTools(server: McpServer): void {
@@ -11,7 +11,7 @@ export function registerChatTools(server: McpServer): void {
       text: z.string().describe('Message text to display'),
     },
     async ({ text }) => {
-      await apiCall('POST', '/chat', { text, from: 'claude' });
+      await apiCall('POST', '/chat', { text, from: getMcpSource() });
       return { content: [{ type: 'text', text: `Message sent: "${text.substring(0, 100)}"` }] };
     }
   );

--- a/src/mcp/tools/tabs.ts
+++ b/src/mcp/tools/tabs.ts
@@ -1,20 +1,38 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { apiCall, logActivity } from '../api-client.js';
+import { apiCall, getMcpSource, logActivity } from '../api-client.js';
+
+interface ContextTab {
+  id: string;
+  title: string;
+  url: string;
+  active?: boolean;
+  emoji?: string | null;
+  workspaceName?: string | null;
+  source?: string | null;
+}
+
+function formatTabLine(tab: ContextTab): string {
+  const marker = tab.active ? '-> ' : '   ';
+  const emojiPrefix = tab.emoji ? `${tab.emoji} ` : '';
+  const details: string[] = [];
+  if (tab.workspaceName) details.push(`workspace: ${tab.workspaceName}`);
+  if (tab.source) details.push(`source: ${tab.source}`);
+  const suffix = details.length > 0 ? ` [${details.join(', ')}]` : '';
+  return `${marker}[${tab.id}] ${emojiPrefix}${tab.title || '(untitled)'}\n   ${tab.url}${suffix}\n`;
+}
 
 export function registerTabTools(server: McpServer): void {
   server.tool(
     'tandem_list_tabs',
-    'List all open browser tabs with their titles, URLs, and IDs',
+    'List all open browser tabs with their titles, URLs, IDs, and workspace/source context when known.',
     async () => {
-      const data = await apiCall('GET', '/tabs/list');
-      const tabs: Array<{ id: string; title: string; url: string; active: boolean; emoji?: string | null }> = data.tabs || [];
+      const data = await apiCall('GET', '/active-tab/context');
+      const tabs: ContextTab[] = data.tabs || [];
 
       let text = `Open tabs (${tabs.length}):\n\n`;
       for (const tab of tabs) {
-        const marker = tab.active ? '→ ' : '  ';
-        const emojiPrefix = tab.emoji ? `${tab.emoji} ` : '';
-        text += `${marker}[${tab.id}] ${emojiPrefix}${tab.title || '(untitled)'}\n   ${tab.url}\n`;
+        text += formatTabLine(tab);
       }
 
       return { content: [{ type: 'text', text }] };
@@ -27,9 +45,13 @@ export function registerTabTools(server: McpServer): void {
     {
       url: z.string().optional().describe('URL to open (default: new tab page)'),
       workspaceId: z.string().optional().describe('Optional workspace ID to assign the new tab to'),
+      source: z.string().optional().describe('Optional actor/source override. Defaults to the MCP connector source.'),
     },
-    async ({ url, workspaceId }) => {
-      const body: Record<string, unknown> = { url: url || undefined, source: 'wingman' };
+    async ({ url, workspaceId, source }) => {
+      const body: Record<string, unknown> = {
+        url: url || undefined,
+        source: source || getMcpSource(),
+      };
       if (workspaceId) body.workspaceId = workspaceId;
       const result = await apiCall('POST', '/tabs/open', body);
       await logActivity('open_tab', url || 'new tab');

--- a/src/mcp/tools/window.ts
+++ b/src/mcp/tools/window.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { apiCall, truncateToWords, logActivity } from '../api-client.js';
+import { apiCall, getMcpSource, truncateToWords, logActivity } from '../api-client.js';
 import { coerceShape } from '../coerce.js';
 import { hostnameMatches, tryParseUrl, urlHasProtocol } from '../../utils/security';
 
@@ -61,8 +61,8 @@ export function registerWindowTools(server: McpServer): void {
       const findings: Array<{ title: string; url: string; snippet: string }> = [];
 
       try {
-        // Step 1: Open a new tab for research (source: wingman)
-        const tabResult = await apiCall('POST', '/tabs/open', { url: 'about:blank', source: 'wingman' });
+        // Step 1: Open a new tab for research with the MCP connector source.
+        const tabResult = await apiCall('POST', '/tabs/open', { url: 'about:blank', source: getMcpSource() });
         const researchTabId = tabResult?.tab?.id;
 
         await humanDelay(TIMING.beforeAction);

--- a/src/tabs/context.ts
+++ b/src/tabs/context.ts
@@ -1,0 +1,78 @@
+export type TabSource = string;
+
+export type ActorKind = 'human' | 'assistant' | 'agent' | 'unknown';
+
+export interface ActorContext {
+  id: string | null;
+  kind: ActorKind;
+}
+
+export interface WorkspaceContextSummary {
+  id: string | null;
+  name: string | null;
+  selectedId: string | null;
+  selectedName: string | null;
+  matchesSelection: boolean | null;
+}
+
+export interface TabOwnershipContext {
+  scope: 'tab' | 'global';
+  source: string | null;
+  actor: ActorContext;
+  workspace: WorkspaceContextSummary;
+}
+
+export function normalizeTabSource(source: unknown): string | null {
+  if (typeof source !== 'string') {
+    return null;
+  }
+
+  const trimmed = source.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function getActorContext(source: unknown): ActorContext {
+  const normalizedSource = normalizeTabSource(source);
+  if (!normalizedSource) {
+    return { id: null, kind: 'unknown' };
+  }
+
+  if (normalizedSource === 'user') {
+    return { id: normalizedSource, kind: 'human' };
+  }
+
+  if (normalizedSource === 'wingman') {
+    return { id: normalizedSource, kind: 'assistant' };
+  }
+
+  return { id: normalizedSource, kind: 'agent' };
+}
+
+export function buildTabOwnershipContext(opts: {
+  source?: unknown;
+  workspaceId?: string | null;
+  workspaceName?: string | null;
+  selectedWorkspaceId?: string | null;
+  selectedWorkspaceName?: string | null;
+  scope?: 'tab' | 'global';
+}): TabOwnershipContext {
+  const workspaceId = opts.workspaceId ?? null;
+  const selectedWorkspaceId = opts.selectedWorkspaceId ?? null;
+
+  return {
+    scope: opts.scope ?? 'tab',
+    source: normalizeTabSource(opts.source),
+    actor: getActorContext(opts.source),
+    workspace: {
+      id: workspaceId,
+      name: opts.workspaceName ?? null,
+      selectedId: selectedWorkspaceId,
+      selectedName: opts.selectedWorkspaceName ?? null,
+      matchesSelection: workspaceId && selectedWorkspaceId
+        ? workspaceId === selectedWorkspaceId
+        : workspaceId === null
+          ? null
+          : false,
+    },
+  };
+}

--- a/src/tabs/manager.ts
+++ b/src/tabs/manager.ts
@@ -4,12 +4,11 @@ import type { SyncManager } from '../sync/manager';
 import type { SessionRestoreManager } from '../session/restore';
 import { createLogger } from '../utils/logger';
 import { IpcChannels } from '../shared/ipc-channels';
+import type { TabSource } from './context';
 
 const log = createLogger('TabManager');
 
 // ─── Types ──────────────────────────────────────────────────────────
-
-export type TabSource = 'user' | 'wingman';
 
 export interface Tab {
   id: string;
@@ -66,6 +65,7 @@ export class TabManager {
   private sessionRestore: SessionRestoreManager | null = null;
   private sessionTimer: ReturnType<typeof setTimeout> | null = null;
   private workspaceIdResolver: ((webContentsId: number) => string | null) | null = null;
+  private activeTabChangedHandler: ((tab: Tab | null) => void | Promise<void>) | null = null;
 
   // === 2. Constructor (BrowserWindow variant) ===
 
@@ -93,6 +93,11 @@ export class TabManager {
     this.workspaceIdResolver = resolver;
   }
 
+  /** Wire a callback that runs after the active tab changes. */
+  setActiveTabChangedHandler(handler: ((tab: Tab | null) => void | Promise<void>) | null): void {
+    this.activeTabChangedHandler = handler;
+  }
+
   // === 4. Public methods ===
 
   /** Get the active tab */
@@ -113,6 +118,16 @@ export class TabManager {
     const tab = this.tabs.get(tabId);
     if (!tab) return null;
     return webContents.fromId(tab.webContentsId) || null;
+  }
+
+  /** Get the active tab's webContents ID, or null when no tab is focused. */
+  getActiveWebContentsId(): number | null {
+    return this.getActiveTab()?.webContentsId ?? null;
+  }
+
+  /** List tracked webContents IDs for all tabs. */
+  listWebContentsIds(): number[] {
+    return this.listTabs().map(tab => tab.webContentsId);
   }
 
   /** Get a tab by ID */
@@ -267,6 +282,8 @@ export class TabManager {
       const remaining = Array.from(this.tabs.keys());
       if (remaining.length > 0) {
         await this.focusTab(remaining[remaining.length - 1]);
+      } else {
+        await this.notifyActiveTabChanged(null);
       }
     }
 
@@ -293,6 +310,8 @@ export class TabManager {
     await this.win.webContents.executeJavaScript(`
       window.__tandemTabs.focusTab(${JSON.stringify(tabId)})
     `);
+
+    await this.notifyActiveTabChanged(tab);
 
     return true;
   }
@@ -455,6 +474,7 @@ export class TabManager {
     };
     this.tabs.set(id, tab);
     this.activeTabId = id;
+    void this.notifyActiveTabChanged(tab);
     return tab;
   }
 
@@ -691,6 +711,21 @@ export class TabManager {
         error instanceof Error ? error.message : String(error),
       );
       return false;
+    }
+  }
+
+  private async notifyActiveTabChanged(tab: Tab | null): Promise<void> {
+    if (!this.activeTabChangedHandler) {
+      return;
+    }
+
+    try {
+      await this.activeTabChangedHandler(tab);
+    } catch (error) {
+      log.warn(
+        'Active tab changed handler failed:',
+        error instanceof Error ? error.message : String(error),
+      );
     }
   }
 }

--- a/src/tabs/runtime-context.ts
+++ b/src/tabs/runtime-context.ts
@@ -1,0 +1,40 @@
+import type { WorkspaceManager } from '../workspaces/manager';
+import type { Tab, TabManager } from './manager';
+import { buildTabOwnershipContext, type TabOwnershipContext } from './context';
+
+function getSelectedWorkspace(workspaceManager: WorkspaceManager): { id: string | null; name: string | null } {
+  const workspace = workspaceManager.getActive();
+  return {
+    id: workspace?.id ?? null,
+    name: workspace?.name ?? null,
+  };
+}
+
+export function buildOwnershipContextForTab(
+  workspaceManager: WorkspaceManager,
+  tab: Pick<Tab, 'webContentsId' | 'source'> | null,
+  scope: 'tab' | 'global' = 'tab',
+): TabOwnershipContext {
+  const selectedWorkspace = getSelectedWorkspace(workspaceManager);
+  const workspaceId = tab ? workspaceManager.getWorkspaceIdForTab(tab.webContentsId) : null;
+  const workspace = workspaceId ? workspaceManager.get(workspaceId) ?? null : null;
+
+  return buildTabOwnershipContext({
+    source: tab?.source ?? null,
+    workspaceId,
+    workspaceName: workspace?.name ?? null,
+    selectedWorkspaceId: selectedWorkspace.id,
+    selectedWorkspaceName: selectedWorkspace.name,
+    scope,
+  });
+}
+
+export function buildOwnershipContextForTabId(
+  tabManager: TabManager,
+  workspaceManager: WorkspaceManager,
+  tabId?: string,
+  scope: 'tab' | 'global' = 'tab',
+): TabOwnershipContext {
+  const tab = tabId ? tabManager.getTab(tabId) : null;
+  return buildOwnershipContextForTab(workspaceManager, tab, scope);
+}

--- a/src/tabs/tests/context.test.ts
+++ b/src/tabs/tests/context.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeTabSource,
+  getActorContext,
+  buildTabOwnershipContext,
+} from '../context';
+
+describe('normalizeTabSource', () => {
+  it('returns null for non-string input', () => {
+    expect(normalizeTabSource(null)).toBeNull();
+    expect(normalizeTabSource(undefined)).toBeNull();
+    expect(normalizeTabSource(42)).toBeNull();
+    expect(normalizeTabSource({})).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(normalizeTabSource('')).toBeNull();
+  });
+
+  it('returns null for whitespace-only string', () => {
+    expect(normalizeTabSource('   ')).toBeNull();
+  });
+
+  it('returns trimmed string for valid input', () => {
+    expect(normalizeTabSource('claude')).toBe('claude');
+    expect(normalizeTabSource('  user  ')).toBe('user');
+    expect(normalizeTabSource('wingman')).toBe('wingman');
+  });
+});
+
+describe('getActorContext', () => {
+  it('returns unknown kind for null/empty source', () => {
+    expect(getActorContext(null)).toEqual({ id: null, kind: 'unknown' });
+    expect(getActorContext('')).toEqual({ id: null, kind: 'unknown' });
+    expect(getActorContext(undefined)).toEqual({ id: null, kind: 'unknown' });
+  });
+
+  it('returns human kind for user source', () => {
+    expect(getActorContext('user')).toEqual({ id: 'user', kind: 'human' });
+  });
+
+  it('returns assistant kind for wingman source', () => {
+    expect(getActorContext('wingman')).toEqual({ id: 'wingman', kind: 'assistant' });
+  });
+
+  it('returns agent kind for any other source', () => {
+    expect(getActorContext('claude')).toEqual({ id: 'claude', kind: 'agent' });
+    expect(getActorContext('codex')).toEqual({ id: 'codex', kind: 'agent' });
+    expect(getActorContext('my-agent')).toEqual({ id: 'my-agent', kind: 'agent' });
+  });
+});
+
+describe('buildTabOwnershipContext', () => {
+  it('builds context with all fields populated', () => {
+    const ctx = buildTabOwnershipContext({
+      source: 'claude',
+      workspaceId: 'ws-1',
+      workspaceName: 'Claude WS',
+      selectedWorkspaceId: 'ws-1',
+      selectedWorkspaceName: 'Claude WS',
+      scope: 'tab',
+    });
+
+    expect(ctx).toEqual({
+      scope: 'tab',
+      source: 'claude',
+      actor: { id: 'claude', kind: 'agent' },
+      workspace: {
+        id: 'ws-1',
+        name: 'Claude WS',
+        selectedId: 'ws-1',
+        selectedName: 'Claude WS',
+        matchesSelection: true,
+      },
+    });
+  });
+
+  it('sets matchesSelection to false when workspace IDs differ', () => {
+    const ctx = buildTabOwnershipContext({
+      source: 'claude',
+      workspaceId: 'ws-1',
+      selectedWorkspaceId: 'ws-2',
+    });
+
+    expect(ctx.workspace.matchesSelection).toBe(false);
+  });
+
+  it('sets matchesSelection to null when workspaceId is null', () => {
+    const ctx = buildTabOwnershipContext({
+      source: 'user',
+      workspaceId: null,
+      selectedWorkspaceId: 'ws-1',
+    });
+
+    expect(ctx.workspace.matchesSelection).toBeNull();
+  });
+
+  it('defaults scope to tab when not specified', () => {
+    const ctx = buildTabOwnershipContext({});
+    expect(ctx.scope).toBe('tab');
+  });
+
+  it('uses global scope when specified', () => {
+    const ctx = buildTabOwnershipContext({ scope: 'global' });
+    expect(ctx.scope).toBe('global');
+  });
+
+  it('handles missing/null source as unknown actor', () => {
+    const ctx = buildTabOwnershipContext({ source: null });
+    expect(ctx.source).toBeNull();
+    expect(ctx.actor).toEqual({ id: null, kind: 'unknown' });
+  });
+
+  it('handles user source as human actor', () => {
+    const ctx = buildTabOwnershipContext({ source: 'user' });
+    expect(ctx.actor).toEqual({ id: 'user', kind: 'human' });
+  });
+
+  it('handles wingman source as assistant actor', () => {
+    const ctx = buildTabOwnershipContext({ source: 'wingman' });
+    expect(ctx.actor).toEqual({ id: 'wingman', kind: 'assistant' });
+  });
+
+  it('nullifies all workspace fields when omitted', () => {
+    const ctx = buildTabOwnershipContext({});
+    expect(ctx.workspace).toEqual({
+      id: null,
+      name: null,
+      selectedId: null,
+      selectedName: null,
+      matchesSelection: null,
+    });
+  });
+});

--- a/src/tabs/tests/runtime-context.test.ts
+++ b/src/tabs/tests/runtime-context.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from 'vitest';
+import { buildOwnershipContextForTab, buildOwnershipContextForTabId } from '../runtime-context';
+
+function createMockWorkspaceManager(overrides: Record<string, unknown> = {}) {
+  return {
+    getActive: vi.fn().mockReturnValue({ id: 'ws-default', name: 'Default' }),
+    getWorkspaceIdForTab: vi.fn().mockReturnValue(null),
+    get: vi.fn().mockReturnValue(null),
+    ...overrides,
+  } as any;
+}
+
+function createMockTabManager(overrides: Record<string, unknown> = {}) {
+  return {
+    getTab: vi.fn().mockReturnValue(null),
+    ...overrides,
+  } as any;
+}
+
+describe('buildOwnershipContextForTab', () => {
+  it('returns global-scope unknown context when tab is null', () => {
+    const wm = createMockWorkspaceManager();
+    const ctx = buildOwnershipContextForTab(wm, null);
+
+    expect(ctx.scope).toBe('tab');
+    expect(ctx.source).toBeNull();
+    expect(ctx.actor).toEqual({ id: null, kind: 'unknown' });
+    expect(ctx.workspace.id).toBeNull();
+    expect(ctx.workspace.selectedId).toBe('ws-default');
+  });
+
+  it('builds context for a tab with a source and workspace', () => {
+    const wm = createMockWorkspaceManager({
+      getActive: vi.fn().mockReturnValue({ id: 'ws-1', name: 'Codex WS' }),
+      getWorkspaceIdForTab: vi.fn().mockReturnValue('ws-1'),
+      get: vi.fn().mockReturnValue({ id: 'ws-1', name: 'Codex WS' }),
+    });
+
+    const tab = { webContentsId: 100, source: 'claude' };
+    const ctx = buildOwnershipContextForTab(wm, tab);
+
+    expect(ctx.scope).toBe('tab');
+    expect(ctx.source).toBe('claude');
+    expect(ctx.actor).toEqual({ id: 'claude', kind: 'agent' });
+    expect(ctx.workspace.id).toBe('ws-1');
+    expect(ctx.workspace.name).toBe('Codex WS');
+    expect(ctx.workspace.selectedId).toBe('ws-1');
+    expect(ctx.workspace.matchesSelection).toBe(true);
+  });
+
+  it('sets matchesSelection to false when tab workspace differs from selected', () => {
+    const wm = createMockWorkspaceManager({
+      getActive: vi.fn().mockReturnValue({ id: 'ws-selected', name: 'Selected' }),
+      getWorkspaceIdForTab: vi.fn().mockReturnValue('ws-tab'),
+      get: vi.fn().mockReturnValue({ id: 'ws-tab', name: 'Tab WS' }),
+    });
+
+    const tab = { webContentsId: 200, source: 'user' };
+    const ctx = buildOwnershipContextForTab(wm, tab);
+
+    expect(ctx.workspace.id).toBe('ws-tab');
+    expect(ctx.workspace.selectedId).toBe('ws-selected');
+    expect(ctx.workspace.matchesSelection).toBe(false);
+  });
+
+  it('respects the scope override', () => {
+    const wm = createMockWorkspaceManager();
+    const ctx = buildOwnershipContextForTab(wm, null, 'global');
+    expect(ctx.scope).toBe('global');
+  });
+
+  it('handles tab with no workspace assignment', () => {
+    const wm = createMockWorkspaceManager({
+      getWorkspaceIdForTab: vi.fn().mockReturnValue(null),
+    });
+
+    const tab = { webContentsId: 300, source: 'user' };
+    const ctx = buildOwnershipContextForTab(wm, tab);
+
+    expect(ctx.workspace.id).toBeNull();
+    expect(ctx.workspace.name).toBeNull();
+  });
+});
+
+describe('buildOwnershipContextForTabId', () => {
+  it('returns unknown context when tabId is undefined', () => {
+    const wm = createMockWorkspaceManager();
+    const tm = createMockTabManager();
+    const ctx = buildOwnershipContextForTabId(tm, wm, undefined);
+
+    expect(ctx.source).toBeNull();
+    expect(ctx.actor.kind).toBe('unknown');
+  });
+
+  it('returns unknown context when tab is not found', () => {
+    const wm = createMockWorkspaceManager();
+    const tm = createMockTabManager({ getTab: vi.fn().mockReturnValue(null) });
+    const ctx = buildOwnershipContextForTabId(tm, wm, 'nonexistent-tab');
+
+    expect(ctx.source).toBeNull();
+    expect(ctx.actor.kind).toBe('unknown');
+  });
+
+  it('builds full context when tab is found', () => {
+    const wm = createMockWorkspaceManager({
+      getActive: vi.fn().mockReturnValue({ id: 'ws-1', name: 'Work' }),
+      getWorkspaceIdForTab: vi.fn().mockReturnValue('ws-1'),
+      get: vi.fn().mockReturnValue({ id: 'ws-1', name: 'Work' }),
+    });
+    const tm = createMockTabManager({
+      getTab: vi.fn().mockReturnValue({ webContentsId: 42, source: 'wingman' }),
+    });
+
+    const ctx = buildOwnershipContextForTabId(tm, wm, 'tab-42');
+
+    expect(ctx.source).toBe('wingman');
+    expect(ctx.actor).toEqual({ id: 'wingman', kind: 'assistant' });
+    expect(ctx.workspace.id).toBe('ws-1');
+  });
+
+  it('respects the scope parameter', () => {
+    const wm = createMockWorkspaceManager();
+    const tm = createMockTabManager();
+    const ctx = buildOwnershipContextForTabId(tm, wm, undefined, 'global');
+    expect(ctx.scope).toBe('global');
+  });
+});

--- a/src/tabs/tests/tabs.test.ts
+++ b/src/tabs/tests/tabs.test.ts
@@ -238,6 +238,18 @@ describe('TabManager', () => {
       const result = await tm.focusTab('nonexistent');
       expect(result).toBe(false);
     });
+
+    it('notifies the active-tab handler after focus changes', async () => {
+      const handler = vi.fn();
+      tm.setActiveTabChangedHandler(handler);
+      await tm.openTab('https://one.com');
+      const t2 = await tm.openTab('https://two.com', undefined, 'user', 'persist:tandem', false);
+
+      handler.mockClear();
+      await tm.focusTab(t2.id);
+
+      expect(handler).toHaveBeenCalledWith(expect.objectContaining({ id: t2.id, webContentsId: t2.webContentsId }));
+    });
   });
 
   describe('updateTab()', () => {

--- a/src/workspaces/manager.ts
+++ b/src/workspaces/manager.ts
@@ -30,6 +30,11 @@ type LegacyWorkspace = Workspace & {
   emoji?: string;
 };
 
+interface ReconcileOptions {
+  notify?: boolean;
+  followFocusedTab?: boolean;
+}
+
 // ─── Storage path ───────────────────────────────────────────────────
 
 const STORAGE_PATH = tandemDir('workspaces.json');
@@ -54,6 +59,10 @@ export class WorkspaceManager {
   private lastModified: string | undefined;
   private mainWindow: BrowserWindow | null = null;
   private syncManager: SyncManager | null = null;
+  private trackedTabIdsResolver: (() => number[]) | null = null;
+  private activeTabIdResolver: (() => number | null) | null = null;
+  private isReconciling = false;
+  private selectionPinned = false;
 
   // === 2. Constructor ===
 
@@ -74,20 +83,33 @@ export class WorkspaceManager {
     this.mergeFromSync();
   }
 
+  /** Wire runtime tab resolvers so workspace state can be reconciled against real tabs. */
+  setTabStateResolvers(opts: {
+    listTrackedTabIds: (() => number[]) | null;
+    getActiveTabId: (() => number | null) | null;
+  }): void {
+    this.trackedTabIdsResolver = opts.listTrackedTabIds;
+    this.activeTabIdResolver = opts.getActiveTabId;
+    this.reconcileWithRuntimeState();
+  }
+
   // === 4. Public methods ===
 
   /** List all workspaces sorted by display order. */
   list(): Workspace[] {
-    return Array.from(this.workspaces.values()).sort((a, b) => a.order - b.order);
+    this.reconcileWithRuntimeState();
+    return this.getSortedWorkspaces();
   }
 
   /** Get a workspace by ID, or undefined if not found. */
   get(id: string): Workspace | undefined {
+    this.reconcileWithRuntimeState();
     return this.workspaces.get(id);
   }
 
   /** Get the currently active workspace (falls back to default). */
   getActive(): Workspace {
+    this.reconcileWithRuntimeState();
     const ws = this.workspaces.get(this.activeId);
     if (!ws) return this.getDefaultWorkspace()!;
     return ws;
@@ -95,7 +117,14 @@ export class WorkspaceManager {
 
   /** Get the ID of the active workspace. */
   getActiveId(): string {
+    this.reconcileWithRuntimeState();
     return this.activeId;
+  }
+
+  /** Get whether the active workspace currently comes from an explicit selection or the focused tab. */
+  getActiveSource(): 'selection' | 'focused-tab' {
+    this.reconcileWithRuntimeState();
+    return this.selectionPinned ? 'selection' : 'focused-tab';
   }
 
   /**
@@ -104,12 +133,95 @@ export class WorkspaceManager {
    * @returns workspace ID, or null if unassigned
    */
   getWorkspaceIdForTab(tabId: number): string | null {
-    for (const workspace of this.workspaces.values()) {
-      if (workspace.tabIds.includes(tabId)) {
-        return workspace.id;
+    this.reconcileWithRuntimeState();
+    return this.getWorkspaceIdForTabInternal(tabId);
+  }
+
+  /**
+   * Reconcile workspace membership against the tracked tabs and sync the active workspace
+   * to the focused tab when possible.
+   */
+  reconcileTabState(
+    tabIds: Iterable<number> | null | undefined,
+    activeTabId?: number | null,
+    options: ReconcileOptions = {},
+  ): { changed: boolean; activeId: string } {
+    const validTabIds = tabIds
+      ? new Set(Array.from(tabIds).filter((tabId) => Number.isFinite(tabId)))
+      : null;
+    const defaultWorkspace = this.getDefaultWorkspace();
+    let changed = false;
+
+    if (validTabIds) {
+      const assignedTabIds = new Set<number>();
+      for (const workspace of this.getSortedWorkspaces()) {
+        const nextTabIds: number[] = [];
+        for (const tabId of workspace.tabIds) {
+          if (!Number.isFinite(tabId) || !validTabIds.has(tabId) || assignedTabIds.has(tabId)) {
+            changed = true;
+            continue;
+          }
+          assignedTabIds.add(tabId);
+          nextTabIds.push(tabId);
+        }
+
+        if (!this.haveSameTabIds(workspace.tabIds, nextTabIds)) {
+          workspace.tabIds = nextTabIds;
+          changed = true;
+        }
+      }
+
+      if (defaultWorkspace) {
+        const unassignedTabIds = Array.from(validTabIds)
+          .filter((tabId) => !assignedTabIds.has(tabId))
+          .sort((left, right) => left - right);
+        if (unassignedTabIds.length > 0) {
+          defaultWorkspace.tabIds = [...defaultWorkspace.tabIds, ...unassignedTabIds];
+          changed = true;
+        }
       }
     }
-    return null;
+
+    const nextActiveId = this.resolveActiveWorkspaceId(activeTabId ?? null, options.followFocusedTab === true);
+    if (nextActiveId !== this.activeId) {
+      this.activeId = nextActiveId;
+      changed = true;
+    }
+
+    if (options.followFocusedTab) {
+      const focusedWorkspaceId = activeTabId != null ? this.getWorkspaceIdForTabInternal(activeTabId) : null;
+      if (focusedWorkspaceId) {
+        this.selectionPinned = false;
+      }
+    }
+
+    if (changed) {
+      this.saveToDisk();
+      const activeWorkspace = this.workspaces.get(this.activeId) || this.getDefaultWorkspace();
+      if (options.notify && activeWorkspace) {
+        this.notifySwitch(activeWorkspace);
+      }
+    }
+
+    return { changed, activeId: this.activeId };
+  }
+
+  /** Reconcile using runtime-provided tab state when available. */
+  reconcileWithRuntimeState(options: ReconcileOptions = {}): { changed: boolean; activeId: string } {
+    if (this.isReconciling) {
+      return { changed: false, activeId: this.activeId };
+    }
+
+    this.isReconciling = true;
+    try {
+      return this.reconcileTabState(
+        this.trackedTabIdsResolver ? this.trackedTabIdsResolver() : null,
+        this.activeTabIdResolver ? this.activeTabIdResolver() : null,
+        options,
+      );
+    } finally {
+      this.isReconciling = false;
+    }
   }
 
   /**
@@ -188,6 +300,7 @@ export class WorkspaceManager {
     const ws = this.workspaces.get(id);
     if (!ws) throw new Error(`Workspace ${id} not found`);
     this.activeId = id;
+    this.selectionPinned = true;
     this.saveToDisk();
     this.notifySwitch(ws);
     log.info(`Switched to workspace "${ws.name}"`);
@@ -203,7 +316,9 @@ export class WorkspaceManager {
         workspace.tabIds.splice(idx, 1);
       }
     }
-    active.tabIds.push(tabId);
+    if (!active.tabIds.includes(tabId)) {
+      active.tabIds.push(tabId);
+    }
     this.saveToDisk();
   }
 
@@ -233,7 +348,9 @@ export class WorkspaceManager {
     }
 
     // Add to target
-    target.tabIds.push(tabId);
+    if (!target.tabIds.includes(tabId)) {
+      target.tabIds.push(tabId);
+    }
     this.saveToDisk();
 
     // Notify shell to re-filter tab bar
@@ -267,6 +384,7 @@ export class WorkspaceManager {
         if (!this.workspaces.has(this.activeId)) {
           this.activeId = this.getDefaultWorkspace()?.id || '';
         }
+        this.reconcileWithRuntimeState();
         this.saveToDisk();
         log.info('Workspaces loaded from sync (newer version found)');
       }
@@ -303,6 +421,7 @@ export class WorkspaceManager {
         if (!this.workspaces.has(this.activeId)) {
           this.activeId = this.getDefaultWorkspace()?.id || '';
         }
+        this.reconcileTabState(null, null);
       }
     } catch (e) {
       log.warn('Failed to load workspaces from disk:', e instanceof Error ? e.message : String(e));
@@ -336,7 +455,7 @@ export class WorkspaceManager {
       this.lastModified = new Date().toISOString();
       const data: WorkspacesFile = {
         activeId: this.activeId,
-        workspaces: this.list(),
+        workspaces: this.getSortedWorkspaces(),
         lastModified: this.lastModified,
       };
       fs.writeFileSync(STORAGE_PATH, JSON.stringify(data, null, 2));
@@ -348,8 +467,53 @@ export class WorkspaceManager {
     }
   }
 
+  private getSortedWorkspaces(): Workspace[] {
+    return Array.from(this.workspaces.values()).sort((a, b) => a.order - b.order);
+  }
+
   private generateId(): string {
     return crypto.randomBytes(8).toString('hex');
+  }
+
+  private getWorkspaceIdForTabInternal(tabId: number): string | null {
+    for (const workspace of this.workspaces.values()) {
+      if (workspace.tabIds.includes(tabId)) {
+        return workspace.id;
+      }
+    }
+    return null;
+  }
+
+  private resolveActiveWorkspaceId(activeTabId: number | null, followFocusedTab: boolean): string {
+    if (activeTabId !== null) {
+      const workspaceId = this.getWorkspaceIdForTabInternal(activeTabId);
+      if (workspaceId && (followFocusedTab || !this.selectionPinned)) {
+        return workspaceId;
+      }
+    }
+
+    if (this.workspaces.has(this.activeId)) {
+      return this.activeId;
+    }
+
+    this.selectionPinned = false;
+
+    if (activeTabId !== null) {
+      const workspaceId = this.getWorkspaceIdForTabInternal(activeTabId);
+      if (workspaceId) {
+        return workspaceId;
+      }
+    }
+
+    return this.getDefaultWorkspace()?.id || '';
+  }
+
+  private haveSameTabIds(left: number[], right: number[]): boolean {
+    if (left.length !== right.length) {
+      return false;
+    }
+
+    return left.every((tabId, index) => tabId === right[index]);
   }
 
   private getDefaultWorkspace(): Workspace | undefined {

--- a/src/workspaces/tests/workspaces.test.ts
+++ b/src/workspaces/tests/workspaces.test.ts
@@ -168,6 +168,7 @@ describe('WorkspaceManager', () => {
       const result = wm.switch(ws.id);
       expect(result.id).toBe(ws.id);
       expect(wm.getActiveId()).toBe(ws.id);
+      expect(wm.getActiveSource()).toBe('selection');
     });
 
     it('throws for nonexistent workspace', () => {
@@ -267,6 +268,67 @@ describe('WorkspaceManager', () => {
       for (const w of wm.list()) {
         expect(w.tabIds).toEqual([]);
       }
+    });
+  });
+
+  describe('reconcileTabState', () => {
+    it('removes stale and duplicate tab IDs, assigns unowned tabs to default, and syncs active workspace to the focused tab', () => {
+      const wm = createManager();
+      const wsA = wm.create({ name: 'Agent A' });
+      const wsB = wm.create({ name: 'Agent B' });
+      const workspaces = (wm as any).workspaces as Map<string, { tabIds: number[] }>;
+      const defaultWs = wm.list().find(w => w.isDefault)!;
+
+      workspaces.get(defaultWs.id)!.tabIds = [1, 1, 999];
+      workspaces.get(wsA.id)!.tabIds = [1, 2];
+      workspaces.get(wsB.id)!.tabIds = [];
+
+      const result = wm.reconcileTabState([1, 2, 3], 2);
+
+      expect(result).toEqual({ changed: true, activeId: wsA.id });
+      expect(workspaces.get(defaultWs.id)!.tabIds).toEqual([1, 3]);
+      expect(workspaces.get(wsA.id)!.tabIds).toEqual([2]);
+      expect(workspaces.get(wsB.id)!.tabIds).toEqual([]);
+      expect(wm.getActiveId()).toBe(wsA.id);
+    });
+
+    it('does not emit workspace-switched notifications for read-path reconciliation unless explicitly requested', () => {
+      const wm = createManager();
+      const ws = wm.create({ name: 'Agent A' });
+      const mockSend = vi.fn();
+      const mockWin = {
+        isDestroyed: vi.fn().mockReturnValue(false),
+        webContents: { send: mockSend, isDestroyed: vi.fn().mockReturnValue(false) },
+      } as any;
+      wm.setMainWindow(mockWin);
+
+      const workspaces = (wm as any).workspaces as Map<string, { tabIds: number[] }>;
+      const defaultWs = wm.list().find(w => w.isDefault)!;
+      workspaces.get(defaultWs.id)!.tabIds = [1];
+      workspaces.get(ws.id)!.tabIds = [2];
+
+      wm.reconcileTabState([1, 2], 2);
+      expect(mockSend).not.toHaveBeenCalled();
+
+      wm.reconcileTabState([1, 2], 1, { notify: true });
+      expect(mockSend).toHaveBeenCalledWith('workspace-switched', expect.objectContaining({ id: defaultWs.id }));
+    });
+
+    it('preserves an explicitly selected empty workspace until focus actually changes', () => {
+      const wm = createManager();
+      const ws = wm.create({ name: 'Empty' });
+
+      wm.switch(ws.id);
+      expect(wm.getActiveId()).toBe(ws.id);
+      expect(wm.getActiveSource()).toBe('selection');
+
+      wm.reconcileTabState([1], 1);
+      expect(wm.getActiveId()).toBe(ws.id);
+      expect(wm.getActiveSource()).toBe('selection');
+
+      wm.reconcileTabState([1], 1, { followFocusedTab: true });
+      expect(wm.getActiveId()).toBe(wm.list().find(workspace => workspace.isDefault)!.id);
+      expect(wm.getActiveSource()).toBe('focused-tab');
     });
   });
 

--- a/src/workspaces/tests/workspaces.test.ts
+++ b/src/workspaces/tests/workspaces.test.ts
@@ -343,4 +343,140 @@ describe('WorkspaceManager', () => {
       expect(list[2].name).toBe('A');
     });
   });
+
+  describe('setTabStateResolvers', () => {
+    it('reconciles immediately using the provided resolvers', () => {
+      const wm = createManager();
+      const ws = wm.create({ name: 'Agent' });
+      const defaultWs = wm.list().find(w => w.isDefault)!;
+
+      // Pre-assign tabs manually
+      const workspaces = (wm as any).workspaces as Map<string, { tabIds: number[] }>;
+      workspaces.get(defaultWs.id)!.tabIds = [];
+      workspaces.get(ws.id)!.tabIds = [10];
+
+      wm.setTabStateResolvers({
+        listTrackedTabIds: () => [10, 20],
+        getActiveTabId: () => 10,
+      });
+
+      // Tab 20 was unowned, should now be assigned to default workspace
+      expect(defaultWs.tabIds).toContain(20);
+      // Active workspace should follow the focused tab (tab 10 is in ws)
+      expect(wm.getActiveId()).toBe(ws.id);
+    });
+
+    it('handles null resolvers gracefully', () => {
+      const wm = createManager();
+      expect(() => wm.setTabStateResolvers({
+        listTrackedTabIds: null,
+        getActiveTabId: null,
+      })).not.toThrow();
+    });
+  });
+
+  describe('reconcileWithRuntimeState', () => {
+    it('uses runtime resolvers when set', () => {
+      const wm = createManager();
+      const ws = wm.create({ name: 'Work' });
+      const workspaces = (wm as any).workspaces as Map<string, { tabIds: number[] }>;
+      workspaces.get(ws.id)!.tabIds = [5];
+
+      wm.setTabStateResolvers({
+        listTrackedTabIds: () => [5],
+        getActiveTabId: () => 5,
+      });
+
+      const result = wm.reconcileWithRuntimeState();
+      expect(result.activeId).toBe(ws.id);
+    });
+
+    it('is a no-op (returns false/current id) when called during an active reconciliation (reentrancy guard)', () => {
+      const wm = createManager();
+      let innerResult: { changed: boolean; activeId: string } | undefined;
+
+      // Simulate reentrancy by calling reconcileWithRuntimeState inside the listTrackedTabIds resolver
+      wm.setTabStateResolvers({
+        listTrackedTabIds: () => {
+          // This inner call should hit the reentrancy guard
+          innerResult = (wm as any).reconcileWithRuntimeState();
+          return [];
+        },
+        getActiveTabId: () => null,
+      });
+
+      wm.reconcileWithRuntimeState();
+      // The inner call should have returned early without changing anything
+      expect(innerResult).toEqual({ changed: false, activeId: expect.any(String) });
+    });
+
+    it('returns focused-tab as active source when selectionPinned is false', () => {
+      const wm = createManager();
+      expect(wm.getActiveSource()).toBe('focused-tab');
+    });
+
+    it('returns selection as active source after an explicit switch', () => {
+      const wm = createManager();
+      const ws = wm.create({ name: 'Pinned' });
+      wm.switch(ws.id);
+      expect(wm.getActiveSource()).toBe('selection');
+    });
+  });
+
+  describe('assignTab duplicate prevention', () => {
+    it('does not add duplicate tab IDs to a workspace', () => {
+      const wm = createManager();
+      wm.assignTab(55);
+      wm.assignTab(55); // second call should be a no-op
+      const active = wm.getActive();
+      expect(active.tabIds.filter(id => id === 55)).toHaveLength(1);
+    });
+  });
+
+  describe('moveTab duplicate prevention', () => {
+    it('does not add a tab ID to the target workspace if it is already there', () => {
+      const wm = createManager();
+      wm.assignTab(66);
+      const ws2 = wm.create({ name: 'Target' });
+      wm.moveTab(66, ws2.id);
+      wm.moveTab(66, ws2.id); // second move should be idempotent
+      expect(ws2.tabIds.filter(id => id === 66)).toHaveLength(1);
+    });
+  });
+
+  describe('reconcileTabState — additional edge cases', () => {
+    it('returns changed:false when nothing needs reconciliation', () => {
+      const wm = createManager();
+      wm.assignTab(77);
+      const defaultWs = wm.list().find(w => w.isDefault)!;
+
+      const result = wm.reconcileTabState([77], 77);
+      expect(result.changed).toBe(false);
+      expect(result.activeId).toBe(defaultWs.id);
+    });
+
+    it('handles null tabIds gracefully (no membership change)', () => {
+      const wm = createManager();
+      wm.assignTab(88);
+      const before = wm.getActiveId();
+
+      const result = wm.reconcileTabState(null, null);
+      expect(result.activeId).toBe(before);
+    });
+
+    it('resolveActiveWorkspaceId falls back to default when activeId workspace no longer exists', () => {
+      const wm = createManager();
+      const ws = wm.create({ name: 'Transient' });
+      wm.switch(ws.id);
+
+      // Manually remove the workspace without going through remove() to bypass guards
+      const workspacesMap = (wm as any).workspaces as Map<string, unknown>;
+      workspacesMap.delete(ws.id);
+
+      // Reconcile should detect the invalid activeId and fall back to default
+      const result = wm.reconcileTabState([], null);
+      const defaultWs = Array.from(workspacesMap.values()).find((w: any) => w.isDefault) as any;
+      expect(result.activeId).toBe(defaultWs.id);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Fix workspace state drift when multiple actors operate simultaneously
- WorkspaceManager reconciles tab-membership deterministically
- Explicit workspace selection support (separate from focused-tab tracking)
- Read-paths no longer emit workspace-switched IPC (fixes refresh/focus loop)

## Changes

**Workspace state:**
- `GET /workspaces` — explicitly global, reports `scope`, `activeTabId`, `activeTabWorkspaceId`, `activeWorkspaceSource`
- `GET /active-tab/context` — reliable ownership context with workspace, source, actor
- `/events/stream` — enriches tab-events with workspace/actor context

**MCP:**
- New helpers: `TANDEM_SOURCE` / `TANDEM_MCP_SOURCE` / `TANDEM_ACTOR_SOURCE`
- No hardcoded wingman/claude source strings in MCP actions
- `tandem://tabs/list` and `tandem://context` include workspace/source context

**New files:**
- `src/tabs/context.ts` — TabSource type + normalizer
- `src/tabs/runtime-context.ts` — ownership context builder

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx vitest run` — 2003 tests passing (96 test files)
- [x] Manual verification in live Tandem (workspace switching, tab opening, SSE events)
- [x] Refresh storm no longer occurs after restart