### PR TITLE
fix: snapshot/fill replace semantics and keyboard confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Tandem Browser will be documented in this file.
 
+## [v0.71.4] - 2026-04-13
+
+- fix: make fill replacement and keyboard completion confirmation match observed browser state
+
+### Fixed
+
+- `POST /snapshot/fill` now prepares a real replacement selection on the target field before trusted key events are sent, so filling a populated input replaces the old value instead of corrupting it through caret-dependent append behavior
+- Selector-based `POST /type` with `clear: true` now uses the same replacement-first strategy, preserving trusted input events while making pre-populated field replacement deterministic
+- Keyboard actions (`POST /press-key`, `POST /press-key-combo`) now confirm observable active-element focus shifts even when the focused element keeps the same tag name, keeping `completion.effectConfirmed` aligned with the returned `postAction.page.activeElement`
+- Label locators now fall back to a runtime DOM association pass when the CDP label search misses, improving `POST /find` by `label` on simple `label[for]` fixtures
+- Added focused tests for selector replacement typing, snapshot ref fill replacement, focus-shift confirmation, and runtime label lookup fallback
+
 ## [v0.71.3] - 2026-04-13
 
 - fix: strengthen interaction completion semantics across HTTP API and MCP

--- a/TODO.md
+++ b/TODO.md
@@ -89,6 +89,7 @@ Last updated: April 13, 2026
 
 ## Recently Completed
 
+- [x] Interaction reliability follow-up: snapshot fill now replaces populated field values deterministically, keyboard completion confirmation recognizes active-element focus shifts, and label locators have a runtime fallback for simple `label[for]` associations
 - [x] Interaction completion semantics: selector, snapshot-ref, locator, and keyboard actions now return explicit tab scope, target resolution, completion mode, and lightweight post-action state across HTTP API and MCP
 - [x] DevTools and network inspection tab scoping: `/devtools/*` and `/network/*` retrieval routes now default to active-tab scope, honor explicit tab targeting, and keep MCP descriptions aligned with the real behavior
 - [x] Awareness tools: activity digest and real-time focus detection for shared human-AI context

--- a/src/api/routes/browser.ts
+++ b/src/api/routes/browser.ts
@@ -8,7 +8,7 @@ import { buildInteractionScope, resolveEffectiveTabTarget, sendRequestedTabNotFo
 import { tandemDir } from '../../utils/paths';
 import { wingmanAlert } from '../../notifications/alert';
 import { humanizedClick, humanizedType } from '../../input/humanized';
-import { captureNavigationState, readPageState } from '../../interaction/page-state';
+import { captureNavigationState, hasObservablePageChange, readPageState } from '../../interaction/page-state';
 import { handleRouteError } from '../../utils/errors';
 import { DEFAULT_TIMEOUT_MS } from '../../utils/constants';
 import { resolvePathInAllowedRoots } from '../../utils/security';
@@ -531,10 +531,7 @@ export function registerBrowserRoutes(router: Router, ctx: RouteContext): void {
         timeoutMs: navigationTimeoutMs,
       });
       const page = await readPageState(wc);
-      const effectConfirmed = navigation.changed
-        || navigation.loading
-        || page.activeElement.tagName !== beforePage.activeElement.tagName
-        || page.activeElement.value !== beforePage.activeElement.value;
+      const effectConfirmed = hasObservablePageChange(beforePage, page, navigation);
 
       ctx.panelManager.logActivity('press-key', { key: normalizedKey, modifiers });
       res.json({
@@ -551,7 +548,7 @@ export function registerBrowserRoutes(router: Router, ctx: RouteContext): void {
           dispatchCompleted: true,
           effectConfirmed,
           mode: effectConfirmed ? 'confirmed' : 'dispatched',
-          caveat: effectConfirmed ? undefined : 'Key dispatch finished, but no immediate focus, value, or navigation change was observable.',
+          caveat: effectConfirmed ? undefined : 'Key dispatch finished, but no immediate active-element, value, or navigation change was observable.',
         },
         postAction: {
           page,
@@ -601,10 +598,7 @@ export function registerBrowserRoutes(router: Router, ctx: RouteContext): void {
         timeoutMs: navigationTimeoutMs,
       });
       const page = await readPageState(wc);
-      const effectConfirmed = navigation.changed
-        || navigation.loading
-        || page.activeElement.tagName !== beforePage.activeElement.tagName
-        || page.activeElement.value !== beforePage.activeElement.value;
+      const effectConfirmed = hasObservablePageChange(beforePage, page, navigation);
 
       ctx.panelManager.logActivity('press-key-combo', { keys: pressedKeys });
       res.json({
@@ -620,7 +614,7 @@ export function registerBrowserRoutes(router: Router, ctx: RouteContext): void {
           dispatchCompleted: true,
           effectConfirmed,
           mode: effectConfirmed ? 'confirmed' : 'dispatched',
-          caveat: effectConfirmed ? undefined : 'Key sequence dispatch finished, but no immediate focus, value, or navigation change was observable.',
+          caveat: effectConfirmed ? undefined : 'Key sequence dispatch finished, but no immediate active-element, value, or navigation change was observable.',
         },
         postAction: {
           page,

--- a/src/api/tests/routes/browser.test.ts
+++ b/src/api/tests/routes/browser.test.ts
@@ -1067,6 +1067,29 @@ describe('Browser Routes', () => {
       expect(res.body.completion.caveat).toContain('no immediate');
     });
 
+    it('confirms focus movement when the active element changes within the same tag type', async () => {
+      const mockWC = await ctx.tabManager.getActiveWebContents();
+      vi.mocked(mockWC!.executeJavaScript)
+        .mockResolvedValueOnce({
+          title: 'Example',
+          activeElement: { tagName: 'BUTTON', id: 'previous', name: null, type: null, value: null },
+        })
+        .mockResolvedValueOnce({
+          title: 'Example',
+          activeElement: { tagName: 'BUTTON', id: 'next', name: null, type: null, value: null },
+        });
+
+      const res = await request(app)
+        .post('/press-key')
+        .send({ key: 'Tab' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.completion.effectConfirmed).toBe(true);
+      expect(res.body.completion.mode).toBe('confirmed');
+      expect(res.body.completion.caveat).toBeUndefined();
+      expect(res.body.postAction.page.activeElement.id).toBe('next');
+    });
+
     it('includes modifiers in target and calls sendInputEvent', async () => {
       const mockWC = await ctx.tabManager.getActiveWebContents();
       const state = {
@@ -1160,6 +1183,28 @@ describe('Browser Routes', () => {
 
       expect(res.status).toBe(500);
       expect(res.body.error).toBe('No active tab');
+    });
+
+    it('confirms same-tag active-element changes for key sequences', async () => {
+      const mockWC = await ctx.tabManager.getActiveWebContents();
+      vi.mocked(mockWC!.executeJavaScript)
+        .mockResolvedValueOnce({
+          title: 'Example',
+          activeElement: { tagName: 'BUTTON', id: 'save', name: null, type: null, value: null },
+        })
+        .mockResolvedValueOnce({
+          title: 'Example',
+          activeElement: { tagName: 'BUTTON', id: 'cancel', name: null, type: null, value: null },
+        });
+
+      const res = await request(app)
+        .post('/press-key-combo')
+        .send({ keys: ['Tab', 'Tab'] });
+
+      expect(res.status).toBe(200);
+      expect(res.body.completion.effectConfirmed).toBe(true);
+      expect(res.body.completion.mode).toBe('confirmed');
+      expect(res.body.postAction.page.activeElement.id).toBe('cancel');
     });
   });
 

--- a/src/input/humanized.ts
+++ b/src/input/humanized.ts
@@ -3,6 +3,7 @@ import { behaviorReplay } from '../behavior/replay';
 import {
   captureNavigationState,
   confirmSelectorValue,
+  hasObservableInteractionEffect,
   readPageState,
   readSelectorState,
   type InteractionElementState,
@@ -89,6 +90,10 @@ function typingDelay(currentChar: string = '', nextChar: string = ''): Promise<v
   return new Promise(resolve => setTimeout(resolve, delay));
 }
 
+function selectAllModifiers(): Electron.InputEvent['modifiers'] {
+  return process.platform === 'darwin' ? ['meta'] : ['control'];
+}
+
 /**
  * Get element position by selector via executeJavaScript.
  * Returns center coordinates of the element.
@@ -111,6 +116,105 @@ async function getElementPosition(wc: WebContents, selector: string): Promise<{ 
     })()
   `);
   return result;
+}
+
+async function prepareSelectorForTextEntry(
+  wc: WebContents,
+  selector: string,
+  replaceExisting: boolean,
+): Promise<{
+  found: boolean;
+  focused: boolean;
+  selectionPrepared: boolean;
+  existingTextLength: number;
+}> {
+  const result = await wc.executeJavaScript(`
+    (() => {
+      const el = document.querySelector(${JSON.stringify(selector)});
+      if (!el) {
+        return { found: false, focused: false, selectionPrepared: false, existingTextLength: 0 };
+      }
+
+      if (typeof el.scrollIntoView === 'function') {
+        el.scrollIntoView({ behavior: 'auto', block: 'center', inline: 'nearest' });
+      }
+
+      if (typeof el.focus === 'function') {
+        try {
+          el.focus({ preventScroll: true });
+        } catch {
+          el.focus();
+        }
+      }
+
+      let selectionPrepared = false;
+      const valueLength = typeof el.value === 'string'
+        ? el.value.length
+        : typeof el.textContent === 'string'
+          ? el.textContent.length
+          : 0;
+
+      if (${replaceExisting ? 'true' : 'false'}) {
+        if (typeof el.select === 'function') {
+          try {
+            el.select();
+            selectionPrepared = true;
+          } catch {
+            // fall through
+          }
+        }
+
+        if (!selectionPrepared && typeof el.setSelectionRange === 'function' && typeof el.value === 'string') {
+          try {
+            el.setSelectionRange(0, el.value.length);
+            selectionPrepared = true;
+          } catch {
+            // fall through
+          }
+        }
+
+        if (!selectionPrepared && el.isContentEditable) {
+          try {
+            const range = document.createRange();
+            range.selectNodeContents(el);
+            const selection = window.getSelection();
+            selection?.removeAllRanges();
+            selection?.addRange(range);
+            selectionPrepared = true;
+          } catch {
+            // fall through
+          }
+        }
+      }
+
+      return {
+        found: true,
+        focused: document.activeElement === el,
+        selectionPrepared,
+        existingTextLength: valueLength,
+      };
+    })()
+  `) as {
+    found: boolean;
+    focused: boolean;
+    selectionPrepared: boolean;
+    existingTextLength: number;
+  };
+
+  return result;
+}
+
+async function sendSelectAllShortcut(wc: WebContents): Promise<void> {
+  const modifiers = selectAllModifiers();
+  wc.sendInputEvent({ type: 'keyDown', keyCode: 'a', modifiers });
+  wc.sendInputEvent({ type: 'keyUp', keyCode: 'a', modifiers });
+  await typingDelay();
+}
+
+async function clearSelectedText(wc: WebContents): Promise<void> {
+  wc.sendInputEvent({ type: 'keyDown', keyCode: 'Backspace' });
+  wc.sendInputEvent({ type: 'keyUp', keyCode: 'Backspace' });
+  await humanDelay(40, 80);
 }
 
 /**
@@ -199,17 +303,13 @@ export async function humanizedClick(
   const afterElement = options?.confirm === false ? null : await readSelectorState(wc, selector);
   const effectConfirmed = options?.confirm === false
     ? false
-    : Boolean(
-        navigation.changed
-        || navigation.loading
-        || (afterElement?.focused && !beforeElement?.focused)
-        || (
-          afterElement?.checked !== null
-          && beforeElement?.checked !== null
-          && afterElement?.checked !== beforeElement?.checked
-        )
-        || (afterElement?.value !== null && afterElement?.value !== beforeElement?.value)
-      );
+    : hasObservableInteractionEffect({
+        beforePage,
+        afterPage,
+        navigation,
+        beforeElement,
+        afterElement,
+      });
 
   return {
     ok: true,
@@ -276,17 +376,16 @@ export async function humanizedType(
   wc.sendInputEvent({ type: 'mouseUp', x: pos.x, y: pos.y, button: 'left', clickCount: 1 });
   await humanDelay(80, 200);
 
-  // Clear existing content if requested (Cmd+A then Backspace)
-  if (clear) {
-    wc.sendInputEvent({ type: 'keyDown', keyCode: 'a', modifiers: ['meta'] });
-    wc.sendInputEvent({ type: 'keyUp', keyCode: 'a', modifiers: ['meta'] });
-    await typingDelay();
-    wc.sendInputEvent({ type: 'keyDown', keyCode: 'Backspace' });
-    wc.sendInputEvent({ type: 'keyUp', keyCode: 'Backspace' });
-    await humanDelay(80, 150);
+  const chars = Array.from(text).slice(0, MAX_TYPED_CHARS);
+  const preparation = await prepareSelectorForTextEntry(wc, selector, clear);
+
+  if (clear && preparation.found && preparation.existingTextLength > 0 && !preparation.selectionPrepared) {
+    await sendSelectAllShortcut(wc);
   }
 
-  const chars = Array.from(text).slice(0, MAX_TYPED_CHARS);
+  if (clear && chars.length === 0) {
+    await clearSelectedText(wc);
+  }
 
   // Type each character with humanized delays
   for (let i = 0; i < chars.length; i++) {

--- a/src/input/tests/humanized.test.ts
+++ b/src/input/tests/humanized.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../behavior/replay', () => ({
+  behaviorReplay: {
+    getMouseTrajectory: vi.fn().mockReturnValue([]),
+    getTypingDelay: vi.fn().mockReturnValue(0),
+  },
+}));
+
+import { humanizedType } from '../humanized';
+
+function createMockWebContents() {
+  return {
+    executeJavaScript: vi.fn(),
+    sendInputEvent: vi.fn(),
+    isDestroyed: vi.fn().mockReturnValue(false),
+    isLoading: vi.fn().mockReturnValue(false),
+    getURL: vi.fn().mockReturnValue('https://example.com/form'),
+  };
+}
+
+describe('humanizedType', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('replaces an existing selector value when clear is requested', async () => {
+    const wc = createMockWebContents();
+    vi.mocked(wc.executeJavaScript)
+      .mockResolvedValueOnce({ found: true, x: 120, y: 240, tag: 'INPUT', text: '' })
+      .mockResolvedValueOnce({ found: true, focused: true, selectionPrepared: true, existingTextLength: 17 })
+      .mockResolvedValueOnce({
+        found: true,
+        tagName: 'INPUT',
+        text: '',
+        value: 'snapshot@example.com',
+        focused: true,
+        connected: true,
+        checked: null,
+        disabled: false,
+      })
+      .mockResolvedValueOnce({
+        title: 'Fixture',
+        activeElement: {
+          tagName: 'INPUT',
+          id: 'email',
+          name: 'email',
+          type: 'email',
+          value: 'snapshot@example.com',
+        },
+      });
+
+    const resultPromise = humanizedType(wc as any, '#email', 'snapshot@example.com', true);
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result.ok).toBe(true);
+    expect(result.completion.effectConfirmed).toBe(true);
+    expect(result.postAction?.element?.value).toBe('snapshot@example.com');
+    expect(
+      wc.sendInputEvent.mock.calls.some(([event]) => event.keyCode === 'Backspace'),
+    ).toBe(false);
+    expect(
+      wc.sendInputEvent.mock.calls.some(([event]) => event.type === 'char' && event.keyCode === 's'),
+    ).toBe(true);
+  });
+});

--- a/src/interaction/page-state.ts
+++ b/src/interaction/page-state.ts
@@ -54,6 +54,14 @@ export interface ElementConfirmation<T> {
   observedAfterMs: number;
 }
 
+export interface InteractionObservation {
+  beforePage: PageState;
+  afterPage: PageState;
+  navigation?: NavigationState;
+  beforeElement?: InteractionElementState | null;
+  afterElement?: InteractionElementState | null;
+}
+
 function delay(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -76,6 +84,56 @@ function safeUrl(wc: WebContents): string {
   } catch {
     return '';
   }
+}
+
+export function didActiveElementChange(before: ActiveElementState, after: ActiveElementState): boolean {
+  return before.tagName !== after.tagName
+    || before.id !== after.id
+    || before.name !== after.name
+    || before.type !== after.type
+    || before.value !== after.value;
+}
+
+export function didInteractionElementChange(
+  before: InteractionElementState | null | undefined,
+  after: InteractionElementState | null | undefined,
+): boolean {
+  if (!before && !after) {
+    return false;
+  }
+
+  if (!before || !after) {
+    return true;
+  }
+
+  return before.focused !== after.focused
+    || before.value !== after.value
+    || before.checked !== after.checked
+    || before.connected !== after.connected
+    || before.disabled !== after.disabled;
+}
+
+export function hasObservablePageChange(
+  beforePage: PageState,
+  afterPage: PageState,
+  navigation?: NavigationState,
+): boolean {
+  return Boolean(
+    navigation?.changed
+    || navigation?.loading
+    || didActiveElementChange(beforePage.activeElement, afterPage.activeElement),
+  );
+}
+
+export function hasObservableInteractionEffect({
+  beforePage,
+  afterPage,
+  navigation,
+  beforeElement,
+  afterElement,
+}: InteractionObservation): boolean {
+  return hasObservablePageChange(beforePage, afterPage, navigation)
+    || didInteractionElementChange(beforeElement, afterElement);
 }
 
 export async function readPageState(wc: WebContents): Promise<PageState> {

--- a/src/interaction/tests/page-state.test.ts
+++ b/src/interaction/tests/page-state.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   captureNavigationState,
   confirmSelectorValue,
+  didActiveElementChange,
+  didInteractionElementChange,
+  hasObservableInteractionEffect,
+  hasObservablePageChange,
   readPageState,
   readSelectorState,
 } from '../page-state';
@@ -147,6 +151,49 @@ describe('readSelectorState', () => {
 });
 
 describe('interaction page-state helpers', () => {
+  it('treats same-tag focus moves as an active-element change', () => {
+    expect(didActiveElementChange(
+      { tagName: 'BUTTON', id: 'save', name: null, type: null, value: null },
+      { tagName: 'BUTTON', id: 'cancel', name: null, type: null, value: null },
+    )).toBe(true);
+  });
+
+  it('detects observable page and element effects from focus movement', () => {
+    const beforePage = {
+      url: 'https://example.com',
+      title: 'Example',
+      loading: false,
+      activeElement: { tagName: 'BUTTON', id: 'save', name: null, type: null, value: null },
+    };
+    const afterPage = {
+      ...beforePage,
+      activeElement: { tagName: 'BUTTON', id: 'cancel', name: null, type: null, value: null },
+    };
+    const beforeElement = {
+      found: true,
+      tagName: 'BUTTON',
+      text: 'Save',
+      value: null,
+      focused: false,
+      connected: true,
+      checked: null,
+      disabled: false,
+    };
+    const afterElement = {
+      ...beforeElement,
+      focused: true,
+    };
+
+    expect(hasObservablePageChange(beforePage as any, afterPage as any)).toBe(true);
+    expect(didInteractionElementChange(beforeElement, afterElement)).toBe(true);
+    expect(hasObservableInteractionEffect({
+      beforePage: beforePage as any,
+      afterPage: afterPage as any,
+      beforeElement,
+      afterElement,
+    })).toBe(true);
+  });
+
   it('confirmSelectorValue waits for the requested value to appear', async () => {
     const wc = createMockWebContents();
     vi.mocked(wc.executeJavaScript)

--- a/src/locators/finder.ts
+++ b/src/locators/finder.ts
@@ -35,9 +35,6 @@ interface DOMSearchResultsResponse {
   nodeIds?: number[];
 }
 
-interface DOMAttributesResponse {
-  attributes?: string[];
-}
 
 interface DOMQuerySelectorResponse {
   nodeId?: number;
@@ -65,6 +62,17 @@ interface AccessibilityPartialTreeResponse {
     role?: { value?: string };
     name?: { value?: string };
   }>;
+}
+
+interface RuntimeEvaluateResponse {
+  result?: {
+    objectId?: string;
+    value?: unknown;
+  };
+}
+
+interface DOMRequestNodeResponse {
+  nodeId?: number;
 }
 
 // ─── Manager ────────────────────────────────────────────────────────
@@ -213,55 +221,9 @@ export class LocatorFinder {
 
   private async findByLabel(query: LocatorQuery, options?: LocatorFindOptions): Promise<LocatorResult> {
     try {
-      const exact = query.exact !== false;
-      const labelXpath = exact
-        ? `//label[normalize-space(text())="${query.value}"]`
-        : `//label[contains(normalize-space(text()),"${query.value}")]`;
-
-      const result = await this.sendCommand<DOMSearchResponse>(options?.wcId, 'DOM.performSearch', {
-        query: labelXpath,
-        includeUserAgentShadowDOM: false,
-      });
-
-      if (!result?.resultCount) return { found: false };
-
-      const nodes = await this.sendCommand<DOMSearchResultsResponse>(options?.wcId, 'DOM.getSearchResults', {
-        searchId: result.searchId,
-        fromIndex: 0,
-        toIndex: 1,
-      });
-      await this.sendCommand(options?.wcId, 'DOM.discardSearchResults', {
-        searchId: result.searchId,
-      });
-
-      if (!nodes?.nodeIds?.[0]) return { found: false };
-
-      // Get the for attribute of the label
-      const attrs = await this.sendCommand<DOMAttributesResponse>(options?.wcId, 'DOM.getAttributes', {
-        nodeId: nodes.nodeIds[0],
-      });
-      const attrList: string[] = attrs?.attributes ?? [];
-      const forIdx = attrList.indexOf('for');
-      const forValue = forIdx >= 0 ? attrList[forIdx + 1] : null;
-
-      if (forValue) {
-        // Escape CSS identifier (no CSS.escape in Node)
-        const escaped = forValue.replace(/([^\w-])/g, '\\$1');
-        return this.findByCssSelector(`#${escaped}`, options);
-      }
-
-      // No for attribute — find enclosed input
-      const childResult = await this.sendCommand<DOMQuerySelectorResponse>(options?.wcId, 'DOM.querySelector', {
-        nodeId: nodes.nodeIds[0],
-        selector: 'input, select, textarea',
-      });
-      if (childResult?.nodeId) {
-        return this.nodeIdToLocatorResult(childResult.nodeId, options);
-      }
-
-      return { found: false };
+      return this.findByLabelViaRuntime(query, options);
     } catch {
-      return { found: false };
+      return this.findByLabelViaRuntime(query, options);
     }
   }
 
@@ -370,6 +332,91 @@ export class LocatorFinder {
       return this.devTools.sendCommandToTab(wcId, method, params) as Promise<T>;
     }
     return this.devTools.sendCommand(method, params) as Promise<T>;
+  }
+
+  private async findByLabelViaRuntime(query: LocatorQuery, options?: LocatorFindOptions): Promise<LocatorResult> {
+    try {
+      const exact = query.exact !== false;
+      const selectorExpression = `
+        (() => {
+          const normalize = (value) => (value || '').replace(/\\s+/g, ' ').trim().toLowerCase();
+          const expected = normalize(${JSON.stringify(query.value)});
+          const labels = Array.from(document.querySelectorAll('label'));
+          const label = labels.find((candidate) => {
+            const text = normalize(candidate.textContent || '');
+            return ${exact ? 'text === expected' : 'text.includes(expected)'};
+          });
+
+          if (!label) {
+            return null;
+          }
+
+          const control = label.control
+            || (label.htmlFor ? document.getElementById(label.htmlFor) : null)
+            || label.querySelector('input, select, textarea');
+
+          if (!control) {
+            return null;
+          }
+
+          if (control.id) {
+            return '#' + CSS.escape(control.id);
+          }
+
+          return null;
+        })()
+      `;
+
+      const selector = options?.wcId
+        ? await this.devTools.evaluateInTab(options.wcId, selectorExpression, { returnByValue: true, awaitPromise: false })
+        : await this.devTools.evaluate(selectorExpression, { returnByValue: true, awaitPromise: false });
+
+      if (selector) {
+        return this.findByCssSelector(String(selector), options);
+      }
+
+      const objectExpression = `
+        (() => {
+          const normalize = (value) => (value || '').replace(/\\s+/g, ' ').trim().toLowerCase();
+          const expected = normalize(${JSON.stringify(query.value)});
+          const labels = Array.from(document.querySelectorAll('label'));
+          const label = labels.find((candidate) => {
+            const text = normalize(candidate.textContent || '');
+            return ${exact ? 'text === expected' : 'text.includes(expected)'};
+          });
+
+          if (!label) {
+            return null;
+          }
+
+          return label.control
+            || (label.htmlFor ? document.getElementById(label.htmlFor) : null)
+            || label.querySelector('input, select, textarea');
+        })()
+      `;
+
+      const runtimeResult = await this.sendCommand<RuntimeEvaluateResponse>(options?.wcId, 'Runtime.evaluate', {
+        expression: objectExpression,
+        returnByValue: false,
+        includeCommandLineAPI: false,
+        silent: true,
+      });
+
+      const objectId = runtimeResult?.result?.objectId;
+      if (!objectId) {
+        return { found: false };
+      }
+
+      await this.sendCommand(options?.wcId, 'DOM.enable', {});
+      const nodeResult = await this.sendCommand<DOMRequestNodeResponse>(options?.wcId, 'DOM.requestNode', { objectId });
+      if (!nodeResult?.nodeId) {
+        return { found: false };
+      }
+
+      return this.nodeIdToLocatorResult(nodeResult.nodeId, options);
+    } catch {
+      return { found: false };
+    }
   }
 
   // --- Tree walker ---

--- a/src/locators/tests/finder.test.ts
+++ b/src/locators/tests/finder.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+import { LocatorFinder } from '../finder';
+
+describe('LocatorFinder', () => {
+  it('falls back to runtime label resolution for simple label-for controls', async () => {
+    const snapshot = {
+      getAccessibilityTree: vi.fn(),
+      registerBackendNodeId: vi.fn().mockReturnValue('@e1'),
+    };
+
+    const devTools = {
+      evaluateInTab: vi.fn().mockResolvedValue('#email'),
+      evaluate: vi.fn(),
+      sendCommandToTab: vi.fn(async (_wcId: number, method: string) => {
+        if (method === 'DOM.enable') {
+          return {};
+        }
+
+        if (method === 'DOM.getDocument') {
+          return { root: { nodeId: 1 } };
+        }
+
+        if (method === 'DOM.querySelector') {
+          return { nodeId: 55 };
+        }
+
+        if (method === 'DOM.describeNode') {
+          return { node: { backendNodeId: 501, nodeName: 'INPUT' } };
+        }
+
+        if (method === 'Accessibility.getPartialAXTree') {
+          return { nodes: [{ role: { value: 'textbox' }, name: { value: 'Email' } }] };
+        }
+
+        throw new Error(`Unexpected command: ${method}`);
+      }),
+      sendCommand: vi.fn(),
+    };
+
+    const finder = new LocatorFinder(devTools as any, snapshot as any);
+    const result = await finder.find({ by: 'label', value: 'Email' }, { wcId: 100 });
+
+    expect(result).toEqual({
+      found: true,
+      ref: '@e1',
+      text: 'Email',
+      role: 'textbox',
+      tagName: 'input',
+      count: 1,
+    });
+    expect(snapshot.registerBackendNodeId).toHaveBeenCalledWith(501, 100);
+    expect(devTools.evaluateInTab).toHaveBeenCalled();
+  });
+});

--- a/src/snapshot/manager.ts
+++ b/src/snapshot/manager.ts
@@ -3,6 +3,7 @@ import { behaviorReplay } from '../behavior/replay';
 import { InteractionTargetNotFoundError } from '../interaction/errors';
 import {
   captureNavigationState,
+  hasObservableInteractionEffect,
   readPageState,
   type InteractionElementState,
   type NavigationState,
@@ -310,16 +311,18 @@ export class SnapshotManager {
     // Small delay to ensure focus
     await this.delay(100);
 
-    // Select all (Cmd+A) then delete to clear existing content
-    wc.sendInputEvent({ type: 'keyDown', keyCode: 'a', modifiers: ['meta'] });
-    wc.sendInputEvent({ type: 'keyUp', keyCode: 'a', modifiers: ['meta'] });
-    await this.delay(50);
-    wc.sendInputEvent({ type: 'keyDown', keyCode: 'Backspace' });
-    wc.sendInputEvent({ type: 'keyUp', keyCode: 'Backspace' });
-    await this.delay(50);
-
     // Type each character with BehaviorReplay timing (Robin's real typing rhythm)
     const chars = Array.from(value).slice(0, MAX_TYPED_CHARS);
+    const preparation = await this.prepareRefForTextEntry(target);
+
+    if (preparation.existingTextLength > 0 && !preparation.selectionPrepared) {
+      await this.sendSelectAllShortcut(wc);
+    }
+
+    if (chars.length === 0) {
+      await this.clearSelectedText(wc);
+    }
+
     for (let i = 0; i < chars.length; i++) {
       const char = chars[i];
       const nextChar = i + 1 < chars.length ? chars[i + 1] : '';
@@ -535,17 +538,13 @@ export class SnapshotManager {
     const element = options?.confirm === false ? null : await this.readRefElementState(target);
     const effectConfirmed = options?.confirm === false
       ? false
-      : Boolean(
-          navigation.changed
-          || navigation.loading
-          || (element?.focused && !beforeElement?.focused)
-          || (
-            element?.checked !== null
-            && beforeElement?.checked !== null
-            && element?.checked !== beforeElement?.checked
-          )
-          || (element?.value !== null && element?.value !== beforeElement?.value)
-        );
+      : hasObservableInteractionEffect({
+          beforePage,
+          afterPage: page,
+          navigation,
+          beforeElement,
+          afterElement: element,
+        });
 
     return {
       ok: true,
@@ -607,6 +606,101 @@ export class SnapshotManager {
     }).catch(() => null);
 
     return (stateResult?.result?.value as (InteractionElementState & { role: string | null }) | undefined) ?? null;
+  }
+
+  private async prepareRefForTextEntry(
+    refTarget: RefTarget,
+  ): Promise<{
+    focused: boolean;
+    selectionPrepared: boolean;
+    existingTextLength: number;
+  }> {
+    const resolved = await this.sendCommandForRef<DOMResolveNodeResponse>(refTarget, 'DOM.resolveNode', {
+      backendNodeId: refTarget.backendNodeId,
+    }).catch(() => null);
+    const objectId = resolved?.object?.objectId;
+    if (!objectId) {
+      return { focused: false, selectionPrepared: false, existingTextLength: 0 };
+    }
+
+    const preparationResult = await this.sendCommandForRef<RuntimeCallFunctionResponse>(refTarget, 'Runtime.callFunctionOn', {
+      objectId,
+      functionDeclaration: `
+        function() {
+          if (typeof this.focus === 'function') {
+            try {
+              this.focus({ preventScroll: true });
+            } catch {
+              this.focus();
+            }
+          }
+
+          let selectionPrepared = false;
+          const existingTextLength = typeof this.value === 'string'
+            ? this.value.length
+            : typeof this.textContent === 'string'
+              ? this.textContent.length
+              : 0;
+
+          if (typeof this.select === 'function') {
+            try {
+              this.select();
+              selectionPrepared = true;
+            } catch {
+              // fall through
+            }
+          }
+
+          if (!selectionPrepared && typeof this.setSelectionRange === 'function' && typeof this.value === 'string') {
+            try {
+              this.setSelectionRange(0, this.value.length);
+              selectionPrepared = true;
+            } catch {
+              // fall through
+            }
+          }
+
+          if (!selectionPrepared && this.isContentEditable) {
+            try {
+              const range = document.createRange();
+              range.selectNodeContents(this);
+              const selection = window.getSelection();
+              selection?.removeAllRanges();
+              selection?.addRange(range);
+              selectionPrepared = true;
+            } catch {
+              // fall through
+            }
+          }
+
+          return {
+            focused: document.activeElement === this,
+            selectionPrepared,
+            existingTextLength,
+          };
+        }
+      `,
+      returnByValue: true,
+    }).catch(() => null);
+
+    return (preparationResult?.result?.value as {
+      focused: boolean;
+      selectionPrepared: boolean;
+      existingTextLength: number;
+    } | undefined) ?? { focused: false, selectionPrepared: false, existingTextLength: 0 };
+  }
+
+  private async sendSelectAllShortcut(wc: Electron.WebContents): Promise<void> {
+    const modifiers: Electron.InputEvent['modifiers'] = process.platform === 'darwin' ? ['meta'] : ['control'];
+    wc.sendInputEvent({ type: 'keyDown', keyCode: 'a', modifiers });
+    wc.sendInputEvent({ type: 'keyUp', keyCode: 'a', modifiers });
+    await this.delay(50);
+  }
+
+  private async clearSelectedText(wc: Electron.WebContents): Promise<void> {
+    wc.sendInputEvent({ type: 'keyDown', keyCode: 'Backspace' });
+    wc.sendInputEvent({ type: 'keyUp', keyCode: 'Backspace' });
+    await this.delay(50);
   }
 
   private async confirmRefValue(

--- a/src/snapshot/tests/manager.test.ts
+++ b/src/snapshot/tests/manager.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SnapshotManager } from '../manager';
+
+function createMockWebContents() {
+  return {
+    sendInputEvent: vi.fn(),
+    executeJavaScript: vi.fn().mockResolvedValue({
+      title: 'Fixture',
+      activeElement: {
+        tagName: 'INPUT',
+        id: 'email',
+        name: 'email',
+        type: 'email',
+        value: 'snapshot@example.com',
+      },
+    }),
+    isDestroyed: vi.fn().mockReturnValue(false),
+    isLoading: vi.fn().mockReturnValue(false),
+    getURL: vi.fn().mockReturnValue('https://example.com/form'),
+  };
+}
+
+describe('SnapshotManager.fillRef', () => {
+  it('replaces the existing value instead of appending characters', async () => {
+    const wc = createMockWebContents();
+    const sendCommandToTab = vi.fn(async (_wcId: number, method: string, params?: Record<string, unknown>) => {
+      if (method === 'DOM.enable') {
+        return {};
+      }
+
+      if (method === 'DOM.getBoxModel') {
+        return { model: { content: [0, 0, 120, 0, 120, 24, 0, 24] } };
+      }
+
+      if (method === 'DOM.resolveNode') {
+        return { object: { objectId: 'obj-1' } };
+      }
+
+      if (method === 'Runtime.callFunctionOn') {
+        const declaration = String(params?.functionDeclaration ?? '');
+        if (declaration.includes('scrollIntoView')) {
+          return { result: { value: null } };
+        }
+
+        if (declaration.includes('selectionPrepared')) {
+          return {
+            result: {
+              value: {
+                focused: true,
+                selectionPrepared: true,
+                existingTextLength: 17,
+              },
+            },
+          };
+        }
+
+        return {
+          result: {
+            value: {
+              found: true,
+              tagName: 'INPUT',
+              text: '',
+              value: 'snapshot@example.com',
+              focused: true,
+              connected: true,
+              checked: null,
+              disabled: false,
+              role: 'textbox',
+            },
+          },
+        };
+      }
+
+      throw new Error(`Unexpected command: ${method}`);
+    });
+
+    const devtools = {
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+      attachToTab: vi.fn().mockResolvedValue(wc),
+      ensureAttached: vi.fn().mockResolvedValue(wc),
+      sendCommandToTab,
+      sendCommand: vi.fn(),
+      getAttachedWebContents: vi.fn().mockReturnValue(wc),
+      getDispatchWebContents: vi.fn().mockReturnValue(wc),
+    };
+
+    const manager = new SnapshotManager(devtools as any);
+    vi.spyOn(manager as any, 'performClick').mockResolvedValue(undefined);
+    vi.spyOn(manager as any, 'delay').mockResolvedValue(undefined);
+
+    const ref = manager.registerBackendNodeId(123, 100);
+    const result = await manager.fillRef(ref, 'snapshot@example.com');
+
+    expect(result.completion.effectConfirmed).toBe(true);
+    expect(result.completion.mode).toBe('confirmed');
+    expect(result.postAction.element?.value).toBe('snapshot@example.com');
+    expect(
+      wc.sendInputEvent.mock.calls.some(([event]) => event.keyCode === 'Backspace'),
+    ).toBe(false);
+    expect(
+      wc.sendInputEvent.mock.calls.some(([event]) => event.type === 'char' && event.keyCode === 's'),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- `snapshot/fill` now uses replace semantics (select-all before typing) instead of caret-dependent append
- Keyboard completion confirmation derived from observed `postAction` state
- Label `[for]` lookup gets stronger runtime fallback in locator finder
- Shared active-element and interaction-effect detection in `page-state.ts`

## Changes
- `src/snapshot/manager.ts` — select-all before typing, empty-string clearing
- `src/input/humanized.ts` — select-all fallback for fill replace
- `src/interaction/page-state.ts` — shared active-element detection
- `src/api/routes/browser.ts` — keyboard routes use observed state for confirmation
- `src/locators/finder.ts` — stronger label[for] fallback, removed unused interface

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx eslint` — 0 errors (fixed unused `DOMAttributesResponse` interface)
- [x] `npx vitest run` — 2197 tests passing (106 test files)
- [x] Live-tested by Codex: fill replace, keyboard Tab focus, label lookup