### PR TITLE
test: improve devtools and network tab-scoping coverage

### DIFF
--- a/src/api/tests/routes/devtools.test.ts
+++ b/src/api/tests/routes/devtools.test.ts
@@ -67,6 +67,44 @@ describe('Devtools Routes', () => {
       expect(ctx.devToolsManager.getStatus).toHaveBeenNthCalledWith(2, { tabId: 'tab-1', wcId: 100 });
     });
 
+    it('returns 404 when X-Tab-Id header refers to unknown tab', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([]);
+
+      const res = await request(app).get('/devtools/status').set('X-Tab-Id', 'tab-missing');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Tab tab-missing not found');
+    });
+
+    it('returns scoped status when valid X-Tab-Id header is provided', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([
+        { id: 'tab-2', webContentsId: 202, url: 'https://two.example', title: 'Two', active: false, source: 'wingman', partition: 'persist:tandem' } as any,
+      ]);
+      const managerStatus = { attached: true, tabId: 'tab-2', wcId: 202 };
+      const scopedStatus = { attached: true, tabId: 'tab-2', wcId: 202, console: { entries: 1, errors: 0, lastId: 1 }, network: { entries: 0 } };
+      vi.mocked(ctx.devToolsManager.getStatus)
+        .mockReturnValueOnce(managerStatus as any)
+        .mockReturnValueOnce(scopedStatus as any);
+
+      const res = await request(app).get('/devtools/status').set('X-Tab-Id', 'tab-2');
+
+      expect(res.status).toBe(200);
+      expect(res.body.scope).toEqual({ kind: 'tab', tabId: 'tab-2', wcId: 202, source: 'header' });
+    });
+
+    it('returns default empty scoped status when no active tab exists', async () => {
+      vi.mocked(ctx.tabManager.getActiveTab).mockReturnValue(null as any);
+      const managerStatus = { attached: false, tabId: null, wcId: null };
+      vi.mocked(ctx.devToolsManager.getStatus).mockReturnValue(managerStatus as any);
+
+      const res = await request(app).get('/devtools/status');
+
+      expect(res.status).toBe(200);
+      expect(res.body.scope).toEqual({ kind: 'tab', tabId: null, wcId: null, source: 'active' });
+      expect(res.body.attached).toBe(false);
+      expect(res.body.console).toEqual({ entries: 0, errors: 0, lastId: 0 });
+    });
+
     it('returns 500 when getStatus throws', async () => {
       vi.mocked(ctx.devToolsManager.getStatus).mockImplementation(() => {
         throw new Error('CDP failed');
@@ -139,6 +177,27 @@ describe('Devtools Routes', () => {
       expect(ctx.devToolsManager.getConsoleEntries).toHaveBeenCalledWith(expect.objectContaining({ tabId: 'tab-2' }));
       expect(ctx.devToolsManager.getConsoleCounts).toHaveBeenCalledWith('tab-2');
     });
+
+    it('returns 404 when X-Tab-Id header refers to unknown tab', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([]);
+
+      const res = await request(app).get('/devtools/console').set('X-Tab-Id', 'tab-gone');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Tab tab-gone not found');
+    });
+
+    it('returns empty entries and zero counts when no active tab', async () => {
+      vi.mocked(ctx.tabManager.getActiveTab).mockReturnValue(null as any);
+
+      const res = await request(app).get('/devtools/console');
+
+      expect(res.status).toBe(200);
+      expect(res.body.entries).toEqual([]);
+      expect(res.body.counts).toEqual({ log: 0, info: 0, warn: 0, error: 0, debug: 0 });
+      expect(res.body.total).toBe(0);
+      expect(ctx.devToolsManager.getConsoleEntries).not.toHaveBeenCalled();
+    });
   });
 
   // ─── GET /devtools/console/errors ──────────────────
@@ -167,6 +226,26 @@ describe('Devtools Routes', () => {
       expect(res.status).toBe(200);
       expect(ctx.devToolsManager.getConsoleErrors).toHaveBeenCalledWith(10, 'tab-1');
     });
+
+    it('returns 404 when X-Tab-Id header refers to unknown tab', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([]);
+
+      const res = await request(app).get('/devtools/console/errors').set('X-Tab-Id', 'tab-gone');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Tab tab-gone not found');
+    });
+
+    it('returns empty errors array when no active tab', async () => {
+      vi.mocked(ctx.tabManager.getActiveTab).mockReturnValue(null as any);
+
+      const res = await request(app).get('/devtools/console/errors');
+
+      expect(res.status).toBe(200);
+      expect(res.body.errors).toEqual([]);
+      expect(res.body.total).toBe(0);
+      expect(ctx.devToolsManager.getConsoleErrors).not.toHaveBeenCalled();
+    });
   });
 
   // ─── POST /devtools/console/clear ──────────────────
@@ -181,6 +260,36 @@ describe('Devtools Routes', () => {
         scope: { kind: 'tab', tabId: 'tab-1', wcId: 100, source: 'active' },
       });
       expect(ctx.devToolsManager.clearConsole).toHaveBeenCalledWith('tab-1');
+    });
+
+    it('returns 404 when X-Tab-Id header refers to unknown tab', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([]);
+
+      const res = await request(app).post('/devtools/console/clear').set('X-Tab-Id', 'tab-gone');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Tab tab-gone not found');
+    });
+
+    it('returns 404 when there is no active tab', async () => {
+      vi.mocked(ctx.tabManager.getActiveTab).mockReturnValue(null as any);
+
+      const res = await request(app).post('/devtools/console/clear');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('No active tab');
+    });
+
+    it('clears a specific background tab when tabId is in body', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([
+        { id: 'tab-2', webContentsId: 202, url: 'https://two.example', title: 'Two', active: false, source: 'wingman', partition: 'persist:tandem' } as any,
+      ]);
+
+      const res = await request(app).post('/devtools/console/clear').send({ tabId: 'tab-2' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.scope).toEqual({ kind: 'tab', tabId: 'tab-2', wcId: 202, source: 'body' });
+      expect(ctx.devToolsManager.clearConsole).toHaveBeenCalledWith('tab-2');
     });
   });
 
@@ -248,6 +357,26 @@ describe('Devtools Routes', () => {
         expect.objectContaining({ failed: false, tabId: 'tab-1', wcId: 100 }),
       );
     });
+
+    it('returns 404 when X-Tab-Id header refers to unknown tab', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([]);
+
+      const res = await request(app).get('/devtools/network').set('X-Tab-Id', 'tab-gone');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Tab tab-gone not found');
+    });
+
+    it('returns empty entries when no active tab', async () => {
+      vi.mocked(ctx.tabManager.getActiveTab).mockReturnValue(null as any);
+
+      const res = await request(app).get('/devtools/network');
+
+      expect(res.status).toBe(200);
+      expect(res.body.entries).toEqual([]);
+      expect(res.body.total).toBe(0);
+      expect(ctx.devToolsManager.getNetworkEntries).not.toHaveBeenCalled();
+    });
   });
 
   // ─── GET /devtools/network/:requestId/body ─────────
@@ -276,6 +405,24 @@ describe('Devtools Routes', () => {
       expect(res.status).toBe(404);
       expect(res.body.error).toBe('Response body not available (evicted or streamed)');
     });
+
+    it('returns 404 when X-Tab-Id header refers to unknown tab', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([]);
+
+      const res = await request(app).get('/devtools/network/req-123/body').set('X-Tab-Id', 'tab-gone');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Tab tab-gone not found');
+    });
+
+    it('returns 404 when there is no active tab', async () => {
+      vi.mocked(ctx.tabManager.getActiveTab).mockReturnValue(null as any);
+
+      const res = await request(app).get('/devtools/network/req-123/body');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('No active tab');
+    });
   });
 
   // ─── POST /devtools/network/clear ──────────────────
@@ -290,6 +437,24 @@ describe('Devtools Routes', () => {
         scope: { kind: 'tab', tabId: 'tab-1', wcId: 100, source: 'active' },
       });
       expect(ctx.devToolsManager.clearNetwork).toHaveBeenCalledWith('tab-1');
+    });
+
+    it('returns 404 when X-Tab-Id header refers to unknown tab', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([]);
+
+      const res = await request(app).post('/devtools/network/clear').set('X-Tab-Id', 'tab-gone');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Tab tab-gone not found');
+    });
+
+    it('returns 404 when there is no active tab', async () => {
+      vi.mocked(ctx.tabManager.getActiveTab).mockReturnValue(null as any);
+
+      const res = await request(app).post('/devtools/network/clear');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('No active tab');
     });
   });
 
@@ -329,6 +494,29 @@ describe('Devtools Routes', () => {
       expect(res.status).toBe(400);
       expect(res.body.error).toBe('selector required');
     });
+
+    it('returns 404 when X-Tab-Id header refers to unknown tab', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([]);
+
+      const res = await request(app)
+        .post('/devtools/dom/query')
+        .set('X-Tab-Id', 'tab-gone')
+        .send({ selector: 'div' });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Tab tab-gone not found');
+    });
+
+    it('returns 404 when there is no active tab', async () => {
+      vi.mocked(ctx.tabManager.getActiveTab).mockReturnValue(null as any);
+
+      const res = await request(app)
+        .post('/devtools/dom/query')
+        .send({ selector: 'div' });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('No active tab');
+    });
   });
 
   // ─── POST /devtools/dom/xpath ──────────────────────
@@ -367,6 +555,29 @@ describe('Devtools Routes', () => {
       expect(res.status).toBe(400);
       expect(res.body.error).toBe('expression required');
     });
+
+    it('returns 404 when X-Tab-Id header refers to unknown tab', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([]);
+
+      const res = await request(app)
+        .post('/devtools/dom/xpath')
+        .set('X-Tab-Id', 'tab-gone')
+        .send({ expression: '//div' });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Tab tab-gone not found');
+    });
+
+    it('returns 404 when there is no active tab', async () => {
+      vi.mocked(ctx.tabManager.getActiveTab).mockReturnValue(null as any);
+
+      const res = await request(app)
+        .post('/devtools/dom/xpath')
+        .send({ expression: '//div' });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('No active tab');
+    });
   });
 
   // ─── GET /devtools/storage ─────────────────────────
@@ -384,6 +595,24 @@ describe('Devtools Routes', () => {
         scope: { kind: 'tab', tabId: 'tab-1', wcId: 100, source: 'active' },
       });
       expect(ctx.devToolsManager.getStorage).toHaveBeenCalledWith(100);
+    });
+
+    it('returns 404 when X-Tab-Id header refers to unknown tab', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([]);
+
+      const res = await request(app).get('/devtools/storage').set('X-Tab-Id', 'tab-gone');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Tab tab-gone not found');
+    });
+
+    it('returns 404 when there is no active tab', async () => {
+      vi.mocked(ctx.tabManager.getActiveTab).mockReturnValue(null as any);
+
+      const res = await request(app).get('/devtools/storage');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('No active tab');
     });
   });
 
@@ -411,6 +640,24 @@ describe('Devtools Routes', () => {
 
       expect(res.status).toBe(503);
       expect(res.body.error).toBe('No targeted tab or CDP not attached');
+    });
+
+    it('returns 404 when X-Tab-Id header refers to unknown tab', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([]);
+
+      const res = await request(app).get('/devtools/performance').set('X-Tab-Id', 'tab-gone');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Tab tab-gone not found');
+    });
+
+    it('returns 404 when there is no active tab', async () => {
+      vi.mocked(ctx.tabManager.getActiveTab).mockReturnValue(null as any);
+
+      const res = await request(app).get('/devtools/performance');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('No active tab');
     });
   });
 
@@ -455,6 +702,29 @@ describe('Devtools Routes', () => {
 
       expect(res.status).toBe(400);
       expect(res.body.error).toBe('expression required');
+    });
+
+    it('returns 404 when X-Tab-Id header refers to unknown tab', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([]);
+
+      const res = await request(app)
+        .post('/devtools/evaluate')
+        .set('X-Tab-Id', 'tab-gone')
+        .send({ expression: '1+1' });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Tab tab-gone not found');
+    });
+
+    it('returns 404 when there is no active tab', async () => {
+      vi.mocked(ctx.tabManager.getActiveTab).mockReturnValue(null as any);
+
+      const res = await request(app)
+        .post('/devtools/evaluate')
+        .send({ expression: '1+1' });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('No active tab');
     });
 
     it('returns 413 when expression exceeds 1MB', async () => {
@@ -532,6 +802,29 @@ describe('Devtools Routes', () => {
       expect(res.status).toBe(400);
       expect(res.body.error).toBe('method required');
     });
+
+    it('returns 404 when X-Tab-Id header refers to unknown tab', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([]);
+
+      const res = await request(app)
+        .post('/devtools/cdp')
+        .set('X-Tab-Id', 'tab-gone')
+        .send({ method: 'Page.reload' });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Tab tab-gone not found');
+    });
+
+    it('returns 404 when there is no active tab', async () => {
+      vi.mocked(ctx.tabManager.getActiveTab).mockReturnValue(null as any);
+
+      const res = await request(app)
+        .post('/devtools/cdp')
+        .send({ method: 'Page.reload' });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('No active tab');
+    });
   });
 
   // ─── POST /devtools/screenshot/element ─────────────
@@ -571,6 +864,29 @@ describe('Devtools Routes', () => {
 
       expect(res.status).toBe(404);
       expect(res.body.error).toBe('Element not found or screenshot failed');
+    });
+
+    it('returns 404 when X-Tab-Id header refers to unknown tab', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([]);
+
+      const res = await request(app)
+        .post('/devtools/screenshot/element')
+        .set('X-Tab-Id', 'tab-gone')
+        .send({ selector: '#hero' });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Tab tab-gone not found');
+    });
+
+    it('returns 404 when there is no active tab', async () => {
+      vi.mocked(ctx.tabManager.getActiveTab).mockReturnValue(null as any);
+
+      const res = await request(app)
+        .post('/devtools/screenshot/element')
+        .send({ selector: '#hero' });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('No active tab');
     });
   });
 

--- a/src/api/tests/routes/network.test.ts
+++ b/src/api/tests/routes/network.test.ts
@@ -97,6 +97,26 @@ describe('Network Routes', () => {
       });
     });
 
+    it('returns 404 when X-Tab-Id header refers to unknown tab', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([]);
+
+      const res = await request(app).get('/network/log').set('X-Tab-Id', 'tab-gone');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Tab tab-gone not found');
+    });
+
+    it('returns empty entries when no active tab', async () => {
+      vi.mocked(ctx.tabManager.getActiveTab).mockReturnValue(null as any);
+
+      const res = await request(app).get('/network/log');
+
+      expect(res.status).toBe(200);
+      expect(res.body.entries).toEqual([]);
+      expect(res.body.count).toBe(0);
+      expect(ctx.networkInspector.getLog).not.toHaveBeenCalled();
+    });
+
     it('returns 500 when getLog throws', async () => {
       vi.mocked(ctx.networkInspector.getLog).mockImplementation(() => { throw new Error('log error'); });
 
@@ -122,6 +142,25 @@ describe('Network Routes', () => {
       expect(ctx.networkInspector.getApis).toHaveBeenCalledWith({ tabId: 'tab-1', wcId: 100 });
     });
 
+    it('returns 404 when X-Tab-Id header refers to unknown tab', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([]);
+
+      const res = await request(app).get('/network/apis').set('X-Tab-Id', 'tab-gone');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Tab tab-gone not found');
+    });
+
+    it('returns empty apis object when no active tab', async () => {
+      vi.mocked(ctx.tabManager.getActiveTab).mockReturnValue(null as any);
+
+      const res = await request(app).get('/network/apis');
+
+      expect(res.status).toBe(200);
+      expect(res.body.apis).toEqual({});
+      expect(ctx.networkInspector.getApis).not.toHaveBeenCalled();
+    });
+
     it('returns 500 when getApis throws', async () => {
       vi.mocked(ctx.networkInspector.getApis).mockImplementation(() => { throw new Error('apis error'); });
 
@@ -145,6 +184,25 @@ describe('Network Routes', () => {
       expect(res.body.scope).toEqual({ kind: 'tab', tabId: 'tab-1', wcId: 100, source: 'active' });
       expect(res.body.domains).toEqual(fakeDomains);
       expect(ctx.networkInspector.getDomains).toHaveBeenCalledWith({ tabId: 'tab-1', wcId: 100 });
+    });
+
+    it('returns 404 when X-Tab-Id header refers to unknown tab', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([]);
+
+      const res = await request(app).get('/network/domains').set('X-Tab-Id', 'tab-gone');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Tab tab-gone not found');
+    });
+
+    it('returns empty domains array when no active tab', async () => {
+      vi.mocked(ctx.tabManager.getActiveTab).mockReturnValue(null as any);
+
+      const res = await request(app).get('/network/domains');
+
+      expect(res.status).toBe(200);
+      expect(res.body.domains).toEqual([]);
+      expect(ctx.networkInspector.getDomains).not.toHaveBeenCalled();
     });
 
     it('returns 500 when getDomains throws', async () => {
@@ -194,6 +252,26 @@ describe('Network Routes', () => {
       expect(res.headers['content-disposition']).toContain('example.com');
     });
 
+    it('returns 404 when X-Tab-Id header refers to unknown tab', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([]);
+
+      const res = await request(app).get('/network/har').set('X-Tab-Id', 'tab-gone');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Tab tab-gone not found');
+    });
+
+    it('generates filename with tab-none when no active tab', async () => {
+      vi.mocked(ctx.tabManager.getActiveTab).mockReturnValue(null as any);
+      const emptyHar = { log: { version: '1.2', creator: { name: 'Tandem Browser', version: '0.0.0' }, pages: [], entries: [] } };
+      vi.mocked(ctx.networkInspector.toHar).mockReturnValue(emptyHar as any);
+
+      const res = await request(app).get('/network/har');
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-disposition']).toContain('tab-none');
+    });
+
     it('returns 500 when har export throws', async () => {
       vi.mocked(ctx.networkInspector.toHar).mockImplementation(() => { throw new Error('har error'); });
 
@@ -216,6 +294,24 @@ describe('Network Routes', () => {
         scope: { kind: 'tab', tabId: 'tab-1', wcId: 100, source: 'active' },
       });
       expect(ctx.networkInspector.clear).toHaveBeenCalledWith('tab-1');
+    });
+
+    it('returns 404 when X-Tab-Id header refers to unknown tab', async () => {
+      vi.mocked(ctx.tabManager.listTabs).mockReturnValue([]);
+
+      const res = await request(app).delete('/network/clear').set('X-Tab-Id', 'tab-gone');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Tab tab-gone not found');
+    });
+
+    it('returns 404 when there is no active tab', async () => {
+      vi.mocked(ctx.tabManager.getActiveTab).mockReturnValue(null as any);
+
+      const res = await request(app).delete('/network/clear');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('No active tab');
     });
 
     it('returns 500 when clear throws', async () => {

--- a/src/mcp/tests/devtools.test.ts
+++ b/src/mcp/tests/devtools.test.ts
@@ -79,6 +79,77 @@ describe('MCP devtools tools', () => {
       expectTextContent(result);
       expect(mockApiCall).toHaveBeenCalledWith('POST', '/devtools/console/clear', undefined, undefined);
     });
+
+    it('forwards tabId as X-Tab-Id header', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: true });
+      await handler({ tabId: 'tab-3' });
+      expect(vi.mocked(tabHeaders)).toHaveBeenCalledWith('tab-3');
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/devtools/console/clear', undefined, { 'X-Tab-Id': 'tab-3' });
+    });
+  });
+
+  // ── tandem_devtools_network ───────────────────────────────────────
+  describe('tandem_devtools_network', () => {
+    const handler = getHandler(tools, 'tandem_devtools_network');
+
+    it('returns network entries as JSON', async () => {
+      const data = { entries: [{ url: 'https://api.com/data', method: 'GET' }] };
+      mockApiCall.mockResolvedValueOnce(data);
+
+      const result = await handler({});
+      const text = expectTextContent(result);
+      expect(JSON.parse(text)).toEqual(data);
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/devtools/network', undefined, undefined);
+    });
+
+    it('builds query string with filters', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+
+      await handler({ domain: 'api.com', type: 'XHR', limit: 50, failed: true });
+      const endpoint = mockApiCall.mock.calls[0][1] as string;
+      expect(endpoint).toContain('domain=api.com');
+      expect(endpoint).toContain('type=XHR');
+      expect(endpoint).toContain('limit=50');
+      expect(endpoint).toContain('failed=true');
+    });
+
+    it('forwards tabId as X-Tab-Id header', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      await handler({ tabId: 'tab-5' });
+      expect(vi.mocked(tabHeaders)).toHaveBeenCalledWith('tab-5');
+    });
+  });
+
+  // ── tandem_devtools_network_body ──────────────────────────────────
+  describe('tandem_devtools_network_body', () => {
+    const handler = getHandler(tools, 'tandem_devtools_network_body');
+
+    it('returns body for a specific request', async () => {
+      mockApiCall.mockResolvedValueOnce({ body: '{"data": true}' });
+
+      const result = await handler({ requestId: 'req-42' });
+      expectTextContent(result);
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/devtools/network/req-42/body', undefined, undefined);
+    });
+  });
+
+  // ── tandem_devtools_network_clear ─────────────────────────────────
+  describe('tandem_devtools_network_clear', () => {
+    const handler = getHandler(tools, 'tandem_devtools_network_clear');
+
+    it('clears network log', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: true });
+      const result = await handler({});
+      expectTextContent(result);
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/devtools/network/clear', undefined, undefined);
+    });
+
+    it('forwards tabId as X-Tab-Id header', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: true });
+      await handler({ tabId: 'tab-4' });
+      expect(vi.mocked(tabHeaders)).toHaveBeenCalledWith('tab-4');
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/devtools/network/clear', undefined, { 'X-Tab-Id': 'tab-4' });
+    });
   });
 
   // ── tandem_devtools_evaluate ──────────────────────────────────────

--- a/src/network/tests/inspector.test.ts
+++ b/src/network/tests/inspector.test.ts
@@ -77,6 +77,23 @@ describe('NetworkInspector', () => {
     expect(har.log.pages[0].title).toContain('api.example.com');
   });
 
+  it('HAR page title includes tab scope label when tabId is provided', () => {
+    mut.requests = [createRequest({ tabId: 'tab-1' })];
+    const har = inspector.toHar({ tabId: 'tab-1' });
+    expect(har.log.pages[0].title).toContain('tab tab-1');
+  });
+
+  it('HAR page title includes webContents scope when only wcId is provided', () => {
+    mut.requests = [createRequest({ wcId: 42 })];
+    const har = inspector.toHar({ wcId: 42 });
+    expect(har.log.pages[0].title).toContain('webContents 42');
+  });
+
+  it('HAR page title says active tab when no scope is provided', () => {
+    const har = inspector.toHar();
+    expect(har.log.pages[0].title).toContain('active tab');
+  });
+
   it('HAR export with empty requests returns empty entries', () => {
     const har = inspector.toHar();
     expect(har.log.entries).toHaveLength(0);
@@ -135,6 +152,19 @@ describe('NetworkInspector', () => {
 
     expect(filtered).toHaveLength(1);
     expect(filtered[0].id).toBe(1);
+  });
+
+  it('getLog filters by wcId', () => {
+    mut.requests = [
+      createRequest({ id: 1, domain: 'a.com', wcId: 101 }),
+      createRequest({ id: 2, domain: 'a.com', wcId: 202 }),
+      createRequest({ id: 3, domain: 'b.com', wcId: 101 }),
+    ];
+
+    const filtered = inspector.getLog({ limit: 100, wcId: 101 });
+
+    expect(filtered).toHaveLength(2);
+    expect(filtered.every(r => r.wcId === 101)).toBe(true);
   });
 
   // ─── getDomains ───
@@ -216,6 +246,18 @@ describe('NetworkInspector', () => {
     expect(inspector.getDomains()).toEqual([
       expect.objectContaining({ domain: 'b.com', requests: 1 }),
     ]);
+  });
+
+  // ─── setTabIdResolver ───
+
+  it('setTabIdResolver stores a resolver that can be invoked', () => {
+    const resolver = (wcId: number) => wcId === 99 ? 'tab-99' : null;
+    inspector.setTabIdResolver(resolver);
+    // Verify the resolver is stored by accessing internal state
+    const internal = inspector as unknown as { tabIdResolver?: (wcId: number) => string | null };
+    expect(internal.tabIdResolver).toBe(resolver);
+    expect(internal.tabIdResolver!(99)).toBe('tab-99');
+    expect(internal.tabIdResolver!(1)).toBeNull();
   });
 
   // ─── addRequest & sliding window ───


### PR DESCRIPTION
## Summary
Add 525 lines of tests to improve Codecov patch coverage for the DevTools tab-scoping changes (#120).

## Coverage improvements
- `src/api/routes/devtools.ts` — 37% → tests for all tab-scoped routes (404 unknown tab, empty responses, scope metadata)
- `src/api/routes/network.ts` — 42% → tests for all 5 network routes with tab header
- `src/network/inspector.ts` — 77% → HAR scope labels, wcId filtering, tabIdResolver
- `src/mcp/tools/devtools.ts` — 80% → network/console clear with tabId forwarding

## Test plan
- [x] `npx vitest run` — 2126 tests passing
- [x] `npx eslint` — clean