### PR TITLE
fix: enforce true tab-scoping for DevTools and network inspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Tandem Browser will be documented in this file.
 
+## [v0.71.2] - 2026-04-13
+
+- fix: harden tab-scoped devtools and network inspection across HTTP API and MCP
+
+### Fixed
+
+- DevTools read routes now resolve an explicit tab target, default to the active tab, and return scope metadata so `status`, `console`, `network`, `performance`, `storage`, `evaluate`, DOM queries, and raw CDP calls no longer imply global state when they are tab-scoped
+- CDP network capture now keys requests by `webContents` target instead of raw `requestId` alone, preventing cross-tab collisions and making `/devtools/network/:requestId/body` trustworthy when multiple attached tabs are active
+- The webRequest-based network inspector now records tab identity and resource type, so `/network/log`, `/network/apis`, `/network/domains`, and `/network/har` can be filtered per tab instead of mixing traffic from unrelated tabs or extension noise
+- MCP DevTools and network tools now describe active-tab-by-default behavior accurately, forward `tabId` only where the HTTP API truly honors it, and expose scoped status/body/summary calls that match the underlying routes
+- Added focused route, MCP, DevTools capture, and network inspector tests to keep scoped-vs-global behavior aligned across the API surface
+
 ## [v0.71.1] - 2026-04-13
 
 - fix: stabilize multi-actor workspace, tab, SSE, and MCP ownership context

--- a/TODO.md
+++ b/TODO.md
@@ -89,6 +89,7 @@ Last updated: April 13, 2026
 
 ## Recently Completed
 
+- [x] DevTools and network inspection tab scoping: `/devtools/*` and `/network/*` retrieval routes now default to active-tab scope, honor explicit tab targeting, and keep MCP descriptions aligned with the real behavior
 - [x] Awareness tools: activity digest and real-time focus detection for shared human-AI context
 - [x] URL bar autocomplete from browsing history (Chrome-style dropdown with inline completion)
 - [x] MCP bookmark management: list, add, delete, update, folders, move, check (7 tools)

--- a/src/api/routes/devtools.ts
+++ b/src/api/routes/devtools.ts
@@ -1,10 +1,57 @@
 import type { Router, Request, Response } from 'express';
 import type { RouteContext } from '../context';
+import { resolveRequestedTab } from '../context';
+import type { Tab } from '../../tabs/manager';
 import { handleRouteError } from '../../utils/errors';
 import { DEFAULT_TIMEOUT_MS } from '../../utils/constants';
 
 /** Maximum allowed expression length for evaluation endpoints (1 MB) */
 const MAX_CODE_LENGTH = 1_048_576;
+
+interface EffectiveTabTarget {
+  requestedTabId: string | null;
+  tab: Tab | null;
+  source: 'header' | 'body' | 'query' | 'session' | 'active';
+}
+
+function sendRequestedTabNotFound(res: Response, tabId: string): void {
+  res.status(404).json({ error: `Tab ${tabId} not found` });
+}
+
+function resolveEffectiveTabTarget(
+  ctx: RouteContext,
+  req: Request,
+  opts?: { allowBody?: boolean; allowQuery?: boolean },
+): EffectiveTabTarget {
+  const requestedTab = resolveRequestedTab(ctx, req, opts);
+  if (requestedTab.requestedTabId) {
+    return {
+      requestedTabId: requestedTab.requestedTabId,
+      tab: requestedTab.tab,
+      source: requestedTab.source ?? 'header',
+    };
+  }
+
+  return {
+    requestedTabId: null,
+    tab: ctx.tabManager.getActiveTab(),
+    source: 'active',
+  };
+}
+
+function buildTabScope(target: EffectiveTabTarget): {
+  kind: 'tab';
+  tabId: string | null;
+  wcId: number | null;
+  source: EffectiveTabTarget['source'];
+} {
+  return {
+    kind: 'tab',
+    tabId: target.tab?.id ?? target.requestedTabId ?? null,
+    wcId: target.tab?.webContentsId ?? null,
+    source: target.source,
+  };
+}
 
 /**
  * Register DevTools CDP bridge routes (console, DOM, evaluate, storage, performance).
@@ -17,10 +64,33 @@ export function registerDevtoolsRoutes(router: Router, ctx: RouteContext): void 
   // ═══════════════════════════════════════════════
 
   /** DevTools status */
-  router.get('/devtools/status', async (_req: Request, res: Response) => {
+  router.get('/devtools/status', async (req: Request, res: Response) => {
     try {
-      const status = ctx.devToolsManager.getStatus();
-      res.json(status);
+      const target = resolveEffectiveTabTarget(ctx, req, { allowQuery: true });
+      if (target.requestedTabId && !target.tab) {
+        sendRequestedTabNotFound(res, target.requestedTabId);
+        return;
+      }
+
+      const managerStatus = ctx.devToolsManager.getStatus();
+      const scopedStatus = target.tab
+        ? ctx.devToolsManager.getStatus({ tabId: target.tab.id, wcId: target.tab.webContentsId })
+        : {
+            attached: false,
+            tabId: null,
+            wcId: null,
+            console: { entries: 0, errors: 0, lastId: 0 },
+            network: { entries: 0 },
+          };
+      res.json({
+        ...scopedStatus,
+        scope: buildTabScope(target),
+        managerPrimary: {
+          attached: managerStatus.attached,
+          tabId: managerStatus.tabId,
+          wcId: managerStatus.wcId,
+        },
+      });
     } catch (e) {
       handleRouteError(res, e);
     }
@@ -29,13 +99,23 @@ export function registerDevtoolsRoutes(router: Router, ctx: RouteContext): void 
   /** Console log entries */
   router.get('/devtools/console', (req: Request, res: Response) => {
     try {
+      const target = resolveEffectiveTabTarget(ctx, req, { allowQuery: true });
+      if (target.requestedTabId && !target.tab) {
+        sendRequestedTabNotFound(res, target.requestedTabId);
+        return;
+      }
       const level = req.query.level as string | undefined;
       const sinceId = req.query.since_id ? parseInt(req.query.since_id as string) : undefined;
       const limit = req.query.limit ? parseInt(req.query.limit as string) : 100;
       const search = req.query.search as string | undefined;
-      const entries = ctx.devToolsManager.getConsoleEntries({ level, sinceId, limit, search });
-      const counts = ctx.devToolsManager.getConsoleCounts();
-      res.json({ entries, counts, total: entries.length });
+      const tabId = target.tab?.id;
+      const entries = tabId
+        ? ctx.devToolsManager.getConsoleEntries({ level, sinceId, limit, search, tabId })
+        : [];
+      const counts = tabId
+        ? ctx.devToolsManager.getConsoleCounts(tabId)
+        : { log: 0, info: 0, warn: 0, error: 0, debug: 0 };
+      res.json({ scope: buildTabScope(target), entries, counts, total: entries.length });
     } catch (e) {
       handleRouteError(res, e);
     }
@@ -44,23 +124,44 @@ export function registerDevtoolsRoutes(router: Router, ctx: RouteContext): void 
   /** Console errors only (convenience) */
   router.get('/devtools/console/errors', (req: Request, res: Response) => {
     try {
+      const target = resolveEffectiveTabTarget(ctx, req, { allowQuery: true });
+      if (target.requestedTabId && !target.tab) {
+        sendRequestedTabNotFound(res, target.requestedTabId);
+        return;
+      }
       const limit = req.query.limit ? parseInt(req.query.limit as string) : 50;
-      const errors = ctx.devToolsManager.getConsoleErrors(limit);
-      res.json({ errors, total: errors.length });
+      const errors = target.tab
+        ? ctx.devToolsManager.getConsoleErrors(limit, target.tab.id)
+        : [];
+      res.json({ scope: buildTabScope(target), errors, total: errors.length });
     } catch (e) {
       handleRouteError(res, e);
     }
   });
 
   /** Clear console log buffer */
-  router.post('/devtools/console/clear', (_req: Request, res: Response) => {
-    ctx.devToolsManager.clearConsole();
-    res.json({ ok: true });
+  router.post('/devtools/console/clear', (req: Request, res: Response) => {
+    const target = resolveEffectiveTabTarget(ctx, req, { allowBody: true, allowQuery: true });
+    if (target.requestedTabId && !target.tab) {
+      sendRequestedTabNotFound(res, target.requestedTabId);
+      return;
+    }
+    if (!target.tab) {
+      res.status(404).json({ error: 'No active tab' });
+      return;
+    }
+    ctx.devToolsManager.clearConsole(target.tab.id);
+    res.json({ ok: true, scope: buildTabScope(target) });
   });
 
   /** Network entries (CDP-level, with headers and POST bodies) */
   router.get('/devtools/network', (req: Request, res: Response) => {
     try {
+      const target = resolveEffectiveTabTarget(ctx, req, { allowQuery: true });
+      if (target.requestedTabId && !target.tab) {
+        sendRequestedTabNotFound(res, target.requestedTabId);
+        return;
+      }
       const limit = req.query.limit ? parseInt(req.query.limit as string) : 100;
       const domain = req.query.domain as string | undefined;
       const type = req.query.type as string | undefined;
@@ -68,8 +169,20 @@ export function registerDevtoolsRoutes(router: Router, ctx: RouteContext): void 
       const search = req.query.search as string | undefined;
       const statusMin = req.query.status_min ? parseInt(req.query.status_min as string) : undefined;
       const statusMax = req.query.status_max ? parseInt(req.query.status_max as string) : undefined;
-      const entries = ctx.devToolsManager.getNetworkEntries({ limit, domain, type, failed, search, statusMin, statusMax });
-      res.json({ entries, total: entries.length });
+      const entries = target.tab
+        ? ctx.devToolsManager.getNetworkEntries({
+            limit,
+            domain,
+            type,
+            failed,
+            search,
+            statusMin,
+            statusMax,
+            tabId: target.tab.id,
+            wcId: target.tab.webContentsId,
+          })
+        : [];
+      res.json({ scope: buildTabScope(target), entries, total: entries.length });
     } catch (e) {
       handleRouteError(res, e);
     }
@@ -78,30 +191,60 @@ export function registerDevtoolsRoutes(router: Router, ctx: RouteContext): void 
   /** Get response body for a specific network request */
   router.get('/devtools/network/:requestId/body', async (req: Request, res: Response) => {
     try {
-      const body = await ctx.devToolsManager.getResponseBody(req.params.requestId as string);
+      const target = resolveEffectiveTabTarget(ctx, req, { allowQuery: true });
+      if (target.requestedTabId && !target.tab) {
+        sendRequestedTabNotFound(res, target.requestedTabId);
+        return;
+      }
+      if (!target.tab) {
+        res.status(404).json({ error: 'No active tab' });
+        return;
+      }
+      const body = await ctx.devToolsManager.getResponseBody(req.params.requestId as string, {
+        tabId: target.tab.id,
+        wcId: target.tab.webContentsId,
+      });
       if (!body) {
         res.status(404).json({ error: 'Response body not available (evicted or streamed)' });
         return;
       }
-      res.json(body);
+      res.json({ ...body, requestId: req.params.requestId, scope: buildTabScope(target) });
     } catch (e) {
       handleRouteError(res, e);
     }
   });
 
   /** Clear network log */
-  router.post('/devtools/network/clear', (_req: Request, res: Response) => {
-    ctx.devToolsManager.clearNetwork();
-    res.json({ ok: true });
+  router.post('/devtools/network/clear', (req: Request, res: Response) => {
+    const target = resolveEffectiveTabTarget(ctx, req, { allowBody: true, allowQuery: true });
+    if (target.requestedTabId && !target.tab) {
+      sendRequestedTabNotFound(res, target.requestedTabId);
+      return;
+    }
+    if (!target.tab) {
+      res.status(404).json({ error: 'No active tab' });
+      return;
+    }
+    ctx.devToolsManager.clearNetwork(target.tab.id);
+    res.json({ ok: true, scope: buildTabScope(target) });
   });
 
   /** Query DOM by CSS selector */
   router.post('/devtools/dom/query', async (req: Request, res: Response) => {
     try {
+      const target = resolveEffectiveTabTarget(ctx, req, { allowBody: true, allowQuery: true });
+      if (target.requestedTabId && !target.tab) {
+        sendRequestedTabNotFound(res, target.requestedTabId);
+        return;
+      }
       const { selector, maxResults = 10 } = req.body;
       if (!selector) { res.status(400).json({ error: 'selector required' }); return; }
-      const nodes = await ctx.devToolsManager.queryDOM(selector, maxResults);
-      res.json({ nodes, total: nodes.length });
+      if (!target.tab) {
+        res.status(404).json({ error: 'No active tab' });
+        return;
+      }
+      const nodes = await ctx.devToolsManager.queryDOM(selector, maxResults, target.tab.webContentsId);
+      res.json({ scope: buildTabScope(target), nodes, total: nodes.length });
     } catch (e) {
       handleRouteError(res, e);
     }
@@ -110,34 +253,61 @@ export function registerDevtoolsRoutes(router: Router, ctx: RouteContext): void 
   /** Query DOM by XPath */
   router.post('/devtools/dom/xpath', async (req: Request, res: Response) => {
     try {
+      const target = resolveEffectiveTabTarget(ctx, req, { allowBody: true, allowQuery: true });
+      if (target.requestedTabId && !target.tab) {
+        sendRequestedTabNotFound(res, target.requestedTabId);
+        return;
+      }
       const { expression, maxResults = 10 } = req.body;
       if (!expression) { res.status(400).json({ error: 'expression required' }); return; }
-      const nodes = await ctx.devToolsManager.queryXPath(expression, maxResults);
-      res.json({ nodes, total: nodes.length });
+      if (!target.tab) {
+        res.status(404).json({ error: 'No active tab' });
+        return;
+      }
+      const nodes = await ctx.devToolsManager.queryXPath(expression, maxResults, target.tab.webContentsId);
+      res.json({ scope: buildTabScope(target), nodes, total: nodes.length });
     } catch (e) {
       handleRouteError(res, e);
     }
   });
 
   /** Get storage (cookies, localStorage, sessionStorage) */
-  router.get('/devtools/storage', async (_req: Request, res: Response) => {
+  router.get('/devtools/storage', async (req: Request, res: Response) => {
     try {
-      const data = await ctx.devToolsManager.getStorage();
-      res.json(data);
+      const target = resolveEffectiveTabTarget(ctx, req, { allowQuery: true });
+      if (target.requestedTabId && !target.tab) {
+        sendRequestedTabNotFound(res, target.requestedTabId);
+        return;
+      }
+      if (!target.tab) {
+        res.status(404).json({ error: 'No active tab' });
+        return;
+      }
+      const data = await ctx.devToolsManager.getStorage(target.tab.webContentsId);
+      res.json({ ...data, scope: buildTabScope(target) });
     } catch (e) {
       handleRouteError(res, e);
     }
   });
 
   /** Get performance metrics */
-  router.get('/devtools/performance', async (_req: Request, res: Response) => {
+  router.get('/devtools/performance', async (req: Request, res: Response) => {
     try {
-      const metrics = await ctx.devToolsManager.getPerformanceMetrics();
-      if (!metrics) {
-        res.status(503).json({ error: 'No active tab or CDP not attached' });
+      const target = resolveEffectiveTabTarget(ctx, req, { allowQuery: true });
+      if (target.requestedTabId && !target.tab) {
+        sendRequestedTabNotFound(res, target.requestedTabId);
         return;
       }
-      res.json(metrics);
+      if (!target.tab) {
+        res.status(404).json({ error: 'No active tab' });
+        return;
+      }
+      const metrics = await ctx.devToolsManager.getPerformanceMetrics(target.tab.webContentsId);
+      if (!metrics) {
+        res.status(503).json({ error: 'No targeted tab or CDP not attached' });
+        return;
+      }
+      res.json({ ...metrics, scope: buildTabScope(target) });
     } catch (e) {
       handleRouteError(res, e);
     }
@@ -146,9 +316,18 @@ export function registerDevtoolsRoutes(router: Router, ctx: RouteContext): void 
   /** Evaluate JavaScript via CDP Runtime */
   router.post('/devtools/evaluate', async (req: Request, res: Response) => {
     try {
+      const target = resolveEffectiveTabTarget(ctx, req, { allowBody: true, allowQuery: true });
+      if (target.requestedTabId && !target.tab) {
+        sendRequestedTabNotFound(res, target.requestedTabId);
+        return;
+      }
       let { expression } = req.body;
       const { returnByValue = true, awaitPromise = true } = req.body;
       if (!expression) { res.status(400).json({ error: 'expression required' }); return; }
+      if (!target.tab) {
+        res.status(404).json({ error: 'No active tab' });
+        return;
+      }
       if (expression.length > MAX_CODE_LENGTH) {
         res.status(413).json({ error: 'Expression too large (max 1MB)' });
         return;
@@ -167,10 +346,10 @@ export function registerDevtoolsRoutes(router: Router, ctx: RouteContext): void 
         setTimeout(() => reject(new Error('Execution timed out')), DEFAULT_TIMEOUT_MS)
       );
       const result = await Promise.race([
-        ctx.devToolsManager.evaluate(expression, { returnByValue, awaitPromise }),
+        ctx.devToolsManager.evaluateInTab(target.tab.webContentsId, expression, { returnByValue, awaitPromise }),
         timeout,
       ]);
-      res.json({ ok: true, result });
+      res.json({ ok: true, result, scope: buildTabScope(target) });
     } catch (e) {
       if (e instanceof Error && e.message === 'Execution timed out') {
         res.status(408).json({ error: `Execution timed out after ${DEFAULT_TIMEOUT_MS / 1000}s` });
@@ -183,10 +362,19 @@ export function registerDevtoolsRoutes(router: Router, ctx: RouteContext): void 
   /** Raw CDP command (advanced — send any CDP method) */
   router.post('/devtools/cdp', async (req: Request, res: Response) => {
     try {
+      const target = resolveEffectiveTabTarget(ctx, req, { allowBody: true, allowQuery: true });
+      if (target.requestedTabId && !target.tab) {
+        sendRequestedTabNotFound(res, target.requestedTabId);
+        return;
+      }
       const { method, params } = req.body;
       if (!method) { res.status(400).json({ error: 'method required' }); return; }
-      const result = await ctx.devToolsManager.sendCommand(method, params);
-      res.json({ ok: true, result });
+      if (!target.tab) {
+        res.status(404).json({ error: 'No active tab' });
+        return;
+      }
+      const result = await ctx.devToolsManager.sendCommandToTab(target.tab.webContentsId, method, params);
+      res.json({ ok: true, result, scope: buildTabScope(target) });
     } catch (e) {
       handleRouteError(res, e);
     }
@@ -195,9 +383,18 @@ export function registerDevtoolsRoutes(router: Router, ctx: RouteContext): void 
   /** Screenshot a specific element by CSS selector */
   router.post('/devtools/screenshot/element', async (req: Request, res: Response) => {
     try {
+      const target = resolveEffectiveTabTarget(ctx, req, { allowBody: true, allowQuery: true });
+      if (target.requestedTabId && !target.tab) {
+        sendRequestedTabNotFound(res, target.requestedTabId);
+        return;
+      }
       const { selector } = req.body;
       if (!selector) { res.status(400).json({ error: 'selector required' }); return; }
-      const png = await ctx.devToolsManager.screenshotElement(selector);
+      if (!target.tab) {
+        res.status(404).json({ error: 'No active tab' });
+        return;
+      }
+      const png = await ctx.devToolsManager.screenshotElement(selector, target.tab.webContentsId);
       if (!png) {
         res.status(404).json({ error: 'Element not found or screenshot failed' });
         return;

--- a/src/api/routes/network.ts
+++ b/src/api/routes/network.ts
@@ -1,6 +1,53 @@
 import type { Router, Request, Response } from 'express';
 import type { RouteContext } from '../context';
+import { resolveRequestedTab } from '../context';
+import type { Tab } from '../../tabs/manager';
 import { handleRouteError } from '../../utils/errors';
+
+interface EffectiveTabTarget {
+  requestedTabId: string | null;
+  tab: Tab | null;
+  source: 'header' | 'body' | 'query' | 'session' | 'active';
+}
+
+function sendRequestedTabNotFound(res: Response, tabId: string): void {
+  res.status(404).json({ error: `Tab ${tabId} not found` });
+}
+
+function resolveEffectiveTabTarget(
+  ctx: RouteContext,
+  req: Request,
+  opts?: { allowBody?: boolean; allowQuery?: boolean },
+): EffectiveTabTarget {
+  const requestedTab = resolveRequestedTab(ctx, req, opts);
+  if (requestedTab.requestedTabId) {
+    return {
+      requestedTabId: requestedTab.requestedTabId,
+      tab: requestedTab.tab,
+      source: requestedTab.source ?? 'header',
+    };
+  }
+
+  return {
+    requestedTabId: null,
+    tab: ctx.tabManager.getActiveTab(),
+    source: 'active',
+  };
+}
+
+function buildTabScope(target: EffectiveTabTarget): {
+  kind: 'tab';
+  tabId: string | null;
+  wcId: number | null;
+  source: EffectiveTabTarget['source'];
+} {
+  return {
+    kind: 'tab',
+    tabId: target.tab?.id ?? target.requestedTabId ?? null,
+    wcId: target.tab?.webContentsId ?? null,
+    source: target.source,
+  };
+}
 
 /**
  * Register network inspector and mock/intercept routes.
@@ -14,28 +61,50 @@ export function registerNetworkRoutes(router: Router, ctx: RouteContext): void {
 
   router.get('/network/log', (req: Request, res: Response) => {
     try {
+      const target = resolveEffectiveTabTarget(ctx, req, { allowQuery: true });
+      if (target.requestedTabId && !target.tab) {
+        sendRequestedTabNotFound(res, target.requestedTabId);
+        return;
+      }
       const limit = parseInt(req.query.limit as string) || 100;
       const domain = req.query.domain as string | undefined;
-      const entries = ctx.networkInspector.getLog(limit, domain);
-      res.json({ entries, count: entries.length });
+      const type = req.query.type as string | undefined;
+      const entries = target.tab
+        ? ctx.networkInspector.getLog({ limit, domain, type, tabId: target.tab.id, wcId: target.tab.webContentsId })
+        : [];
+      res.json({ scope: buildTabScope(target), entries, count: entries.length });
     } catch (e) {
       handleRouteError(res, e);
     }
   });
 
-  router.get('/network/apis', (_req: Request, res: Response) => {
+  router.get('/network/apis', (req: Request, res: Response) => {
     try {
-      const apis = ctx.networkInspector.getApis();
-      res.json({ apis });
+      const target = resolveEffectiveTabTarget(ctx, req, { allowQuery: true });
+      if (target.requestedTabId && !target.tab) {
+        sendRequestedTabNotFound(res, target.requestedTabId);
+        return;
+      }
+      const apis = target.tab
+        ? ctx.networkInspector.getApis({ tabId: target.tab.id, wcId: target.tab.webContentsId })
+        : {};
+      res.json({ scope: buildTabScope(target), apis });
     } catch (e) {
       handleRouteError(res, e);
     }
   });
 
-  router.get('/network/domains', (_req: Request, res: Response) => {
+  router.get('/network/domains', (req: Request, res: Response) => {
     try {
-      const domains = ctx.networkInspector.getDomains();
-      res.json({ domains });
+      const target = resolveEffectiveTabTarget(ctx, req, { allowQuery: true });
+      if (target.requestedTabId && !target.tab) {
+        sendRequestedTabNotFound(res, target.requestedTabId);
+        return;
+      }
+      const domains = target.tab
+        ? ctx.networkInspector.getDomains({ tabId: target.tab.id, wcId: target.tab.webContentsId })
+        : [];
+      res.json({ scope: buildTabScope(target), domains });
     } catch (e) {
       handleRouteError(res, e);
     }
@@ -43,23 +112,40 @@ export function registerNetworkRoutes(router: Router, ctx: RouteContext): void {
 
   router.get('/network/har', (req: Request, res: Response) => {
     try {
+      const target = resolveEffectiveTabTarget(ctx, req, { allowQuery: true });
+      if (target.requestedTabId && !target.tab) {
+        sendRequestedTabNotFound(res, target.requestedTabId);
+        return;
+      }
       const limit = parseInt(req.query.limit as string) || 100;
       const domain = req.query.domain as string | undefined;
-      const har = ctx.networkInspector.toHar(limit, domain);
+      const har = target.tab
+        ? ctx.networkInspector.toHar({ limit, domain, tabId: target.tab.id, wcId: target.tab.webContentsId })
+        : ctx.networkInspector.toHar({ limit: 0, domain });
       const stamp = new Date().toISOString().replace(/[:.]/g, '-');
       const suffix = domain ? `-${domain.replace(/[^a-zA-Z0-9.-]/g, '_')}` : '';
+      const tabSuffix = target.tab?.id ? `-tab-${target.tab.id.replace(/[^a-zA-Z0-9.-]/g, '_')}` : '-tab-none';
       res.setHeader('Content-Type', 'application/json; charset=utf-8');
-      res.setHeader('Content-Disposition', `attachment; filename="tandem-network${suffix}-${stamp}.har"`);
+      res.setHeader('Content-Disposition', `attachment; filename="tandem-network${tabSuffix}${suffix}-${stamp}.har"`);
       res.json(har);
     } catch (e) {
       handleRouteError(res, e);
     }
   });
 
-  router.delete('/network/clear', (_req: Request, res: Response) => {
+  router.delete('/network/clear', (req: Request, res: Response) => {
     try {
-      ctx.networkInspector.clear();
-      res.json({ ok: true });
+      const target = resolveEffectiveTabTarget(ctx, req, { allowBody: true, allowQuery: true });
+      if (target.requestedTabId && !target.tab) {
+        sendRequestedTabNotFound(res, target.requestedTabId);
+        return;
+      }
+      if (!target.tab) {
+        res.status(404).json({ error: 'No active tab' });
+        return;
+      }
+      ctx.networkInspector.clear(target.tab.id);
+      res.json({ ok: true, scope: buildTabScope(target) });
     } catch (e) {
       handleRouteError(res, e);
     }

--- a/src/api/tests/routes/devtools.test.ts
+++ b/src/api/tests/routes/devtools.test.ts
@@ -48,15 +48,23 @@ describe('Devtools Routes', () => {
   // ─── GET /devtools/status ──────────────────────────
 
   describe('GET /devtools/status', () => {
-    it('returns devtools status', async () => {
-      const status = { attached: true, tabId: 'tab-1' };
-      vi.mocked(ctx.devToolsManager.getStatus).mockReturnValue(status as any);
+    it('returns devtools status for the active tab with scope metadata', async () => {
+      const managerStatus = { attached: true, tabId: 'tab-2', wcId: 200, console: { entries: 4, errors: 1, lastId: 9 }, network: { entries: 7 } };
+      const scopedStatus = { attached: true, tabId: 'tab-1', wcId: 100, console: { entries: 2, errors: 1, lastId: 5 }, network: { entries: 3 } };
+      vi.mocked(ctx.devToolsManager.getStatus)
+        .mockReturnValueOnce(managerStatus as any)
+        .mockReturnValueOnce(scopedStatus as any);
 
       const res = await request(app).get('/devtools/status');
 
       expect(res.status).toBe(200);
-      expect(res.body).toEqual(status);
-      expect(ctx.devToolsManager.getStatus).toHaveBeenCalled();
+      expect(res.body).toEqual({
+        ...scopedStatus,
+        scope: { kind: 'tab', tabId: 'tab-1', wcId: 100, source: 'active' },
+        managerPrimary: { attached: true, tabId: 'tab-2', wcId: 200 },
+      });
+      expect(ctx.devToolsManager.getStatus).toHaveBeenNthCalledWith(1);
+      expect(ctx.devToolsManager.getStatus).toHaveBeenNthCalledWith(2, { tabId: 'tab-1', wcId: 100 });
     });
 
     it('returns 500 when getStatus throws', async () => {
@@ -83,6 +91,7 @@ describe('Devtools Routes', () => {
       const res = await request(app).get('/devtools/console');
 
       expect(res.status).toBe(200);
+      expect(res.body.scope).toEqual({ kind: 'tab', tabId: 'tab-1', wcId: 100, source: 'active' });
       expect(res.body.entries).toEqual(entries);
       expect(res.body.counts).toEqual(counts);
       expect(res.body.total).toBe(1);
@@ -91,7 +100,9 @@ describe('Devtools Routes', () => {
         sinceId: undefined,
         limit: 100,
         search: undefined,
+        tabId: 'tab-1',
       });
+      expect(ctx.devToolsManager.getConsoleCounts).toHaveBeenCalledWith('tab-1');
     });
 
     it('parses level, since_id, limit, and search query params', async () => {
@@ -108,7 +119,25 @@ describe('Devtools Routes', () => {
         sinceId: 5,
         limit: 20,
         search: 'foo',
+        tabId: 'tab-1',
       });
+    });
+
+    it('uses X-Tab-Id to scope console retrieval to a background tab', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([
+        { id: 'tab-2', webContentsId: 202, url: 'https://two.example', title: 'Two', active: false, source: 'wingman', partition: 'persist:tandem' } as any,
+      ]);
+      vi.mocked(ctx.devToolsManager.getConsoleEntries).mockReturnValue([] as any);
+      vi.mocked(ctx.devToolsManager.getConsoleCounts).mockReturnValue({} as any);
+
+      const res = await request(app)
+        .get('/devtools/console')
+        .set('X-Tab-Id', 'tab-2');
+
+      expect(res.status).toBe(200);
+      expect(res.body.scope).toEqual({ kind: 'tab', tabId: 'tab-2', wcId: 202, source: 'header' });
+      expect(ctx.devToolsManager.getConsoleEntries).toHaveBeenCalledWith(expect.objectContaining({ tabId: 'tab-2' }));
+      expect(ctx.devToolsManager.getConsoleCounts).toHaveBeenCalledWith('tab-2');
     });
   });
 
@@ -124,7 +153,8 @@ describe('Devtools Routes', () => {
       expect(res.status).toBe(200);
       expect(res.body.errors).toEqual(errors);
       expect(res.body.total).toBe(1);
-      expect(ctx.devToolsManager.getConsoleErrors).toHaveBeenCalledWith(50);
+      expect(res.body.scope).toEqual({ kind: 'tab', tabId: 'tab-1', wcId: 100, source: 'active' });
+      expect(ctx.devToolsManager.getConsoleErrors).toHaveBeenCalledWith(50, 'tab-1');
     });
 
     it('parses limit query param', async () => {
@@ -135,7 +165,7 @@ describe('Devtools Routes', () => {
         .query({ limit: '10' });
 
       expect(res.status).toBe(200);
-      expect(ctx.devToolsManager.getConsoleErrors).toHaveBeenCalledWith(10);
+      expect(ctx.devToolsManager.getConsoleErrors).toHaveBeenCalledWith(10, 'tab-1');
     });
   });
 
@@ -146,8 +176,11 @@ describe('Devtools Routes', () => {
       const res = await request(app).post('/devtools/console/clear');
 
       expect(res.status).toBe(200);
-      expect(res.body).toEqual({ ok: true });
-      expect(ctx.devToolsManager.clearConsole).toHaveBeenCalled();
+      expect(res.body).toEqual({
+        ok: true,
+        scope: { kind: 'tab', tabId: 'tab-1', wcId: 100, source: 'active' },
+      });
+      expect(ctx.devToolsManager.clearConsole).toHaveBeenCalledWith('tab-1');
     });
   });
 
@@ -161,6 +194,7 @@ describe('Devtools Routes', () => {
       const res = await request(app).get('/devtools/network');
 
       expect(res.status).toBe(200);
+      expect(res.body.scope).toEqual({ kind: 'tab', tabId: 'tab-1', wcId: 100, source: 'active' });
       expect(res.body.entries).toEqual(entries);
       expect(res.body.total).toBe(1);
       expect(ctx.devToolsManager.getNetworkEntries).toHaveBeenCalledWith({
@@ -171,6 +205,8 @@ describe('Devtools Routes', () => {
         search: undefined,
         statusMin: undefined,
         statusMax: undefined,
+        tabId: 'tab-1',
+        wcId: 100,
       });
     });
 
@@ -198,6 +234,8 @@ describe('Devtools Routes', () => {
         search: 'users',
         statusMin: 400,
         statusMax: 500,
+        tabId: 'tab-1',
+        wcId: 100,
       });
     });
 
@@ -207,7 +245,7 @@ describe('Devtools Routes', () => {
       await request(app).get('/devtools/network').query({ failed: 'false' });
 
       expect(ctx.devToolsManager.getNetworkEntries).toHaveBeenCalledWith(
-        expect.objectContaining({ failed: false }),
+        expect.objectContaining({ failed: false, tabId: 'tab-1', wcId: 100 }),
       );
     });
   });
@@ -222,8 +260,12 @@ describe('Devtools Routes', () => {
       const res = await request(app).get('/devtools/network/req-123/body');
 
       expect(res.status).toBe(200);
-      expect(res.body).toEqual(body);
-      expect(ctx.devToolsManager.getResponseBody).toHaveBeenCalledWith('req-123');
+      expect(res.body).toEqual({
+        ...body,
+        requestId: 'req-123',
+        scope: { kind: 'tab', tabId: 'tab-1', wcId: 100, source: 'active' },
+      });
+      expect(ctx.devToolsManager.getResponseBody).toHaveBeenCalledWith('req-123', { tabId: 'tab-1', wcId: 100 });
     });
 
     it('returns 404 when body is null', async () => {
@@ -243,8 +285,11 @@ describe('Devtools Routes', () => {
       const res = await request(app).post('/devtools/network/clear');
 
       expect(res.status).toBe(200);
-      expect(res.body).toEqual({ ok: true });
-      expect(ctx.devToolsManager.clearNetwork).toHaveBeenCalled();
+      expect(res.body).toEqual({
+        ok: true,
+        scope: { kind: 'tab', tabId: 'tab-1', wcId: 100, source: 'active' },
+      });
+      expect(ctx.devToolsManager.clearNetwork).toHaveBeenCalledWith('tab-1');
     });
   });
 
@@ -260,9 +305,10 @@ describe('Devtools Routes', () => {
         .send({ selector: '.main', maxResults: 5 });
 
       expect(res.status).toBe(200);
+      expect(res.body.scope).toEqual({ kind: 'tab', tabId: 'tab-1', wcId: 100, source: 'active' });
       expect(res.body.nodes).toEqual(nodes);
       expect(res.body.total).toBe(1);
-      expect(ctx.devToolsManager.queryDOM).toHaveBeenCalledWith('.main', 5);
+      expect(ctx.devToolsManager.queryDOM).toHaveBeenCalledWith('.main', 5, 100);
     });
 
     it('uses default maxResults of 10', async () => {
@@ -272,7 +318,7 @@ describe('Devtools Routes', () => {
         .post('/devtools/dom/query')
         .send({ selector: 'div' });
 
-      expect(ctx.devToolsManager.queryDOM).toHaveBeenCalledWith('div', 10);
+      expect(ctx.devToolsManager.queryDOM).toHaveBeenCalledWith('div', 10, 100);
     });
 
     it('returns 400 when selector is missing', async () => {
@@ -297,9 +343,10 @@ describe('Devtools Routes', () => {
         .send({ expression: '//div[@class="main"]', maxResults: 3 });
 
       expect(res.status).toBe(200);
+      expect(res.body.scope).toEqual({ kind: 'tab', tabId: 'tab-1', wcId: 100, source: 'active' });
       expect(res.body.nodes).toEqual(nodes);
       expect(res.body.total).toBe(1);
-      expect(ctx.devToolsManager.queryXPath).toHaveBeenCalledWith('//div[@class="main"]', 3);
+      expect(ctx.devToolsManager.queryXPath).toHaveBeenCalledWith('//div[@class="main"]', 3, 100);
     });
 
     it('uses default maxResults of 10', async () => {
@@ -309,7 +356,7 @@ describe('Devtools Routes', () => {
         .post('/devtools/dom/xpath')
         .send({ expression: '//h1' });
 
-      expect(ctx.devToolsManager.queryXPath).toHaveBeenCalledWith('//h1', 10);
+      expect(ctx.devToolsManager.queryXPath).toHaveBeenCalledWith('//h1', 10, 100);
     });
 
     it('returns 400 when expression is missing', async () => {
@@ -332,8 +379,11 @@ describe('Devtools Routes', () => {
       const res = await request(app).get('/devtools/storage');
 
       expect(res.status).toBe(200);
-      expect(res.body).toEqual(data);
-      expect(ctx.devToolsManager.getStorage).toHaveBeenCalled();
+      expect(res.body).toEqual({
+        ...data,
+        scope: { kind: 'tab', tabId: 'tab-1', wcId: 100, source: 'active' },
+      });
+      expect(ctx.devToolsManager.getStorage).toHaveBeenCalledWith(100);
     });
   });
 
@@ -347,7 +397,11 @@ describe('Devtools Routes', () => {
       const res = await request(app).get('/devtools/performance');
 
       expect(res.status).toBe(200);
-      expect(res.body).toEqual(metrics);
+      expect(res.body).toEqual({
+        ...metrics,
+        scope: { kind: 'tab', tabId: 'tab-1', wcId: 100, source: 'active' },
+      });
+      expect(ctx.devToolsManager.getPerformanceMetrics).toHaveBeenCalledWith(100);
     });
 
     it('returns 503 when metrics are null', async () => {
@@ -356,7 +410,7 @@ describe('Devtools Routes', () => {
       const res = await request(app).get('/devtools/performance');
 
       expect(res.status).toBe(503);
-      expect(res.body.error).toBe('No active tab or CDP not attached');
+      expect(res.body.error).toBe('No targeted tab or CDP not attached');
     });
   });
 
@@ -365,7 +419,7 @@ describe('Devtools Routes', () => {
   describe('POST /devtools/evaluate', () => {
     it('evaluates an expression with defaults', async () => {
       const result = { type: 'number', value: 42 };
-      vi.mocked(ctx.devToolsManager.evaluate).mockResolvedValue(result as any);
+      vi.mocked(ctx.devToolsManager.evaluateInTab).mockResolvedValue(result as any);
 
       const res = await request(app)
         .post('/devtools/evaluate')
@@ -374,20 +428,21 @@ describe('Devtools Routes', () => {
       expect(res.status).toBe(200);
       expect(res.body.ok).toBe(true);
       expect(res.body.result).toEqual(result);
-      expect(ctx.devToolsManager.evaluate).toHaveBeenCalledWith('1 + 1', {
+      expect(res.body.scope).toEqual({ kind: 'tab', tabId: 'tab-1', wcId: 100, source: 'active' });
+      expect(ctx.devToolsManager.evaluateInTab).toHaveBeenCalledWith(100, '1 + 1', {
         returnByValue: true,
         awaitPromise: true,
       });
     });
 
     it('passes returnByValue and awaitPromise options', async () => {
-      vi.mocked(ctx.devToolsManager.evaluate).mockResolvedValue({} as any);
+      vi.mocked(ctx.devToolsManager.evaluateInTab).mockResolvedValue({} as any);
 
       await request(app)
         .post('/devtools/evaluate')
         .send({ expression: 'document', returnByValue: false, awaitPromise: false });
 
-      expect(ctx.devToolsManager.evaluate).toHaveBeenCalledWith('document', {
+      expect(ctx.devToolsManager.evaluateInTab).toHaveBeenCalledWith(100, 'document', {
         returnByValue: false,
         awaitPromise: false,
       });
@@ -417,7 +472,7 @@ describe('Devtools Routes', () => {
 
     it('returns 408 when evaluation times out', async () => {
       // evaluate returns a promise that never resolves
-      vi.mocked(ctx.devToolsManager.evaluate).mockReturnValue(new Promise(() => {}) as any);
+      vi.mocked(ctx.devToolsManager.evaluateInTab).mockReturnValue(new Promise(() => {}) as any);
 
       const res = await request(app)
         .post('/devtools/evaluate')
@@ -429,7 +484,7 @@ describe('Devtools Routes', () => {
     });
 
     it('returns 500 when evaluate throws', async () => {
-      vi.mocked(ctx.devToolsManager.evaluate).mockRejectedValue(new Error('CDP disconnected'));
+      vi.mocked(ctx.devToolsManager.evaluateInTab).mockRejectedValue(new Error('CDP disconnected'));
 
       const res = await request(app)
         .post('/devtools/evaluate')
@@ -445,7 +500,7 @@ describe('Devtools Routes', () => {
   describe('POST /devtools/cdp', () => {
     it('sends a raw CDP command', async () => {
       const result = { nodes: [] };
-      vi.mocked(ctx.devToolsManager.sendCommand).mockResolvedValue(result as any);
+      vi.mocked(ctx.devToolsManager.sendCommandToTab).mockResolvedValue(result as any);
 
       const res = await request(app)
         .post('/devtools/cdp')
@@ -454,18 +509,19 @@ describe('Devtools Routes', () => {
       expect(res.status).toBe(200);
       expect(res.body.ok).toBe(true);
       expect(res.body.result).toEqual(result);
-      expect(ctx.devToolsManager.sendCommand).toHaveBeenCalledWith('DOM.getDocument', { depth: 1 });
+      expect(res.body.scope).toEqual({ kind: 'tab', tabId: 'tab-1', wcId: 100, source: 'active' });
+      expect(ctx.devToolsManager.sendCommandToTab).toHaveBeenCalledWith(100, 'DOM.getDocument', { depth: 1 });
     });
 
     it('sends a CDP command without params', async () => {
-      vi.mocked(ctx.devToolsManager.sendCommand).mockResolvedValue({} as any);
+      vi.mocked(ctx.devToolsManager.sendCommandToTab).mockResolvedValue({} as any);
 
       const res = await request(app)
         .post('/devtools/cdp')
         .send({ method: 'Page.reload' });
 
       expect(res.status).toBe(200);
-      expect(ctx.devToolsManager.sendCommand).toHaveBeenCalledWith('Page.reload', undefined);
+      expect(ctx.devToolsManager.sendCommandToTab).toHaveBeenCalledWith(100, 'Page.reload', undefined);
     });
 
     it('returns 400 when method is missing', async () => {
@@ -494,7 +550,7 @@ describe('Devtools Routes', () => {
       expect(res.headers['content-type']).toMatch(/image\/png/);
       expect(Buffer.isBuffer(res.body)).toBe(true);
       expect(res.body.toString()).toBe('fake-png-data');
-      expect(ctx.devToolsManager.screenshotElement).toHaveBeenCalledWith('#hero');
+      expect(ctx.devToolsManager.screenshotElement).toHaveBeenCalledWith('#hero', 100);
     });
 
     it('returns 400 when selector is missing', async () => {

--- a/src/api/tests/routes/network.test.ts
+++ b/src/api/tests/routes/network.test.ts
@@ -34,18 +34,31 @@ describe('Network Routes', () => {
       const res = await request(app).get('/network/log');
 
       expect(res.status).toBe(200);
+      expect(res.body.scope).toEqual({ kind: 'tab', tabId: 'tab-1', wcId: 100, source: 'active' });
       expect(res.body.entries).toEqual(fakeEntries);
       expect(res.body.count).toBe(1);
-      expect(ctx.networkInspector.getLog).toHaveBeenCalledWith(100, undefined);
+      expect(ctx.networkInspector.getLog).toHaveBeenCalledWith({
+        limit: 100,
+        domain: undefined,
+        type: undefined,
+        tabId: 'tab-1',
+        wcId: 100,
+      });
     });
 
-    it('parses limit and domain query params', async () => {
+    it('parses limit, domain, and type query params', async () => {
       vi.mocked(ctx.networkInspector.getLog).mockReturnValue([]);
 
-      const res = await request(app).get('/network/log?limit=50&domain=example.com');
+      const res = await request(app).get('/network/log?limit=50&domain=example.com&type=xhr');
 
       expect(res.status).toBe(200);
-      expect(ctx.networkInspector.getLog).toHaveBeenCalledWith(50, 'example.com');
+      expect(ctx.networkInspector.getLog).toHaveBeenCalledWith({
+        limit: 50,
+        domain: 'example.com',
+        type: 'xhr',
+        tabId: 'tab-1',
+        wcId: 100,
+      });
     });
 
     it('defaults limit to 100 when invalid', async () => {
@@ -54,7 +67,34 @@ describe('Network Routes', () => {
       const res = await request(app).get('/network/log?limit=abc');
 
       expect(res.status).toBe(200);
-      expect(ctx.networkInspector.getLog).toHaveBeenCalledWith(100, undefined);
+      expect(ctx.networkInspector.getLog).toHaveBeenCalledWith({
+        limit: 100,
+        domain: undefined,
+        type: undefined,
+        tabId: 'tab-1',
+        wcId: 100,
+      });
+    });
+
+    it('uses X-Tab-Id to target a background tab', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([
+        { id: 'tab-2', webContentsId: 202, url: 'https://two.example', title: 'Two', active: false, source: 'wingman', partition: 'persist:tandem' } as any,
+      ]);
+      vi.mocked(ctx.networkInspector.getLog).mockReturnValue([]);
+
+      const res = await request(app)
+        .get('/network/log')
+        .set('X-Tab-Id', 'tab-2');
+
+      expect(res.status).toBe(200);
+      expect(res.body.scope).toEqual({ kind: 'tab', tabId: 'tab-2', wcId: 202, source: 'header' });
+      expect(ctx.networkInspector.getLog).toHaveBeenCalledWith({
+        limit: 100,
+        domain: undefined,
+        type: undefined,
+        tabId: 'tab-2',
+        wcId: 202,
+      });
     });
 
     it('returns 500 when getLog throws', async () => {
@@ -77,7 +117,9 @@ describe('Network Routes', () => {
       const res = await request(app).get('/network/apis');
 
       expect(res.status).toBe(200);
+      expect(res.body.scope).toEqual({ kind: 'tab', tabId: 'tab-1', wcId: 100, source: 'active' });
       expect(res.body.apis).toEqual(fakeApis);
+      expect(ctx.networkInspector.getApis).toHaveBeenCalledWith({ tabId: 'tab-1', wcId: 100 });
     });
 
     it('returns 500 when getApis throws', async () => {
@@ -100,7 +142,9 @@ describe('Network Routes', () => {
       const res = await request(app).get('/network/domains');
 
       expect(res.status).toBe(200);
+      expect(res.body.scope).toEqual({ kind: 'tab', tabId: 'tab-1', wcId: 100, source: 'active' });
       expect(res.body.domains).toEqual(fakeDomains);
+      expect(ctx.networkInspector.getDomains).toHaveBeenCalledWith({ tabId: 'tab-1', wcId: 100 });
     });
 
     it('returns 500 when getDomains throws', async () => {
@@ -126,7 +170,13 @@ describe('Network Routes', () => {
       expect(res.body).toEqual(fakeHar);
       expect(res.headers['content-type']).toContain('application/json');
       expect(res.headers['content-disposition']).toContain('.har');
-      expect(ctx.networkInspector.toHar).toHaveBeenCalledWith(100, undefined);
+      expect(res.headers['content-disposition']).toContain('tab-tab-1');
+      expect(ctx.networkInspector.toHar).toHaveBeenCalledWith({
+        limit: 100,
+        domain: undefined,
+        tabId: 'tab-1',
+        wcId: 100,
+      });
     });
 
     it('parses limit and domain query params for har export', async () => {
@@ -135,7 +185,12 @@ describe('Network Routes', () => {
       const res = await request(app).get('/network/har?limit=25&domain=example.com');
 
       expect(res.status).toBe(200);
-      expect(ctx.networkInspector.toHar).toHaveBeenCalledWith(25, 'example.com');
+      expect(ctx.networkInspector.toHar).toHaveBeenCalledWith({
+        limit: 25,
+        domain: 'example.com',
+        tabId: 'tab-1',
+        wcId: 100,
+      });
       expect(res.headers['content-disposition']).toContain('example.com');
     });
 
@@ -156,8 +211,11 @@ describe('Network Routes', () => {
       const res = await request(app).delete('/network/clear');
 
       expect(res.status).toBe(200);
-      expect(res.body.ok).toBe(true);
-      expect(ctx.networkInspector.clear).toHaveBeenCalled();
+      expect(res.body).toEqual({
+        ok: true,
+        scope: { kind: 'tab', tabId: 'tab-1', wcId: 100, source: 'active' },
+      });
+      expect(ctx.networkInspector.clear).toHaveBeenCalledWith('tab-1');
     });
 
     it('returns 500 when clear throws', async () => {

--- a/src/bootstrap/runtime.ts
+++ b/src/bootstrap/runtime.ts
@@ -145,6 +145,9 @@ export async function initializeRuntimeManagers(opts: InitializeRuntimeOptions):
   runtime.contextBridge = new ContextBridge();
   runtime.pipManager = new PiPManager();
   runtime.networkInspector = new NetworkInspector();
+  runtime.networkInspector.setTabIdResolver((webContentsId) =>
+    runtime.tabManager.listTabs().find(tab => tab.webContentsId === webContentsId)?.id ?? null,
+  );
   if (dispatcher) {
     runtime.networkInspector.registerWith(dispatcher);
   }

--- a/src/devtools/console-capture.ts
+++ b/src/devtools/console-capture.ts
@@ -135,9 +135,16 @@ export class ConsoleCapture {
     }
   }
 
+  private filterEntries(tabId?: string): ConsoleEntry[] {
+    if (!tabId) {
+      return this.entries;
+    }
+    return this.entries.filter(entry => entry.tabId === tabId);
+  }
+
   /** Get entries, optionally filtered by level and/or since an ID */
-  getEntries(opts?: { level?: string; sinceId?: number; limit?: number; search?: string }): ConsoleEntry[] {
-    let result = this.entries;
+  getEntries(opts?: { level?: string; sinceId?: number; limit?: number; search?: string; tabId?: string }): ConsoleEntry[] {
+    let result = this.filterEntries(opts?.tabId);
     if (opts?.sinceId) result = result.filter(e => e.id > opts.sinceId!);
     if (opts?.level) result = result.filter(e => e.level === opts.level);
     if (opts?.search) {
@@ -149,21 +156,25 @@ export class ConsoleCapture {
   }
 
   /** Get only errors (convenience) */
-  getErrors(limit = 50): ConsoleEntry[] {
-    return this.getEntries({ level: 'error', limit });
+  getErrors(limit = 50, tabId?: string): ConsoleEntry[] {
+    return this.getEntries({ level: 'error', limit, tabId });
   }
 
   /** Get entry count by level */
-  getCounts(): Record<string, number> {
+  getCounts(tabId?: string): Record<string, number> {
     const counts: Record<string, number> = { log: 0, info: 0, warn: 0, error: 0, debug: 0 };
-    for (const e of this.entries) {
+    for (const e of this.filterEntries(tabId)) {
       counts[e.level] = (counts[e.level] || 0) + 1;
     }
     return counts;
   }
 
   /** Clear all entries */
-  clear(): void {
+  clear(tabId?: string): void {
+    if (tabId) {
+      this.entries = this.entries.filter(entry => entry.tabId !== tabId);
+      return;
+    }
     this.entries = [];
   }
 
@@ -181,7 +192,16 @@ export class ConsoleCapture {
     return this.entries.length;
   }
 
+  getEntryCount(tabId?: string): number {
+    return this.filterEntries(tabId).length;
+  }
+
   get lastEntryId(): number {
     return this.entries.length > 0 ? this.entries[this.entries.length - 1].id : 0;
+  }
+
+  getLastEntryId(tabId?: string): number {
+    const entries = this.filterEntries(tabId);
+    return entries.length > 0 ? entries[entries.length - 1].id : 0;
   }
 }

--- a/src/devtools/manager.ts
+++ b/src/devtools/manager.ts
@@ -67,8 +67,14 @@ export class DevToolsManager {
   constructor(tabManager: TabManager) {
     this.tabManager = tabManager;
     this.consoleCapture = new ConsoleCapture();
-    this.networkCapture = new NetworkCapture(() => this.ensureAttached());
-    this.pageInspector = new PageInspector(() => this.ensureAttached());
+    this.networkCapture = new NetworkCapture(
+      () => this.ensureAttached(),
+      (wcId) => this.attachToTab(wcId, { makePrimary: false }),
+    );
+    this.pageInspector = new PageInspector(
+      () => this.ensureAttached(),
+      (wcId) => this.attachToTab(wcId, { makePrimary: false }),
+    );
   }
 
   // === 3. Dependency setters ===
@@ -180,20 +186,20 @@ export class DevToolsManager {
 
   // ── Delegated: Console (→ ConsoleCapture) ──
 
-  getConsoleEntries(opts?: { level?: string; sinceId?: number; limit?: number; search?: string }): ConsoleEntry[] {
+  getConsoleEntries(opts?: { level?: string; sinceId?: number; limit?: number; search?: string; tabId?: string }): ConsoleEntry[] {
     return this.consoleCapture.getEntries(opts);
   }
 
-  getConsoleErrors(limit?: number): ConsoleEntry[] {
-    return this.consoleCapture.getErrors(limit);
+  getConsoleErrors(limit?: number, tabId?: string): ConsoleEntry[] {
+    return this.consoleCapture.getErrors(limit, tabId);
   }
 
-  getConsoleCounts(): Record<string, number> {
-    return this.consoleCapture.getCounts();
+  getConsoleCounts(tabId?: string): Record<string, number> {
+    return this.consoleCapture.getCounts(tabId);
   }
 
-  clearConsole(): void {
-    this.consoleCapture.clear();
+  clearConsole(tabId?: string): void {
+    this.consoleCapture.clear(tabId);
   }
 
   // ── Delegated: Network (→ NetworkCapture) ──
@@ -206,38 +212,43 @@ export class DevToolsManager {
     statusMax?: number;
     failed?: boolean;
     search?: string;
+    tabId?: string;
+    wcId?: number;
   }): CDPNetworkEntry[] {
     return this.networkCapture.getEntries(opts);
   }
 
-  async getResponseBody(requestId: string): Promise<{ body: string; base64Encoded: boolean } | null> {
-    return this.networkCapture.getResponseBody(requestId);
+  async getResponseBody(
+    requestId: string,
+    opts?: { tabId?: string; wcId?: number },
+  ): Promise<{ body: string; base64Encoded: boolean } | null> {
+    return this.networkCapture.getResponseBody(requestId, opts);
   }
 
-  clearNetwork(): void {
-    this.networkCapture.clear();
+  clearNetwork(tabId?: string): void {
+    this.networkCapture.clear(tabId);
   }
 
   // ── Delegated: Page Inspection (→ PageInspector) ──
 
-  async queryDOM(selector: string, maxResults = 10): Promise<DOMNodeInfo[]> {
-    return this.pageInspector.queryDOM(selector, maxResults);
+  async queryDOM(selector: string, maxResults = 10, wcId?: number): Promise<DOMNodeInfo[]> {
+    return this.pageInspector.queryDOM(selector, maxResults, wcId);
   }
 
-  async queryXPath(expression: string, maxResults = 10): Promise<DOMNodeInfo[]> {
-    return this.pageInspector.queryXPath(expression, maxResults);
+  async queryXPath(expression: string, maxResults = 10, wcId?: number): Promise<DOMNodeInfo[]> {
+    return this.pageInspector.queryXPath(expression, maxResults, wcId);
   }
 
-  async getStorage(): Promise<StorageData> {
-    return this.pageInspector.getStorage();
+  async getStorage(wcId?: number): Promise<StorageData> {
+    return this.pageInspector.getStorage(wcId);
   }
 
-  async getPerformanceMetrics(): Promise<PerformanceMetrics | null> {
-    return this.pageInspector.getPerformanceMetrics();
+  async getPerformanceMetrics(wcId?: number): Promise<PerformanceMetrics | null> {
+    return this.pageInspector.getPerformanceMetrics(wcId);
   }
 
-  async screenshotElement(selector: string): Promise<Buffer | null> {
-    return this.pageInspector.screenshotElement(selector);
+  async screenshotElement(selector: string, wcId?: number): Promise<Buffer | null> {
+    return this.pageInspector.screenshotElement(selector, wcId);
   }
 
   // ── Raw CDP ──
@@ -304,25 +315,30 @@ export class DevToolsManager {
 
   // ── Status ──
 
-  getStatus(): {
+  getStatus(target?: {
+    tabId?: string;
+    wcId?: number;
+  }): {
     attached: boolean;
     tabId: string | null;
     wcId: number | null;
     console: { entries: number; errors: number; lastId: number };
     network: { entries: number };
   } {
-    const tabId = this.primaryWcId ? this.findTabIdByWcId(this.primaryWcId) || null : null;
+    const scopedWcId = target?.wcId ?? (target?.tabId ? this.findWcIdByTabId(target.tabId) ?? null : null);
+    const wcId = target ? scopedWcId : this.primaryWcId;
+    const tabId = target?.tabId ?? (wcId ? this.findTabIdByWcId(wcId) || null : null);
     return {
-      attached: this.primaryWcId !== null,
+      attached: wcId !== null && this.attachedSessions.has(wcId),
       tabId,
-      wcId: this.primaryWcId,
+      wcId,
       console: {
-        entries: this.consoleCapture.entryCount,
-        errors: this.consoleCapture.getErrors().length,
-        lastId: this.consoleCapture.lastEntryId,
+        entries: this.consoleCapture.getEntryCount(tabId ?? undefined),
+        errors: this.consoleCapture.getErrors(Number.MAX_SAFE_INTEGER, tabId ?? undefined).length,
+        lastId: this.consoleCapture.getLastEntryId(tabId ?? undefined),
       },
       network: {
-        entries: this.networkCapture.entryCount,
+        entries: this.networkCapture.getEntryCount({ tabId: tabId ?? undefined, wcId: wcId ?? undefined }),
       },
     };
   }
@@ -507,7 +523,7 @@ export class DevToolsManager {
       }
 
       // Network events
-      this.networkCapture.handleEvent(method, params, tabId);
+      this.networkCapture.handleEvent(method, params, tabId, wcId);
 
       // Dispatch to subscribers (always — security modules need to see all events)
       for (const sub of this.subscribers) {
@@ -584,5 +600,9 @@ export class DevToolsManager {
   private findTabIdByWcId(wcId: number): string | undefined {
     const tabs = this.tabManager.listTabs();
     return tabs.find(t => t.webContentsId === wcId)?.id;
+  }
+
+  private findWcIdByTabId(tabId: string): number | undefined {
+    return this.tabManager.getTab(tabId)?.webContentsId;
   }
 }

--- a/src/devtools/network-capture.ts
+++ b/src/devtools/network-capture.ts
@@ -22,35 +22,60 @@ export class NetworkCapture {
   private networkEntries: Map<string, CDPNetworkEntry> = new Map();
   private networkOrder: string[] = []; // insertion order for ring buffer
   private ensureAttached: () => Promise<WebContents | null>;
+  private ensureAttachedToTab?: (wcId: number) => Promise<WebContents | null>;
 
-  constructor(ensureAttached: () => Promise<WebContents | null>) {
+  constructor(
+    ensureAttached: () => Promise<WebContents | null>,
+    ensureAttachedToTab?: (wcId: number) => Promise<WebContents | null>,
+  ) {
     this.ensureAttached = ensureAttached;
+    this.ensureAttachedToTab = ensureAttachedToTab;
   }
 
   /**
    * Handle a CDP network event. Called by DevToolsManager's message router.
    * Returns true if this capture handled the event.
    */
-  handleEvent(method: string, params: Record<string, unknown>, tabId?: string): boolean {
+  handleEvent(method: string, params: Record<string, unknown>, tabId?: string, wcId?: number): boolean {
     switch (method) {
       case 'Network.requestWillBeSent':
-        this.onNetworkRequest(params as unknown as CDPRequestWillBeSentParams, tabId);
+        this.onNetworkRequest(params as unknown as CDPRequestWillBeSentParams, tabId, wcId);
         return true;
       case 'Network.responseReceived':
-        this.onNetworkResponse(params as unknown as CDPResponseReceivedParams);
+        this.onNetworkResponse(params as unknown as CDPResponseReceivedParams, wcId);
         return true;
       case 'Network.loadingFinished':
-        this.onNetworkLoadingFinished(params as unknown as CDPLoadingFinishedParams);
+        this.onNetworkLoadingFinished(params as unknown as CDPLoadingFinishedParams, wcId);
         return true;
       case 'Network.loadingFailed':
-        this.onNetworkFailed(params as unknown as CDPLoadingFailedParams);
+        this.onNetworkFailed(params as unknown as CDPLoadingFailedParams, wcId);
         return true;
       default:
         return false;
     }
   }
 
-  private onNetworkRequest(params: CDPRequestWillBeSentParams, tabId?: string): void {
+  private buildRequestKey(requestId: string, wcId?: number): string {
+    return `${wcId ?? 'active'}:${requestId}`;
+  }
+
+  private removeEntry(requestKey: string): void {
+    this.networkEntries.delete(requestKey);
+    this.networkOrder = this.networkOrder.filter(key => key !== requestKey);
+  }
+
+  private resolveEntries(requestId: string, opts?: { tabId?: string; wcId?: number }): CDPNetworkEntry[] {
+    let entries = Array.from(this.networkEntries.values()).filter(entry => entry.request.id === requestId);
+    if (opts?.wcId !== undefined) {
+      entries = entries.filter(entry => entry.request.wcId === opts.wcId);
+    }
+    if (opts?.tabId) {
+      entries = entries.filter(entry => entry.request.tabId === opts.tabId);
+    }
+    return entries;
+  }
+
+  private onNetworkRequest(params: CDPRequestWillBeSentParams, tabId?: string, wcId?: number): void {
     const req: CDPNetworkRequest = {
       id: params.requestId,
       url: params.request.url,
@@ -60,10 +85,12 @@ export class NetworkCapture {
       resourceType: params.type || 'Other',
       timestamp: Date.now(),
       tabId,
+      wcId,
     };
 
-    this.networkEntries.set(params.requestId, { request: req });
-    this.networkOrder.push(params.requestId);
+    const requestKey = this.buildRequestKey(params.requestId, wcId);
+    this.networkEntries.set(requestKey, { request: req });
+    this.networkOrder.push(requestKey);
 
     // Ring buffer
     while (this.networkOrder.length > MAX_NETWORK_ENTRIES) {
@@ -72,8 +99,8 @@ export class NetworkCapture {
     }
   }
 
-  private onNetworkResponse(params: CDPResponseReceivedParams): void {
-    const entry = this.networkEntries.get(params.requestId);
+  private onNetworkResponse(params: CDPResponseReceivedParams, wcId?: number): void {
+    const entry = this.networkEntries.get(this.buildRequestKey(params.requestId, wcId));
     if (!entry) return;
 
     entry.response = {
@@ -92,15 +119,15 @@ export class NetworkCapture {
     }
   }
 
-  private onNetworkLoadingFinished(params: CDPLoadingFinishedParams): void {
-    const entry = this.networkEntries.get(params.requestId);
+  private onNetworkLoadingFinished(params: CDPLoadingFinishedParams, wcId?: number): void {
+    const entry = this.networkEntries.get(this.buildRequestKey(params.requestId, wcId));
     if (entry?.response) {
       entry.response.size = params.encodedDataLength || entry.response.size;
     }
   }
 
-  private onNetworkFailed(params: CDPLoadingFailedParams): void {
-    const entry = this.networkEntries.get(params.requestId);
+  private onNetworkFailed(params: CDPLoadingFailedParams, wcId?: number): void {
+    const entry = this.networkEntries.get(this.buildRequestKey(params.requestId, wcId));
     if (entry) {
       entry.failed = true;
       entry.errorText = params.errorText || 'Unknown error';
@@ -116,8 +143,17 @@ export class NetworkCapture {
     statusMax?: number;
     failed?: boolean;
     search?: string;
+    tabId?: string;
+    wcId?: number;
   }): CDPNetworkEntry[] {
     let entries = Array.from(this.networkEntries.values());
+
+    if (opts?.wcId !== undefined) {
+      entries = entries.filter(e => e.request.wcId === opts.wcId);
+    }
+    if (opts?.tabId) {
+      entries = entries.filter(e => e.request.tabId === opts.tabId);
+    }
 
     if (opts?.domain) {
       const d = opts.domain.toLowerCase();
@@ -148,8 +184,22 @@ export class NetworkCapture {
   }
 
   /** Get response body for a specific request (fetches from CDP on demand) */
-  async getResponseBody(requestId: string): Promise<{ body: string; base64Encoded: boolean } | null> {
-    const wc = await this.ensureAttached();
+  async getResponseBody(
+    requestId: string,
+    opts?: { tabId?: string; wcId?: number },
+  ): Promise<{ body: string; base64Encoded: boolean } | null> {
+    const matches = this.resolveEntries(requestId, opts);
+    if (matches.length === 0) {
+      return null;
+    }
+    if (matches.length > 1 && !opts?.tabId && opts?.wcId === undefined) {
+      return null;
+    }
+
+    const targetEntry = matches[matches.length - 1];
+    const wc = targetEntry.request.wcId !== undefined && this.ensureAttachedToTab
+      ? await this.ensureAttachedToTab(targetEntry.request.wcId)
+      : await this.ensureAttached();
     if (!wc) return null;
 
     try {
@@ -168,12 +218,24 @@ export class NetworkCapture {
     }
   }
 
-  clear(): void {
+  clear(tabId?: string): void {
+    if (tabId) {
+      for (const [requestKey, entry] of Array.from(this.networkEntries.entries())) {
+        if (entry.request.tabId === tabId) {
+          this.removeEntry(requestKey);
+        }
+      }
+      return;
+    }
     this.networkEntries.clear();
     this.networkOrder = [];
   }
 
   get entryCount(): number {
     return this.networkEntries.size;
+  }
+
+  getEntryCount(opts?: { tabId?: string; wcId?: number }): number {
+    return this.getEntries({ ...opts, limit: Number.MAX_SAFE_INTEGER }).length;
   }
 }

--- a/src/devtools/page-inspector.ts
+++ b/src/devtools/page-inspector.ts
@@ -16,16 +16,28 @@ const log = createLogger('CDP:Inspector');
  */
 export class PageInspector {
   private ensureAttached: () => Promise<WebContents | null>;
+  private ensureAttachedToTab?: (wcId: number) => Promise<WebContents | null>;
 
-  constructor(ensureAttached: () => Promise<WebContents | null>) {
+  constructor(
+    ensureAttached: () => Promise<WebContents | null>,
+    ensureAttachedToTab?: (wcId: number) => Promise<WebContents | null>,
+  ) {
     this.ensureAttached = ensureAttached;
+    this.ensureAttachedToTab = ensureAttachedToTab;
+  }
+
+  private async getTargetWebContents(wcId?: number): Promise<WebContents | null> {
+    if (wcId !== undefined && this.ensureAttachedToTab) {
+      return this.ensureAttachedToTab(wcId);
+    }
+    return this.ensureAttached();
   }
 
   // ═══ DOM ═══
 
   /** Query DOM by CSS selector, return matching nodes */
-  async queryDOM(selector: string, maxResults = 10): Promise<DOMNodeInfo[]> {
-    const wc = await this.ensureAttached();
+  async queryDOM(selector: string, maxResults = 10, wcId?: number): Promise<DOMNodeInfo[]> {
+    const wc = await this.getTargetWebContents(wcId);
     if (!wc) return [];
 
     try {
@@ -48,8 +60,8 @@ export class PageInspector {
   }
 
   /** Query DOM by XPath */
-  async queryXPath(expression: string, maxResults = 10): Promise<DOMNodeInfo[]> {
-    const wc = await this.ensureAttached();
+  async queryXPath(expression: string, maxResults = 10, wcId?: number): Promise<DOMNodeInfo[]> {
+    const wc = await this.getTargetWebContents(wcId);
     if (!wc) return [];
 
     try {
@@ -163,8 +175,8 @@ export class PageInspector {
   // ═══ Storage ═══
 
   /** Get cookies, localStorage, sessionStorage for current page */
-  async getStorage(): Promise<StorageData> {
-    const wc = await this.ensureAttached();
+  async getStorage(wcId?: number): Promise<StorageData> {
+    const wc = await this.getTargetWebContents(wcId);
     const empty: StorageData = { cookies: [], localStorage: {}, sessionStorage: {} };
     if (!wc) return empty;
 
@@ -219,8 +231,8 @@ export class PageInspector {
 
   // ═══ Performance ═══
 
-  async getPerformanceMetrics(): Promise<PerformanceMetrics | null> {
-    const wc = await this.ensureAttached();
+  async getPerformanceMetrics(wcId?: number): Promise<PerformanceMetrics | null> {
+    const wc = await this.getTargetWebContents(wcId);
     if (!wc) return null;
 
     try {
@@ -239,8 +251,8 @@ export class PageInspector {
 
   // ═══ Element Screenshot ═══
 
-  async screenshotElement(selector: string): Promise<Buffer | null> {
-    const wc = await this.ensureAttached();
+  async screenshotElement(selector: string, wcId?: number): Promise<Buffer | null> {
+    const wc = await this.getTargetWebContents(wcId);
     if (!wc) return null;
 
     try {

--- a/src/devtools/tests/captures.test.ts
+++ b/src/devtools/tests/captures.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ConsoleCapture } from '../console-capture';
+import { NetworkCapture } from '../network-capture';
+
+describe('DevTools captures', () => {
+  it('filters console entries by tabId', () => {
+    const capture = new ConsoleCapture();
+
+    capture.handleEvent('Runtime.consoleAPICalled', {
+      type: 'log',
+      args: [{ type: 'string', value: 'alpha' }],
+      executionContextId: 1,
+      timestamp: 1,
+    }, 'tab-1');
+    capture.handleEvent('Runtime.consoleAPICalled', {
+      type: 'error',
+      args: [{ type: 'string', value: 'beta' }],
+      executionContextId: 1,
+      timestamp: 2,
+    }, 'tab-2');
+
+    expect(capture.getEntries({ tabId: 'tab-1' })).toEqual([
+      expect.objectContaining({ text: 'alpha', tabId: 'tab-1' }),
+    ]);
+    expect(capture.getErrors(50, 'tab-2')).toEqual([
+      expect.objectContaining({ text: 'beta', tabId: 'tab-2' }),
+    ]);
+    expect(capture.getCounts('tab-1')).toEqual({ log: 1, info: 0, warn: 0, error: 0, debug: 0 });
+
+    capture.clear('tab-1');
+
+    expect(capture.getEntries({ tabId: 'tab-1' })).toEqual([]);
+    expect(capture.getEntries({ tabId: 'tab-2' })).toHaveLength(1);
+  });
+
+  it('keeps duplicate requestIds separate across tabs and resolves response bodies by tab', async () => {
+    const sendCommandOne = vi.fn().mockResolvedValue({ body: 'one', base64Encoded: false });
+    const sendCommandTwo = vi.fn().mockResolvedValue({ body: 'two', base64Encoded: false });
+    const wcOne = { debugger: { sendCommand: sendCommandOne } };
+    const wcTwo = { debugger: { sendCommand: sendCommandTwo } };
+    const capture = new NetworkCapture(
+      async () => wcOne as never,
+      async (wcId) => (wcId === 101 ? wcOne : wcTwo) as never,
+    );
+
+    capture.handleEvent('Network.requestWillBeSent', {
+      requestId: 'req-1',
+      request: { url: 'https://one.example/api', method: 'GET', headers: {} },
+      type: 'XHR',
+      timestamp: 1,
+    }, 'tab-1', 101);
+    capture.handleEvent('Network.requestWillBeSent', {
+      requestId: 'req-1',
+      request: { url: 'https://two.example/api', method: 'GET', headers: {} },
+      type: 'XHR',
+      timestamp: 2,
+    }, 'tab-2', 202);
+    capture.handleEvent('Network.responseReceived', {
+      requestId: 'req-1',
+      response: { url: 'https://one.example/api', status: 200, statusText: 'OK', headers: {}, mimeType: 'application/json' },
+      timestamp: 3,
+    }, undefined, 101);
+    capture.handleEvent('Network.responseReceived', {
+      requestId: 'req-1',
+      response: { url: 'https://two.example/api', status: 200, statusText: 'OK', headers: {}, mimeType: 'application/json' },
+      timestamp: 4,
+    }, undefined, 202);
+
+    expect(capture.getEntries({ tabId: 'tab-1' })).toEqual([
+      expect.objectContaining({ request: expect.objectContaining({ url: 'https://one.example/api', tabId: 'tab-1', wcId: 101 }) }),
+    ]);
+    expect(capture.getEntries({ tabId: 'tab-2' })).toEqual([
+      expect.objectContaining({ request: expect.objectContaining({ url: 'https://two.example/api', tabId: 'tab-2', wcId: 202 }) }),
+    ]);
+
+    await expect(capture.getResponseBody('req-1', { tabId: 'tab-2', wcId: 202 })).resolves.toEqual({
+      body: 'two',
+      base64Encoded: false,
+    });
+    expect(sendCommandOne).not.toHaveBeenCalled();
+    expect(sendCommandTwo).toHaveBeenCalledWith('Network.getResponseBody', { requestId: 'req-1' });
+  });
+});

--- a/src/devtools/types.ts
+++ b/src/devtools/types.ts
@@ -26,6 +26,7 @@ export interface CDPNetworkRequest {
   resourceType: string; // Document, Script, XHR, Fetch, etc.
   timestamp: number;
   tabId?: string;
+  wcId?: number;
 }
 
 /**

--- a/src/mcp/tests/devtools.test.ts
+++ b/src/mcp/tests/devtools.test.ts
@@ -77,7 +77,7 @@ describe('MCP devtools tools', () => {
       mockApiCall.mockResolvedValueOnce({ ok: true });
       const result = await handler({});
       expectTextContent(result);
-      expect(mockApiCall).toHaveBeenCalledWith('POST', '/devtools/console/clear');
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/devtools/console/clear', undefined, undefined);
     });
   });
 
@@ -158,9 +158,12 @@ describe('MCP devtools tools', () => {
 
       const result = await handler({ method: 'Page.reload', params: { ignoreCache: true } });
       expectTextContent(result);
-      expect(mockApiCall).toHaveBeenCalledWith('POST', '/devtools/cdp', {
-        method: 'Page.reload', params: { ignoreCache: true },
-      });
+      expect(mockApiCall).toHaveBeenCalledWith(
+        'POST',
+        '/devtools/cdp',
+        { method: 'Page.reload', params: { ignoreCache: true } },
+        undefined,
+      );
     });
   });
 
@@ -172,6 +175,7 @@ describe('MCP devtools tools', () => {
       mockApiCall.mockResolvedValueOnce({ connected: true });
       const result = await handler({});
       expectTextContent(result);
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/devtools/status', undefined, undefined);
     });
   });
 
@@ -184,6 +188,37 @@ describe('MCP devtools tools', () => {
       const result = await handler({});
       expectTextContent(result);
       expect(mockApiCall).toHaveBeenCalledWith('POST', '/devtools/toggle');
+    });
+  });
+
+  describe('tab-aware forwarding', () => {
+    it('forwards tabId for network body lookups', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      const handler = getHandler(tools, 'tandem_devtools_network_body');
+
+      await handler({ requestId: 'req-1', tabId: 'tab-7' });
+
+      expect(vi.mocked(tabHeaders)).toHaveBeenCalledWith('tab-7');
+      expect(mockApiCall).toHaveBeenCalledWith(
+        'GET',
+        '/devtools/network/req-1/body',
+        undefined,
+        { 'X-Tab-Id': 'tab-7' },
+      );
+    });
+
+    it('forwards tabId for status and raw CDP calls', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockApiCall.mockResolvedValueOnce({});
+      const statusHandler = getHandler(tools, 'tandem_devtools_status');
+      const cdpHandler = getHandler(tools, 'tandem_devtools_cdp');
+
+      await statusHandler({ tabId: 'tab-8' });
+      await cdpHandler({ method: 'Page.reload', tabId: 'tab-8' });
+
+      expect(vi.mocked(tabHeaders)).toHaveBeenCalledWith('tab-8');
+      expect(mockApiCall).toHaveBeenNthCalledWith(1, 'GET', '/devtools/status', undefined, { 'X-Tab-Id': 'tab-8' });
+      expect(mockApiCall).toHaveBeenNthCalledWith(2, 'POST', '/devtools/cdp', { method: 'Page.reload', params: undefined }, { 'X-Tab-Id': 'tab-8' });
     });
   });
 });

--- a/src/mcp/tests/network.test.ts
+++ b/src/mcp/tests/network.test.ts
@@ -63,7 +63,7 @@ describe('MCP network tools', () => {
 
       const result = await handler({});
       expectTextContent(result);
-      expect(mockApiCall).toHaveBeenCalledWith('GET', '/network/apis');
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/network/apis', undefined, undefined);
     });
   });
 
@@ -75,6 +75,7 @@ describe('MCP network tools', () => {
       mockApiCall.mockResolvedValueOnce({ domains: { 'api.com': 15 } });
       const result = await handler({});
       expectTextContent(result);
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/network/domains', undefined, undefined);
     });
   });
 
@@ -131,7 +132,7 @@ describe('MCP network tools', () => {
 
       const result = await handler({});
       expectTextContent(result);
-      expect(mockApiCall).toHaveBeenCalledWith('DELETE', '/network/clear');
+      expect(mockApiCall).toHaveBeenCalledWith('DELETE', '/network/clear', undefined, undefined);
     });
   });
 
@@ -154,6 +155,26 @@ describe('MCP network tools', () => {
       mockApiCall.mockRejectedValueOnce(new Error('server error'));
       const handler = getHandler(tools, 'tandem_network_har');
       await expect(handler({})).rejects.toThrow('server error');
+    });
+  });
+
+  describe('tab-aware forwarding', () => {
+    it('passes tabId to apis, domains, har, and clear', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      mockApiCall.mockResolvedValueOnce({});
+      mockApiCall.mockResolvedValueOnce({});
+      mockApiCall.mockResolvedValueOnce({});
+
+      await getHandler(tools, 'tandem_network_apis')({ tabId: 'tab-9' });
+      await getHandler(tools, 'tandem_network_domains')({ tabId: 'tab-9' });
+      await getHandler(tools, 'tandem_network_har')({ tabId: 'tab-9' });
+      await getHandler(tools, 'tandem_network_clear')({ tabId: 'tab-9' });
+
+      expect(vi.mocked(tabHeaders)).toHaveBeenCalledWith('tab-9');
+      expect(mockApiCall).toHaveBeenNthCalledWith(1, 'GET', '/network/apis', undefined, { 'X-Tab-Id': 'tab-9' });
+      expect(mockApiCall).toHaveBeenNthCalledWith(2, 'GET', '/network/domains', undefined, { 'X-Tab-Id': 'tab-9' });
+      expect(mockApiCall).toHaveBeenNthCalledWith(3, 'GET', '/network/har', undefined, { 'X-Tab-Id': 'tab-9' });
+      expect(mockApiCall).toHaveBeenNthCalledWith(4, 'DELETE', '/network/clear', undefined, { 'X-Tab-Id': 'tab-9' });
     });
   });
 });

--- a/src/mcp/tools/devtools.ts
+++ b/src/mcp/tools/devtools.ts
@@ -6,7 +6,7 @@ import { coerceShape } from '../coerce.js';
 export function registerDevtoolsTools(server: McpServer): void {
   server.tool(
     'tandem_devtools_console',
-    'Get console log entries from the browser DevTools. Use to inspect logs, warnings, errors, and debug output from the page. Supports filtering by level (log, warn, error, info, debug) and searching message text. Supports targeting a background tab by ID.',
+    'Get console log entries for the active tab by default, or for a specific background tab when tabId is provided. Supports filtering by level (log, warn, error, info, debug) and searching message text.',
     coerceShape({
       level: z.string().optional().describe('Filter by log level: log, warn, error, info, debug'),
       search: z.string().optional().describe('Search string to filter messages'),
@@ -27,7 +27,7 @@ export function registerDevtoolsTools(server: McpServer): void {
 
   server.tool(
     'tandem_devtools_console_errors',
-    'Get only console errors from the browser DevTools. A quick way to check if the page has any JavaScript errors. Supports targeting a background tab by ID.',
+    'Get only console errors for the active tab by default, or for a specific background tab when tabId is provided.',
     coerceShape({
       limit: z.number().optional().describe('Maximum errors to return (default: 50)'),
       tabId: z.string().optional().describe('Optional tab ID to target a background tab instead of the active tab'),
@@ -44,16 +44,19 @@ export function registerDevtoolsTools(server: McpServer): void {
 
   server.tool(
     'tandem_devtools_console_clear',
-    'Clear the console log buffer in DevTools. Removes all captured console entries.',
-    async () => {
-      const data = await apiCall('POST', '/devtools/console/clear');
+    'Clear the DevTools console buffer for the active tab by default, or for a specific background tab when tabId is provided.',
+    {
+      tabId: z.string().optional().describe('Optional tab ID to clear a specific tab instead of the active tab'),
+    },
+    async ({ tabId }) => {
+      const data = await apiCall('POST', '/devtools/console/clear', undefined, tabHeaders(tabId));
       return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
     }
   );
 
   server.tool(
     'tandem_devtools_network',
-    'Get network request entries captured via CDP (Chrome DevTools Protocol). Includes full headers and POST bodies. Use to inspect API calls, failed requests, and resource loading. Supports targeting a background tab by ID.',
+    'Get CDP network request entries for the active tab by default, or for a specific background tab when tabId is provided. Includes full headers and POST bodies.',
     coerceShape({
       domain: z.string().optional().describe('Filter by domain (e.g. "api.example.com")'),
       type: z.string().optional().describe('Filter by resource type (e.g. "XHR", "Fetch", "Script")'),
@@ -76,28 +79,32 @@ export function registerDevtoolsTools(server: McpServer): void {
 
   server.tool(
     'tandem_devtools_network_body',
-    'Get the response body for a specific network request captured via CDP. Use requestId from tandem_devtools_network results.',
+    'Get the response body for a specific CDP network request from the active tab by default, or from a specific background tab when tabId is provided.',
     {
       requestId: z.string().describe('The request ID from DevTools network entries'),
+      tabId: z.string().optional().describe('Optional tab ID to target a specific tab for this request body lookup'),
     },
-    async ({ requestId }) => {
-      const data = await apiCall('GET', `/devtools/network/${encodeURIComponent(requestId)}/body`);
+    async ({ requestId, tabId }) => {
+      const data = await apiCall('GET', `/devtools/network/${encodeURIComponent(requestId)}/body`, undefined, tabHeaders(tabId));
       return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
     }
   );
 
   server.tool(
     'tandem_devtools_network_clear',
-    'Clear the DevTools network log buffer. Removes all captured network entries.',
-    async () => {
-      const data = await apiCall('POST', '/devtools/network/clear');
+    'Clear the DevTools network log buffer for the active tab by default, or for a specific background tab when tabId is provided.',
+    {
+      tabId: z.string().optional().describe('Optional tab ID to clear a specific tab instead of the active tab'),
+    },
+    async ({ tabId }) => {
+      const data = await apiCall('POST', '/devtools/network/clear', undefined, tabHeaders(tabId));
       return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
     }
   );
 
   server.tool(
     'tandem_devtools_evaluate',
-    'Evaluate a JavaScript expression via CDP Runtime in the active tab. Returns the result. Use for inspecting page state, reading variables, or running diagnostic code. Supports targeting a background tab by ID. WARNING: This can modify page state.',
+    'Evaluate a JavaScript expression via CDP Runtime in the active tab by default, or in a specific background tab when tabId is provided. WARNING: This can modify page state.',
     {
       expression: z.string().describe('JavaScript expression to evaluate'),
       tabId: z.string().optional().describe('Optional tab ID to target a background tab instead of the active tab'),
@@ -115,7 +122,7 @@ export function registerDevtoolsTools(server: McpServer): void {
 
   server.tool(
     'tandem_devtools_dom_query',
-    'Query the DOM by CSS selector via CDP. Returns matching nodes with their attributes and text content. Use to inspect page structure without executing JavaScript. Supports targeting a background tab by ID.',
+    'Query the DOM by CSS selector via CDP for the active tab by default, or for a specific background tab when tabId is provided.',
     {
       selector: z.string().describe('CSS selector to query'),
       tabId: z.string().optional().describe('Optional tab ID to target a background tab instead of the active tab'),
@@ -128,7 +135,7 @@ export function registerDevtoolsTools(server: McpServer): void {
 
   server.tool(
     'tandem_devtools_dom_xpath',
-    'Query the DOM by XPath expression via CDP. Returns matching nodes with their attributes and text content. Supports targeting a background tab by ID.',
+    'Query the DOM by XPath expression via CDP for the active tab by default, or for a specific background tab when tabId is provided.',
     {
       expression: z.string().describe('XPath expression to evaluate'),
       tabId: z.string().optional().describe('Optional tab ID to target a background tab instead of the active tab'),
@@ -141,7 +148,7 @@ export function registerDevtoolsTools(server: McpServer): void {
 
   server.tool(
     'tandem_devtools_performance',
-    'Get performance metrics from the browser via CDP. Includes timing data like DOM content loaded, first paint, layout counts, and memory usage. Supports targeting a background tab by ID.',
+    'Get performance metrics for the active tab by default, or for a specific background tab when tabId is provided.',
     {
       tabId: z.string().optional().describe('Optional tab ID to target a background tab instead of the active tab'),
     },
@@ -153,7 +160,7 @@ export function registerDevtoolsTools(server: McpServer): void {
 
   server.tool(
     'tandem_devtools_storage',
-    'Get browser storage data (cookies, localStorage, sessionStorage) for the current page via CDP. Supports targeting a background tab by ID.',
+    'Get browser storage data (cookies, localStorage, sessionStorage) for the active tab by default, or for a specific background tab when tabId is provided.',
     {
       tabId: z.string().optional().describe('Optional tab ID to target a background tab instead of the active tab'),
     },
@@ -165,7 +172,7 @@ export function registerDevtoolsTools(server: McpServer): void {
 
   server.tool(
     'tandem_devtools_screenshot_element',
-    'Take a screenshot of a specific DOM element by CSS selector. Returns the screenshot as a PNG image. Supports targeting a background tab by ID.',
+    'Take a screenshot of a specific DOM element from the active tab by default, or from a specific background tab when tabId is provided.',
     {
       selector: z.string().describe('CSS selector of the element to screenshot'),
       tabId: z.string().optional().describe('Optional tab ID to target a background tab instead of the active tab'),
@@ -185,27 +192,31 @@ export function registerDevtoolsTools(server: McpServer): void {
 
   server.tool(
     'tandem_devtools_status',
-    'Get the current status of the DevTools manager. Shows whether DevTools is connected and available.',
-    async () => {
-      const data = await apiCall('GET', '/devtools/status');
+    'Get DevTools status for the active tab by default, or for a specific background tab when tabId is provided. The response also includes the manager primary target for comparison.',
+    {
+      tabId: z.string().optional().describe('Optional tab ID to target a specific tab instead of the active tab'),
+    },
+    async ({ tabId }) => {
+      const data = await apiCall('GET', '/devtools/status', undefined, tabHeaders(tabId));
       return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
     }
   );
 
   server.tool(
     'tandem_devtools_cdp',
-    'Send a raw Chrome DevTools Protocol (CDP) command. WARNING: This is a powerful low-level tool that can modify browser state.',
+    'Send a raw Chrome DevTools Protocol (CDP) command to the active tab by default, or to a specific background tab when tabId is provided. WARNING: This is a powerful low-level tool that can modify browser state.',
     {
       method: z.string().describe('CDP method name (e.g. "Page.reload", "DOM.getDocument")'),
       params: z.object({}).passthrough().optional().describe('Optional CDP method parameters'),
+      tabId: z.string().optional().describe('Optional tab ID to target a specific tab instead of the active tab'),
     },
     {
       destructiveHint: true,
       readOnlyHint: false,
       openWorldHint: true,
     },
-    async ({ method, params }) => {
-      const data = await apiCall('POST', '/devtools/cdp', { method, params });
+    async ({ method, params, tabId }) => {
+      const data = await apiCall('POST', '/devtools/cdp', { method, params }, tabHeaders(tabId));
       return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
     }
   );

--- a/src/mcp/tools/network.ts
+++ b/src/mcp/tools/network.ts
@@ -6,7 +6,7 @@ import { coerceShape } from '../coerce.js';
 export function registerNetworkTools(server: McpServer): void {
   server.tool(
     'tandem_network_log',
-    'Get the network request log captured via Electron webRequest API. Lighter-weight than DevTools network — shows URL, method, status, and timing for recent requests. Supports targeting a background tab by ID.',
+    'Get the webRequest-based network log for the active tab by default, or for a specific background tab when tabId is provided. Lighter-weight than DevTools network and useful for recent request inspection.',
     coerceShape({
       domain: z.string().optional().describe('Filter by domain'),
       type: z.string().optional().describe('Filter by resource type'),
@@ -27,27 +27,36 @@ export function registerNetworkTools(server: McpServer): void {
 
   server.tool(
     'tandem_network_apis',
-    'Get a summary of detected API endpoints from network traffic. Shows unique API paths grouped by domain, useful for understanding what services the page communicates with.',
-    async () => {
-      const data = await apiCall('GET', '/network/apis');
+    'Get a summary of detected API endpoints for the active tab by default, or for a specific background tab when tabId is provided.',
+    {
+      tabId: z.string().optional().describe('Optional tab ID to target a specific tab instead of the active tab'),
+    },
+    async ({ tabId }) => {
+      const data = await apiCall('GET', '/network/apis', undefined, tabHeaders(tabId));
       return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
     }
   );
 
   server.tool(
     'tandem_network_domains',
-    'Get a list of all domains that the page has made requests to, with request counts. Useful for understanding third-party dependencies and data flows.',
-    async () => {
-      const data = await apiCall('GET', '/network/domains');
+    'Get a list of request domains for the active tab by default, or for a specific background tab when tabId is provided.',
+    {
+      tabId: z.string().optional().describe('Optional tab ID to target a specific tab instead of the active tab'),
+    },
+    async ({ tabId }) => {
+      const data = await apiCall('GET', '/network/domains', undefined, tabHeaders(tabId));
       return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
     }
   );
 
   server.tool(
     'tandem_network_har',
-    'Export the network log as a HAR (HTTP Archive) file. Returns a full HAR 1.2 JSON object that can be imported into browser DevTools or other analysis tools.',
-    async () => {
-      const data = await apiCall('GET', '/network/har');
+    'Export the active tab network log as a HAR (HTTP Archive) by default, or export a specific background tab when tabId is provided.',
+    {
+      tabId: z.string().optional().describe('Optional tab ID to target a specific tab instead of the active tab'),
+    },
+    async ({ tabId }) => {
+      const data = await apiCall('GET', '/network/har', undefined, tabHeaders(tabId));
       return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
     }
   );
@@ -101,9 +110,12 @@ export function registerNetworkTools(server: McpServer): void {
 
   server.tool(
     'tandem_network_clear',
-    'Clear the network request log. Removes all captured webRequest-level network entries.',
-    async () => {
-      const data = await apiCall('DELETE', '/network/clear');
+    'Clear the webRequest-level network log for the active tab by default, or for a specific background tab when tabId is provided.',
+    {
+      tabId: z.string().optional().describe('Optional tab ID to clear a specific tab instead of the active tab'),
+    },
+    async ({ tabId }) => {
+      const data = await apiCall('DELETE', '/network/clear', undefined, tabHeaders(tabId));
       return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
     }
   );

--- a/src/network/inspector.ts
+++ b/src/network/inspector.ts
@@ -20,6 +20,9 @@ export interface NetworkRequest {
   initiator: string;
   domain: string;
   durationMs: number;
+  resourceType?: string;
+  tabId?: string;
+  wcId?: number;
   requestHeaders: Record<string, string>;
   responseHeaders: Record<string, string[]>;
 }
@@ -29,6 +32,14 @@ interface DomainData {
   requests: number;
   apis: string[];
   lastSeen: number;
+}
+
+interface NetworkQueryOptions {
+  limit?: number;
+  domain?: string;
+  type?: string;
+  tabId?: string;
+  wcId?: number;
 }
 
 interface HarHeader {
@@ -111,6 +122,7 @@ export class NetworkInspector {
   private maxRequests = 1000;
   private networkDir: string;
   private domainStats: Map<string, DomainData> = new Map();
+  private tabIdResolver?: (wcId: number) => string | null;
 
   // === 2. Constructor ===
   constructor() {
@@ -122,6 +134,10 @@ export class NetworkInspector {
 
   // === 3. Dependency setters ===
 
+  setTabIdResolver(resolver: (wcId: number) => string | null): void {
+    this.tabIdResolver = resolver;
+  }
+
   /** Register as a dispatcher consumer (late registration supported) */
   registerWith(dispatcher: RequestDispatcher): void {
     dispatcher.registerBeforeRequest({
@@ -131,6 +147,8 @@ export class NetworkInspector {
         const domain = this.extractDomain(details.url);
         if (domain && !details.url.startsWith('file://') && !details.url.startsWith('devtools://')) {
           const id = ++this.counter;
+          const wcId = this.getWebContentsId(details);
+          const tabId = wcId !== undefined ? this.tabIdResolver?.(wcId) ?? undefined : undefined;
           this.pendingRequests.set(String(details.id ?? id), {
             id,
             url: details.url,
@@ -142,6 +160,9 @@ export class NetworkInspector {
             contentType: '',
             size: 0,
             durationMs: 0,
+            resourceType: this.getResourceType(details),
+            tabId,
+            wcId,
             requestHeaders: {},
             responseHeaders: {},
           });
@@ -197,6 +218,9 @@ export class NetworkInspector {
             initiator: pending.initiator!,
             domain: pending.domain!,
             durationMs: Math.max(0, Date.now() - pending.timestamp!),
+            resourceType: pending.resourceType,
+            tabId: pending.tabId,
+            wcId: pending.wcId,
             requestHeaders: pending.requestHeaders || {},
             responseHeaders: pending.responseHeaders || details.responseHeaders || {},
           };
@@ -248,28 +272,60 @@ export class NetworkInspector {
   }
 
   /** Get recent requests, optionally filtered */
-  getLog(limit: number = 100, domain?: string): NetworkRequest[] {
-    let filtered = this.requests;
-    if (domain) {
-      filtered = filtered.filter(r => r.domain === domain);
-    }
+  getLog(opts: NetworkQueryOptions = {}): NetworkRequest[] {
+    const filtered = this.filterRequests(opts);
+    const limit = opts.limit ?? 100;
     return filtered.slice(-limit);
   }
 
   /** Get discovered API endpoints grouped by domain */
-  getApis(): Record<string, string[]> {
-    const result: Record<string, string[]> = {};
-    for (const [domain, data] of this.domainStats) {
-      if (data.apis.length > 0) {
-        result[domain] = data.apis;
+  getApis(opts: Omit<NetworkQueryOptions, 'limit'> = {}): Record<string, string[]> {
+    const result = new Map<string, Set<string>>();
+    for (const request of this.filterRequests(opts)) {
+      if (!this.isApiEndpoint(request)) {
+        continue;
       }
+      const apiPath = this.extractApiPath(request.url);
+      if (!apiPath) {
+        continue;
+      }
+      if (!result.has(request.domain)) {
+        result.set(request.domain, new Set());
+      }
+      result.get(request.domain)!.add(apiPath);
     }
-    return result;
+
+    return Object.fromEntries(
+      Array.from(result.entries()).map(([domain, apis]) => [domain, Array.from(apis)]),
+    );
   }
 
   /** Get domain list with request counts */
-  getDomains(): Array<{ domain: string; requests: number; lastSeen: number; apiCount: number }> {
-    return Array.from(this.domainStats.values()).map(d => ({
+  getDomains(opts: Omit<NetworkQueryOptions, 'limit'> = {}): Array<{ domain: string; requests: number; lastSeen: number; apiCount: number }> {
+    const domains = new Map<string, DomainData>();
+
+    for (const request of this.filterRequests(opts)) {
+      let entry = domains.get(request.domain);
+      if (!entry) {
+        entry = {
+          domain: request.domain,
+          requests: 0,
+          apis: [],
+          lastSeen: 0,
+        };
+        domains.set(request.domain, entry);
+      }
+      entry.requests += 1;
+      entry.lastSeen = Math.max(entry.lastSeen, request.timestamp);
+      if (this.isApiEndpoint(request)) {
+        const apiPath = this.extractApiPath(request.url);
+        if (apiPath && !entry.apis.includes(apiPath)) {
+          entry.apis.push(apiPath);
+        }
+      }
+    }
+
+    return Array.from(domains.values()).map(d => ({
       domain: d.domain,
       requests: d.requests,
       lastSeen: d.lastSeen,
@@ -279,13 +335,18 @@ export class NetworkInspector {
 
   /**
    * Export logged requests as a HAR 1.2 archive.
-   * @param limit - max entries to include (default 100)
-   * @param domain - optional domain filter
    */
-  toHar(limit: number = 100, domain?: string): HarExport {
-    const entries = this.getLog(limit, domain).map((request) => this.toHarEntry(request));
+  toHar(opts: NetworkQueryOptions = {}): HarExport {
+    const entries = this.getLog(opts).map((request) => this.toHarEntry(request));
     const startedDateTime = entries[0]?.startedDateTime ?? new Date().toISOString();
-    const title = domain ? `Network log for ${domain}` : 'Tandem network log';
+    const scopeLabel = opts.tabId
+      ? `tab ${opts.tabId}`
+      : opts.wcId !== undefined
+        ? `webContents ${opts.wcId}`
+        : 'active tab';
+    const title = opts.domain
+      ? `Network log for ${opts.domain} (${scopeLabel})`
+      : `Tandem network log (${scopeLabel})`;
 
     return {
       log: {
@@ -309,7 +370,15 @@ export class NetworkInspector {
   }
 
   /** Clear all logged data */
-  clear(): void {
+  clear(tabId?: string): void {
+    if (tabId) {
+      this.requests = this.requests.filter(request => request.tabId !== tabId);
+      this.pendingRequests = new Map(
+        Array.from(this.pendingRequests.entries()).filter(([, pending]) => pending.tabId !== tabId),
+      );
+      this.rebuildDomainStats();
+      return;
+    }
     this.requests = [];
     this.pendingRequests.clear();
     this.domainStats.clear();
@@ -347,6 +416,43 @@ export class NetworkInspector {
       const apiPath = this.extractApiPath(req.url);
       if (apiPath && !domainData.apis.includes(apiPath)) {
         domainData.apis.push(apiPath);
+      }
+    }
+  }
+
+  private filterRequests(opts: NetworkQueryOptions = {}): NetworkRequest[] {
+    let filtered = this.requests;
+    if (opts.tabId) {
+      filtered = filtered.filter(request => request.tabId === opts.tabId);
+    }
+    if (opts.wcId !== undefined) {
+      filtered = filtered.filter(request => request.wcId === opts.wcId);
+    }
+    if (opts.domain) {
+      filtered = filtered.filter(request => request.domain === opts.domain);
+    }
+    if (opts.type) {
+      const type = opts.type.toLowerCase();
+      filtered = filtered.filter(request => request.resourceType?.toLowerCase() === type);
+    }
+    return filtered;
+  }
+
+  private rebuildDomainStats(): void {
+    this.domainStats.clear();
+    for (const request of this.requests) {
+      let domainData = this.domainStats.get(request.domain);
+      if (!domainData) {
+        domainData = { domain: request.domain, requests: 0, apis: [], lastSeen: 0 };
+        this.domainStats.set(request.domain, domainData);
+      }
+      domainData.requests += 1;
+      domainData.lastSeen = request.timestamp;
+      if (this.isApiEndpoint(request)) {
+        const apiPath = this.extractApiPath(request.url);
+        if (apiPath && !domainData.apis.includes(apiPath)) {
+          domainData.apis.push(apiPath);
+        }
       }
     }
   }
@@ -390,6 +496,14 @@ export class NetworkInspector {
     } catch {
       return '';
     }
+  }
+
+  private getWebContentsId(details: { webContentsId?: number }): number | undefined {
+    return typeof details.webContentsId === 'number' ? details.webContentsId : undefined;
+  }
+
+  private getResourceType(details: { resourceType?: string }): string | undefined {
+    return typeof details.resourceType === 'string' ? details.resourceType : undefined;
   }
 
   private toHarEntry(request: NetworkRequest): HarEntry {

--- a/src/network/tests/inspector.test.ts
+++ b/src/network/tests/inspector.test.ts
@@ -26,6 +26,7 @@ type MutableInspector = {
   isApiEndpoint: (req: NetworkRequest) => boolean;
   extractApiPath: (url: string) => string;
   extractDomain: (url: string) => string;
+  rebuildDomainStats: () => void;
 };
 
 describe('NetworkInspector', () => {
@@ -72,7 +73,7 @@ describe('NetworkInspector', () => {
 
   it('HAR page title includes domain when domain filter is provided', () => {
     mut.requests = [createRequest()];
-    const har = inspector.toHar(100, 'api.example.com');
+    const har = inspector.toHar({ limit: 100, domain: 'api.example.com' });
     expect(har.log.pages[0].title).toContain('api.example.com');
   });
 
@@ -103,7 +104,7 @@ describe('NetworkInspector', () => {
     mut.requests = Array.from({ length: 5 }, (_, i) =>
       createRequest({ id: i + 1, domain: 'example.com' }),
     );
-    expect(inspector.getLog(3)).toHaveLength(3);
+    expect(inspector.getLog({ limit: 3 })).toHaveLength(3);
     expect(inspector.getLog()).toHaveLength(5);
   });
 
@@ -113,28 +114,45 @@ describe('NetworkInspector', () => {
       createRequest({ id: 2, domain: 'b.com' }),
       createRequest({ id: 3, domain: 'a.com' }),
     ];
-    const filtered = inspector.getLog(100, 'a.com');
+    const filtered = inspector.getLog({ limit: 100, domain: 'a.com' });
     expect(filtered).toHaveLength(2);
     expect(filtered.every(r => r.domain === 'a.com')).toBe(true);
   });
 
   it('getLog returns empty for non-existent domain', () => {
     mut.requests = [createRequest({ domain: 'a.com' })];
-    expect(inspector.getLog(100, 'nonexistent.com')).toHaveLength(0);
+    expect(inspector.getLog({ limit: 100, domain: 'nonexistent.com' })).toHaveLength(0);
+  });
+
+  it('getLog filters by tabId and resource type', () => {
+    mut.requests = [
+      createRequest({ id: 1, domain: 'a.com', tabId: 'tab-1', resourceType: 'xhr' }),
+      createRequest({ id: 2, domain: 'a.com', tabId: 'tab-2', resourceType: 'xhr' }),
+      createRequest({ id: 3, domain: 'a.com', tabId: 'tab-1', resourceType: 'script' }),
+    ];
+
+    const filtered = inspector.getLog({ limit: 100, tabId: 'tab-1', type: 'xhr' });
+
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].id).toBe(1);
   });
 
   // ─── getDomains ───
 
   it('getDomains returns domain stats sorted by request count', () => {
-    mut.domainStats.set('a.com', { domain: 'a.com', requests: 10, apis: [], lastSeen: 1 });
-    mut.domainStats.set('b.com', { domain: 'b.com', requests: 50, apis: ['/api/v1'], lastSeen: 2 });
-    mut.domainStats.set('c.com', { domain: 'c.com', requests: 5, apis: [], lastSeen: 3 });
+    mut.requests = [
+      createRequest({ id: 1, domain: 'a.com', url: 'https://a.com/app' }),
+      createRequest({ id: 2, domain: 'b.com', url: 'https://b.com/api/v1' }),
+      createRequest({ id: 3, domain: 'b.com', url: 'https://b.com/api/v2' }),
+      createRequest({ id: 4, domain: 'c.com', url: 'https://c.com/app' }),
+      createRequest({ id: 5, domain: 'b.com', url: 'https://b.com/api/v3' }),
+    ];
 
     const domains = inspector.getDomains();
     expect(domains).toHaveLength(3);
     expect(domains[0].domain).toBe('b.com');
-    expect(domains[0].requests).toBe(50);
-    expect(domains[0].apiCount).toBe(1);
+    expect(domains[0].requests).toBe(3);
+    expect(domains[0].apiCount).toBe(3);
     expect(domains[2].domain).toBe('c.com');
   });
 
@@ -145,12 +163,29 @@ describe('NetworkInspector', () => {
   // ─── getApis ───
 
   it('getApis returns only domains with discovered endpoints', () => {
-    mut.domainStats.set('api.com', { domain: 'api.com', requests: 5, apis: ['/v1/users', '/v1/items'], lastSeen: 1 });
-    mut.domainStats.set('cdn.com', { domain: 'cdn.com', requests: 100, apis: [], lastSeen: 2 });
+    mut.requests = [
+      createRequest({ domain: 'api.com', url: 'https://api.com/v1/users' }),
+      createRequest({ id: 2, domain: 'api.com', url: 'https://api.com/v1/items' }),
+      createRequest({ id: 3, domain: 'cdn.com', url: 'https://cdn.com/style.css', contentType: 'text/css' }),
+    ];
 
     const apis = inspector.getApis();
     expect(Object.keys(apis)).toEqual(['api.com']);
     expect(apis['api.com']).toEqual(['/v1/users', '/v1/items']);
+  });
+
+  it('getApis and getDomains scope summaries by tabId', () => {
+    mut.requests = [
+      createRequest({ id: 1, domain: 'api.com', tabId: 'tab-1', url: 'https://api.com/v1/users' }),
+      createRequest({ id: 2, domain: 'api.com', tabId: 'tab-2', url: 'https://api.com/v1/admin' }),
+      createRequest({ id: 3, domain: 'cdn.com', tabId: 'tab-2', url: 'https://cdn.com/app.js', contentType: 'application/javascript' }),
+    ];
+
+    expect(inspector.getApis({ tabId: 'tab-1' })).toEqual({ 'api.com': ['/v1/users'] });
+    expect(inspector.getDomains({ tabId: 'tab-2' })).toEqual([
+      { domain: 'api.com', requests: 1, lastSeen: mut.requests[1].timestamp, apiCount: 1 },
+      { domain: 'cdn.com', requests: 1, lastSeen: mut.requests[2].timestamp, apiCount: 0 },
+    ]);
   });
 
   // ─── clear ───
@@ -164,6 +199,23 @@ describe('NetworkInspector', () => {
     expect(inspector.getLog()).toHaveLength(0);
     expect(inspector.getDomains()).toHaveLength(0);
     expect(inspector.getApis()).toEqual({});
+  });
+
+  it('clear removes only the targeted tab when tabId is provided', () => {
+    mut.requests = [
+      createRequest({ id: 1, tabId: 'tab-1', domain: 'a.com', url: 'https://a.com/v1/users' }),
+      createRequest({ id: 2, tabId: 'tab-2', domain: 'b.com', url: 'https://b.com/v1/users' }),
+    ];
+    mut.rebuildDomainStats();
+
+    inspector.clear('tab-1');
+
+    expect(inspector.getLog()).toEqual([
+      expect.objectContaining({ id: 2, tabId: 'tab-2' }),
+    ]);
+    expect(inspector.getDomains()).toEqual([
+      expect.objectContaining({ domain: 'b.com', requests: 1 }),
+    ]);
   });
 
   // ─── addRequest & sliding window ───


### PR DESCRIPTION
## Summary
- DevTools and network capture are now keyed by target webContents (not global)
- CDP requestIds from different tabs no longer collide
- Routes return explicit `scope` metadata so callers know which tab data came from
- `GET /devtools/status` exposes `managerPrimary` separately from requested tab
- MCP tools forward `tabId` and match real tab-scoped behavior

## Tab-scoped routes
`/devtools/status`, `/devtools/console`, `/devtools/console/errors`, `/devtools/console/clear`, `/devtools/network`, `/devtools/network/:requestId/body`, `/devtools/network/clear`, `/devtools/dom/query`, `/devtools/dom/xpath`, `/devtools/storage`, `/devtools/performance`, `/devtools/evaluate`, `/devtools/cdp`, `/devtools/screenshot/element`, `/network/log`, `/network/apis`, `/network/domains`, `/network/har`, `/network/clear`

## Intentionally global
`/devtools/shell`, `/devtools/toggle`, network mock/intercept routes

## Review notes
- Fixed one lint error (unused `result` variable in `network/inspector.ts`)
- TS clean, 2074 tests passing, consistency check passes
- Codex tested live with curl against running Tandem instance

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx eslint` — 0 errors
- [x] `npx vitest run` — 2074 tests passing (100 test files)
- [x] `node scripts/check-consistency.js` — consistent
- [x] Live-tested by Codex with multi-tab curl validation