### PR TITLE
[codex] Add explicit human-agent handoffs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ how it works, and why it exists.
 
 - **Repo:** `hydro13/tandem-browser` (GitHub: hydro13)
 - **Stack:** Electron 40 + TypeScript + Express.js API (`localhost:8765`) +
-  MCP server (239 tools)
+  MCP server (244 tools)
 - **Goal:** An agent-first browser where any AI (via MCP, HTTP API, or
   WebSocket) and a human browse together
 - **Philosophy:** Local-first, privacy-first, no cloud dependencies in the
@@ -39,7 +39,7 @@ tandem-browser/
 │   ├── snapshot/                 # Accessibility tree with @refs
 │   ├── network/                  # Inspector + mocking
 │   ├── sessions/                 # Multi-session isolation
-│   ├── mcp/                      # MCP server (239 tools, full API parity)
+│   ├── mcp/                      # MCP server (244 tools, full API parity)
 │   │   ├── server.ts             # MCP server entry point
 │   │   └── tools/                # Tool definitions (one file per domain)
 │   ├── agents/                   # TaskManager, X-Scout, TabLockManager

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to Tandem Browser will be documented in this file.
 - `POST /wingman-alert` now acts as a compatibility wrapper over the handoff system, preserving the old alert behavior while also creating a durable `needs_human` handoff
 - Task approval requests now also appear as structured handoffs instead of only transient approval cards, keeping human attention requests visible in one place
 - Wingman Activity logging now records handoff lifecycle updates so the user can see when a handoff was created, updated, or resolved
+- Handoff metadata normalization now treats blank titles/reasons as defaults, and focused route/MCP/manager tests cover the new handoff lifecycle more thoroughly so coverage matches the added product surface
 
 ## [v0.71.4] - 2026-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to Tandem Browser will be documented in this file.
 
+## [v0.72.0] - 2026-04-13
+
+- feat: add explicit human↔agent handoffs across API, MCP, events, and Wingman UI
+
+### Added
+
+- Durable `HandoffManager` persistence in `~/.tandem/handoffs.json` with explicit statuses for `needs_human`, `blocked`, `waiting_approval`, `ready_to_resume`, `completed_review`, and `resolved`
+- New HTTP API routes for handoff lifecycle and targeting: `GET /handoffs`, `GET /handoffs/:id`, `POST /handoffs`, `PATCH /handoffs/:id`, `POST /handoffs/:id/resolve`, and `POST /handoffs/:id/activate`
+- New MCP tools for the same handoff system: `tandem_handoff_create`, `tandem_handoff_list`, `tandem_handoff_get`, `tandem_handoff_update`, and `tandem_handoff_resolve`
+- New MCP resource `tandem://handoffs/open` plus SSE handoff events so open handoffs can be observed live
+- A real Wingman Activity inbox for open handoffs, including workspace/tab context, action hints, open-context targeting, and resolve/mark-ready actions
+
+### Changed
+
+- `POST /wingman-alert` now acts as a compatibility wrapper over the handoff system, preserving the old alert behavior while also creating a durable `needs_human` handoff
+- Task approval requests now also appear as structured handoffs instead of only transient approval cards, keeping human attention requests visible in one place
+- Wingman Activity logging now records handoff lifecycle updates so the user can see when a handoff was created, updated, or resolved
+
 ## [v0.71.4] - 2026-04-13
 
 - fix: make fill replacement and keyboard completion confirmation match observed browser state

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -10,7 +10,7 @@ bicycle: two riders, one machine, each contributing what the other can't do
 alone.
 
 The browser runs two things in parallel. The human uses it like any other browser
-while AI agents operate through a built-in **MCP server** (239 tools) or a full
+while AI agents operate through a built-in **MCP server** (244 tools) or a full
 local **HTTP API** on `127.0.0.1:8765` with 300+ endpoints for navigation,
 interaction, data extraction, automation, sessions, sync, extensions, and
 developer tooling. Websites see a normal Chrome browser on macOS. They don't see

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Coverage](https://codecov.io/gh/hydro13/tandem-browser/branch/main/graph/badge.svg)](https://codecov.io/gh/hydro13/tandem-browser)
 [![Ask a question](https://img.shields.io/badge/discussions-Q%26A-blue)](https://github.com/hydro13/tandem-browser/discussions/categories/q-a)
 
-**239 MCP tools. Plug in any AI. No scraping. No API wrangling.**
+**244 MCP tools. Plug in any AI. No scraping. No API wrangling.**
 
 Tandem is a local-first Electron browser where a human and an AI agent browse
 together. The agent sees what you see, navigates your tabs, reads your pages,
@@ -50,7 +50,7 @@ Want the fastest path in?
 | **System** | 6 | Browser status, headless mode, Google Photos, security overrides |
 | **Awareness** | 2 | Activity digest, real-time focus detection — the AI knows what you're doing |
 
-**239 tools total** — full parity with the HTTP API.
+**244 tools total** — full parity with the HTTP API.
 
 ## Why Not Just Use Playwright?
 
@@ -121,7 +121,7 @@ Add to your MCP configuration:
 }
 ```
 
-Start Tandem, and 239 tools are available immediately.
+Start Tandem, and 244 tools are available immediately.
 
 ### Cursor / Windsurf / Other MCP Clients
 

--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,7 @@ Last updated: April 13, 2026
 ## Current Snapshot
 
 - Current app version: `0.70.0`
-- MCP server: 239 tools (full API parity + awareness)
+- MCP server: 244 tools (full API parity + awareness)
 - The codebase scope is larger than this backlog summary and includes major subsystems such as `sidebar`, `workspaces`, `pinboards`, `sync`, `headless`, and `sessions`.
 - Scheduled browsing already exists in baseline form via `WatchManager` and the `/watch/*` API routes.
 - Session isolation already exists in baseline form via `SessionManager` and the `/sessions/*` API routes.

--- a/TODO.md
+++ b/TODO.md
@@ -60,6 +60,7 @@ Last updated: April 13, 2026
 - [ ] Investigate strict Gatekeeper fallback blocking mainstream site scripts when the local agent bridge is unavailable; manual startup checks on March 14, 2026 showed GitHub asset scripts being denied under `strict_low_trust_script`
 - [ ] Investigate the remaining 1Password MV3 service-worker startup noise (`DidStartWorkerFail ...: 5` and policy calculation errors) and determine whether it affects any real user-facing behavior; the old `__tandemExtensionHeaders` background error is fixed, and current manual checks indicate the extension still works for normal use
 - [ ] Make `ContextBridge` summaries natively actor/workspace-aware so `/context/summary` and other non-MCP consumers stop relying on MCP-side enrichment for ownership context
+- [ ] Expand the new handoff system with richer task linkage, agent-side resume signals, and a dedicated handoff history/detail view beyond the first Activity-tab inbox
 - [x] Add GitHub Actions verification for `npm run verify` on pushes and pull requests
 
 ## Later
@@ -89,6 +90,7 @@ Last updated: April 13, 2026
 
 ## Recently Completed
 
+- [x] Explicit human↔agent handoffs: durable handoff records with statuses (`needs_human`, `blocked`, `waiting_approval`, `ready_to_resume`, `completed_review`, `resolved`) now exist across HTTP API, MCP tools, live event surfaces, and the Wingman Activity inbox, with workspace/tab targeting and resolve/resume actions
 - [x] Interaction reliability follow-up: snapshot fill now replaces populated field values deterministically, keyboard completion confirmation recognizes active-element focus shifts, and label locators have a runtime fallback for simple `label[for]` associations
 - [x] Interaction completion semantics: selector, snapshot-ref, locator, and keyboard actions now return explicit tab scope, target resolution, completion mode, and lightweight post-action state across HTTP API and MCP
 - [x] DevTools and network inspection tab scoping: `/devtools/*` and `/network/*` retrieval routes now default to active-tab scope, honor explicit tab targeting, and keep MCP descriptions aligned with the real behavior

--- a/docs/api.html
+++ b/docs/api.html
@@ -117,7 +117,7 @@ footer a:hover{color:var(--text2)}
 <div class="hero-stats">
 <div class="stat"><span class="stat-num">280+</span><span class="stat-label">Endpoints</span></div>
 <div class="stat"><span class="stat-num">19</span><span class="stat-label">Domains</span></div>
-<div class="stat"><span class="stat-num">239</span><span class="stat-label">MCP tools</span></div>
+<div class="stat"><span class="stat-num">244</span><span class="stat-label">MCP tools</span></div>
 </div>
 </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,9 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Tandem Browser — The AI browser where human and AI work as one</title>
-<meta name="description" content="Tandem Browser is the local-first browser for real human-AI collaboration. 513 GitHub stars, 239 MCP tools, 300+ HTTP endpoints, strong security boundaries, open source MIT developer preview.">
+<meta name="description" content="Tandem Browser is the local-first browser for real human-AI collaboration. 513 GitHub stars, 244 MCP tools, 300+ HTTP endpoints, strong security boundaries, open source MIT developer preview.">
 <meta property="og:title" content="Tandem Browser">
-<meta property="og:description" content="Local-first browser for real human-AI collaboration. 513 GitHub stars, 239 MCP tools, 300+ HTTP endpoints, MIT developer preview.">
+<meta property="og:description" content="Local-first browser for real human-AI collaboration. 513 GitHub stars, 244 MCP tools, 300+ HTTP endpoints, MIT developer preview.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://tandembrowser.org">
 <link rel="canonical" href="https://tandembrowser.org">
@@ -145,7 +145,7 @@ footer a:hover{color:var(--text2)}
 <p>Tandem Browser gives AI agents secure access to a real human browser. No API wrappers, no scraping, no bot detection. The accessibility tree becomes the universal interaction layer. The AI rides alongside you, same tabs, same session, same screen.</p>
 <div class="hero-stats">
 <div class="stat"><span class="stat-num">513</span><span class="stat-label">GitHub stars</span></div>
-<div class="stat"><span class="stat-num">239</span><span class="stat-label">MCP tools</span></div>
+<div class="stat"><span class="stat-num">244</span><span class="stat-label">MCP tools</span></div>
 <div class="stat"><span class="stat-num">300+</span><span class="stat-label">HTTP endpoints</span></div>
 <div class="stat"><span class="stat-num">8</span><span class="stat-label">Security layers</span></div>
 </div>

--- a/docs/public-launch.md
+++ b/docs/public-launch.md
@@ -5,7 +5,7 @@ repository to the public.
 
 ## GitHub Repository Description
 
-Agent-first browser for human-AI collaboration — 239 MCP tools, 300+ HTTP endpoints, built-in security.
+Agent-first browser for human-AI collaboration — 244 MCP tools, 300+ HTTP endpoints, built-in security.
 
 ## Short Tagline
 
@@ -13,14 +13,14 @@ An agent-first browser for human-AI collaboration.
 
 ## Social / Announcement One-Liner
 
-Tandem Browser is now public: an agent-first browser for human-AI collaboration with 239 MCP tools and 300+ HTTP endpoints, released as a developer preview.
+Tandem Browser is now public: an agent-first browser for human-AI collaboration with 244 MCP tools and 300+ HTTP endpoints, released as a developer preview.
 
 ## Launch Post
 
 Tandem Browser is now public.
 
 Tandem is an agent-first browser built for human-AI collaboration on the local
-machine. The human browses normally. Any AI agent that speaks MCP (239 tools) or
+machine. The human browses normally. Any AI agent that speaks MCP (244 tools) or
 HTTP (300+ endpoints) gets full browser control for navigation, extraction,
 automation, screenshots, session work, and observability, while websites
 continue to see a normal Chromium browser instead of an "AI browser" fingerprint.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tandem-browser",
   "version": "0.70.0",
-  "description": "Local-first Electron browser for human-AI collaboration with 239-tool MCP server, 300+ endpoint HTTP API, and built-in security controls",
+  "description": "Local-first Electron browser for human-AI collaboration with 244-tool MCP server, 300+ endpoint HTTP API, and built-in security controls",
   "main": "dist/main.js",
   "author": "Tandem Browser contributors",
   "license": "MIT",

--- a/shell/css/wingman.css
+++ b/shell/css/wingman.css
@@ -220,6 +220,164 @@
       font-size: 10px;
     }
 
+    .handoff-inbox {
+      flex-shrink: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      padding-bottom: 10px;
+      border-bottom: 1px solid var(--border-color);
+      margin-bottom: 10px;
+    }
+
+    .handoff-inbox-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      color: var(--text);
+      font-size: 12px;
+      font-weight: 600;
+      padding: 2px 2px 0;
+    }
+
+    .handoff-count {
+      min-width: 18px;
+      padding: 1px 6px;
+      border-radius: 999px;
+      background: rgba(233, 69, 96, 0.18);
+      color: var(--accent);
+      font-size: 10px;
+      text-align: center;
+    }
+
+    .handoff-empty {
+      color: var(--text-dim);
+      font-size: 11px;
+      padding: 2px 2px 0;
+    }
+
+    .handoff-list {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      max-height: 310px;
+      overflow-y: auto;
+      padding-right: 2px;
+    }
+
+    .handoff-card {
+      padding: 10px 12px;
+      background: rgba(255, 255, 255, 0.04);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 10px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .handoff-card.status-needs_human,
+    .handoff-card.status-blocked {
+      border-color: rgba(233, 69, 96, 0.28);
+      background: rgba(233, 69, 96, 0.1);
+    }
+
+    .handoff-card.status-waiting_approval {
+      border-color: rgba(251, 191, 36, 0.28);
+      background: rgba(251, 191, 36, 0.1);
+    }
+
+    .handoff-card.status-ready_to_resume,
+    .handoff-card.status-completed_review {
+      border-color: rgba(16, 185, 129, 0.28);
+      background: rgba(16, 185, 129, 0.08);
+    }
+
+    .handoff-topline {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+    }
+
+    .handoff-status {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 2px 8px;
+      border-radius: 999px;
+      font-size: 10px;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      background: rgba(255, 255, 255, 0.08);
+      color: var(--text);
+    }
+
+    .handoff-time {
+      font-size: 10px;
+      color: var(--text-dim);
+      white-space: nowrap;
+    }
+
+    .handoff-title {
+      color: var(--text);
+      font-size: 13px;
+      font-weight: 600;
+    }
+
+    .handoff-body {
+      color: var(--text-dim);
+      font-size: 11px;
+      line-height: 1.45;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    .handoff-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+
+    .handoff-pill {
+      padding: 2px 6px;
+      border-radius: 999px;
+      font-size: 10px;
+      background: rgba(255, 255, 255, 0.08);
+      color: var(--text-dim);
+    }
+
+    .handoff-actions {
+      display: flex;
+      gap: 8px;
+    }
+
+    .handoff-actions button {
+      flex: 1;
+      padding: 6px 10px;
+      border-radius: 7px;
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      background: rgba(255, 255, 255, 0.05);
+      color: var(--text);
+      font-size: 11px;
+      cursor: pointer;
+      transition: all 0.15s;
+    }
+
+    .handoff-actions button:hover {
+      background: rgba(255, 255, 255, 0.1);
+    }
+
+    .handoff-actions .primary {
+      border-color: rgba(233, 69, 96, 0.28);
+      color: var(--accent);
+    }
+
+    .activity-feed {
+      flex: 1;
+      overflow-y: auto;
+      min-height: 0;
+    }
+
     /* Tab source indicator */
     .tab .tab-source {
       font-size: 10px;
@@ -1151,4 +1309,3 @@
     }
 
     /* END LGL STYLES */
-

--- a/shell/index.html
+++ b/shell/index.html
@@ -273,6 +273,15 @@
       <div class="panel-body" id="panel-body">
         <!-- Activity tab -->
         <div class="panel-content" id="panel-activity" style="display:none;flex-direction:column;flex:1;">
+          <div class="handoff-inbox" id="handoff-inbox">
+            <div class="handoff-inbox-header">
+              <span>Open handoffs</span>
+              <span class="handoff-count" id="handoff-count">0</span>
+            </div>
+            <div class="handoff-empty" id="handoff-empty">No open handoffs.</div>
+            <div class="handoff-list" id="handoff-list"></div>
+          </div>
+          <div class="activity-feed" id="activity-feed"></div>
         </div>
         <!-- Chat tab — Multi-backend via ChatRouter (Phase 3) -->
         <div class="panel-content" id="panel-chat"

--- a/shell/js/wingman.js
+++ b/shell/js/wingman.js
@@ -179,13 +179,180 @@
       });
 
       // Activity events
+      const activityEl = document.getElementById('activity-feed');
+      const handoffListEl = document.getElementById('handoff-list');
+      const handoffEmptyEl = document.getElementById('handoff-empty');
+      const handoffCountEl = document.getElementById('handoff-count');
+      const activityTabButton = document.querySelector('[data-panel-tab="activity"]');
+      const openHandoffs = new Map();
+
+      function formatHandoffStatus(status) {
+        const labels = {
+          needs_human: 'Needs Human',
+          blocked: 'Blocked',
+          waiting_approval: 'Waiting Approval',
+          ready_to_resume: 'Ready To Resume',
+          completed_review: 'Completed Review',
+          resolved: 'Resolved',
+        };
+        return labels[status] || status;
+      }
+
+      function formatHandoffTime(timestamp) {
+        if (!timestamp) return '';
+        return new Date(timestamp).toLocaleTimeString('nl-BE', {
+          hour: '2-digit',
+          minute: '2-digit',
+        });
+      }
+
+      function escapeHtml(s) {
+        return String(s)
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/\n/g, '<br>');
+      }
+
+      function updateActivityTabBadge() {
+        const count = openHandoffs.size;
+        if (handoffCountEl) {
+          handoffCountEl.textContent = String(count);
+        }
+        if (activityTabButton) {
+          activityTabButton.textContent = count > 0 ? `Activity (${count})` : 'Activity';
+        }
+      }
+
+      async function activateHandoff(handoffId) {
+        await fetch(`http://localhost:8765/handoffs/${handoffId}/activate`, { method: 'POST' });
+      }
+
+      async function updateHandoffStatus(handoffId, payload) {
+        await fetch(`http://localhost:8765/handoffs/${handoffId}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+      }
+
+      async function resolveHandoff(handoffId) {
+        await fetch(`http://localhost:8765/handoffs/${handoffId}/resolve`, { method: 'POST' });
+      }
+
+      async function hydrateHandoff(handoff) {
+        if (!handoff || !handoff.id) return handoff;
+        if (handoff.workspaceName || handoff.tabTitle || handoff.tabUrl) return handoff;
+        try {
+          const response = await fetch(`http://localhost:8765/handoffs/${handoff.id}`);
+          if (!response.ok) return handoff;
+          return await response.json();
+        } catch {
+          return handoff;
+        }
+      }
+
+      function renderHandoffs() {
+        if (!handoffListEl || !handoffEmptyEl) return;
+        handoffListEl.innerHTML = '';
+
+        const handoffs = Array.from(openHandoffs.values())
+          .sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
+
+        handoffEmptyEl.style.display = handoffs.length === 0 ? 'block' : 'none';
+
+        for (const handoff of handoffs) {
+          const card = document.createElement('div');
+          card.className = `handoff-card status-${handoff.status}`;
+          const meta = [];
+          if (handoff.reason) meta.push(`<span class="handoff-pill">Reason: ${escapeHtml(handoff.reason)}</span>`);
+          if (handoff.workspaceName || handoff.workspaceId) meta.push(`<span class="handoff-pill">Workspace: ${escapeHtml(handoff.workspaceName || handoff.workspaceId)}</span>`);
+          if (handoff.tabTitle || handoff.tabId) meta.push(`<span class="handoff-pill">Tab: ${escapeHtml(handoff.tabTitle || handoff.tabId)}</span>`);
+          if (handoff.source || handoff.agentId) meta.push(`<span class="handoff-pill">Source: ${escapeHtml(handoff.source || handoff.agentId)}</span>`);
+          if (handoff.actionLabel) meta.push(`<span class="handoff-pill">${escapeHtml(handoff.actionLabel)}</span>`);
+
+          card.innerHTML = `
+            <div class="handoff-topline">
+              <span class="handoff-status">${escapeHtml(formatHandoffStatus(handoff.status))}</span>
+              <span class="handoff-time">${escapeHtml(formatHandoffTime(handoff.updatedAt))}</span>
+            </div>
+            <div class="handoff-title">${escapeHtml(handoff.title || 'Untitled handoff')}</div>
+            <div class="handoff-body">${escapeHtml(handoff.body || '')}</div>
+            <div class="handoff-meta">${meta.join('')}</div>
+            <div class="handoff-actions">
+              <button class="primary" data-action="open">Open Context</button>
+              <button data-action="ready">Mark Ready</button>
+              <button data-action="resolve">${handoff.status === 'completed_review' ? 'Mark Reviewed' : 'Resolve'}</button>
+            </div>
+          `;
+
+          card.querySelector('[data-action="open"]').addEventListener('click', async () => {
+            try {
+              await activateHandoff(handoff.id);
+            } catch (e) {
+              console.error('activateHandoff failed:', e);
+            }
+          });
+
+          card.querySelector('[data-action="ready"]').addEventListener('click', async () => {
+            try {
+              await updateHandoffStatus(handoff.id, { status: 'ready_to_resume', open: true });
+            } catch (e) {
+              console.error('updateHandoffStatus failed:', e);
+            }
+          });
+
+          card.querySelector('[data-action="resolve"]').addEventListener('click', async () => {
+            try {
+              await resolveHandoff(handoff.id);
+            } catch (e) {
+              console.error('resolveHandoff failed:', e);
+            }
+          });
+
+          handoffListEl.appendChild(card);
+        }
+
+        updateActivityTabBadge();
+      }
+
+      async function applyHandoffUpdate(handoff) {
+        if (!handoff || !handoff.id) return;
+        const hydrated = await hydrateHandoff(handoff);
+        if (hydrated.open) {
+          openHandoffs.set(hydrated.id, hydrated);
+        } else {
+          openHandoffs.delete(hydrated.id);
+        }
+        renderHandoffs();
+      }
+
+      async function loadOpenHandoffs() {
+        try {
+          const response = await fetch('http://localhost:8765/handoffs?openOnly=true');
+          const data = await response.json();
+          openHandoffs.clear();
+          for (const handoff of data.handoffs || []) {
+            if (handoff.open) {
+              openHandoffs.set(handoff.id, handoff);
+            }
+          }
+          renderHandoffs();
+        } catch (e) {
+          console.error('loadOpenHandoffs failed:', e);
+        }
+      }
+
+      void loadOpenHandoffs();
+
       window.tandem.onActivityEvent((event) => {
-        const activityEl = document.getElementById('panel-activity');
-        const icons = { navigate: '🧭', click: '👆', scroll: '📜', input: '⌨️', 'tab-switch': '🔀', 'tab-open': '➕', 'tab-close': '✖️' };
+        if (!activityEl) return;
+        const icons = { navigate: '🧭', click: '👆', scroll: '📜', input: '⌨️', 'tab-switch': '🔀', 'tab-open': '➕', 'tab-close': '✖️', handoff: '🤝' };
         const icon = icons[event.type] || '•';
         const time = new Date(event.timestamp).toLocaleTimeString('nl-BE', { hour: '2-digit', minute: '2-digit', second: '2-digit' });
         let text = event.type;
-        if (event.data.url) text = `${event.type}: ${event.data.url}`;
+        if (event.type === 'handoff' && event.data.title) text = `handoff: ${event.data.title}${event.data.status ? ` (${event.data.status})` : ''}`;
+        else if (event.data.url) text = `${event.type}: ${event.data.url}`;
         else if (event.data.selector) text = `${event.type}: ${event.data.selector}`;
         else if (event.data.title) text = `${event.type}: ${event.data.title}`;
 
@@ -201,6 +368,12 @@
         // Keep max 200 items
         while (activityEl.children.length > 200) activityEl.removeChild(activityEl.firstChild);
       });
+
+      if (window.tandem.onHandoffUpdated) {
+        window.tandem.onHandoffUpdated((data) => {
+          void applyHandoffUpdate(data.handoff);
+        });
+      }
 
       // Tab source changes (🧀/👤 indicator) + AI tab visual border
       window.tandem.onTabSourceChanged((data) => {

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -22,7 +22,7 @@ instead of a sandbox browser, especially for:
 
 ### Option 1: MCP Server (recommended)
 
-The MCP server exposes 239 tools with full API parity. Add to your MCP client
+The MCP server exposes 244 tools with full API parity. Add to your MCP client
 configuration (e.g. `~/.claude/settings.json` for Claude Code):
 
 ```json
@@ -36,7 +36,7 @@ configuration (e.g. `~/.claude/settings.json` for Claude Code):
 }
 ```
 
-Start Tandem (`npm start`), and the agent has 239 tools available immediately.
+Start Tandem (`npm start`), and the agent has 244 tools available immediately.
 All MCP tools mirror the HTTP API below, so the same capabilities are available
 through either connection method.
 

--- a/src/api/routes/browser.ts
+++ b/src/api/routes/browser.ts
@@ -631,15 +631,30 @@ export function registerBrowserRoutes(router: Router, ctx: RouteContext): void {
   // ═══════════════════════════════════════════════
 
   router.post('/wingman-alert', (req: Request, res: Response) => {
-    const { title = 'Need help', body = '', workspaceId } = req.body;
+    const { title = 'Need help', body = '', workspaceId, tabId, agentId, source, actionLabel, reason } = req.body;
     if (workspaceId !== undefined && typeof workspaceId !== 'string') {
       res.status(400).json({ error: 'workspaceId must be a workspace ID string' });
+      return;
+    }
+    if (tabId !== undefined && typeof tabId !== 'string') {
+      res.status(400).json({ error: 'tabId must be a tab ID string' });
       return;
     }
     try {
       if (workspaceId) {
         ctx.workspaceManager.switch(workspaceId);
       }
+      ctx.handoffManager.create({
+        status: 'needs_human',
+        title,
+        body,
+        reason: typeof reason === 'string' && reason.trim().length > 0 ? reason : 'legacy_alert',
+        workspaceId: typeof workspaceId === 'string' ? workspaceId : null,
+        tabId: typeof tabId === 'string' ? tabId : null,
+        agentId: typeof agentId === 'string' ? agentId : null,
+        source: typeof source === 'string' ? source : 'wingman-alert',
+        actionLabel: typeof actionLabel === 'string' ? actionLabel : null,
+      });
       wingmanAlert(title, body);
       res.json({ ok: true, sent: true });
     } catch (e) {

--- a/src/api/routes/handoffs.ts
+++ b/src/api/routes/handoffs.ts
@@ -1,0 +1,350 @@
+import type { Request, Response, Router } from 'express';
+import type { RouteContext } from '../context';
+import type { Handoff, HandoffStatus, UpdateHandoffInput } from '../../handoffs/manager';
+import { HANDOFF_STATUSES } from '../../handoffs/manager';
+import { wingmanAlert } from '../../notifications/alert';
+import { handleRouteError } from '../../utils/errors';
+
+interface SerializedHandoff extends Handoff {
+  actionable: boolean;
+  workspaceName: string | null;
+  tabTitle: string | null;
+  tabUrl: string | null;
+}
+
+function isHandoffStatus(value: unknown): value is HandoffStatus {
+  return typeof value === 'string' && HANDOFF_STATUSES.includes(value as HandoffStatus);
+}
+
+function getOptionalString(value: unknown): string | null | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null) {
+    return null;
+  }
+  if (typeof value !== 'string') {
+    throw new Error('expected string');
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function isOptionalStringInput(value: unknown): boolean {
+  return value === undefined || value === null || typeof value === 'string';
+}
+
+function serializeHandoff(ctx: RouteContext, handoff: Handoff): SerializedHandoff {
+  const workspace = handoff.workspaceId ? ctx.workspaceManager.get(handoff.workspaceId) : undefined;
+  const tab = handoff.tabId
+    ? ctx.tabManager.listTabs().find(candidate => candidate.id === handoff.tabId) ?? null
+    : null;
+
+  return {
+    ...handoff,
+    actionable: handoff.open,
+    workspaceName: workspace?.name ?? null,
+    tabTitle: tab?.title ?? null,
+    tabUrl: tab?.url ?? null,
+  };
+}
+
+function resolveTargetContext(ctx: RouteContext, workspaceId: string | null | undefined, tabId: string | null | undefined): { workspaceId: string | null; tabId: string | null } {
+  const normalizedWorkspaceId = workspaceId ?? null;
+  const normalizedTabId = tabId ?? null;
+  let resolvedWorkspaceId = normalizedWorkspaceId;
+
+  if (normalizedWorkspaceId) {
+    const workspace = ctx.workspaceManager.get(normalizedWorkspaceId);
+    if (!workspace) {
+      throw new Error(`Workspace ${normalizedWorkspaceId} not found`);
+    }
+  }
+
+  if (normalizedTabId) {
+    const tab = ctx.tabManager.listTabs().find(candidate => candidate.id === normalizedTabId);
+    if (!tab) {
+      throw new Error(`Tab ${normalizedTabId} not found`);
+    }
+    const tabWorkspaceId = ctx.workspaceManager.getWorkspaceIdForTab(tab.webContentsId);
+    if (resolvedWorkspaceId && tabWorkspaceId && resolvedWorkspaceId !== tabWorkspaceId) {
+      throw new Error(`Tab ${normalizedTabId} does not belong to workspace ${resolvedWorkspaceId}`);
+    }
+    resolvedWorkspaceId = resolvedWorkspaceId ?? tabWorkspaceId ?? null;
+  }
+
+  return {
+    workspaceId: resolvedWorkspaceId,
+    tabId: normalizedTabId,
+  };
+}
+
+export function registerHandoffRoutes(router: Router, ctx: RouteContext): void {
+  router.get('/handoffs', (req: Request, res: Response) => {
+    try {
+      const openOnly = req.query.openOnly === 'true' || req.query.openOnly === '1';
+      const status = req.query.status;
+      if (status !== undefined && !isHandoffStatus(status)) {
+        res.status(400).json({ error: `status must be one of: ${HANDOFF_STATUSES.join(', ')}` });
+        return;
+      }
+
+      const workspaceId = typeof req.query.workspaceId === 'string' ? req.query.workspaceId : undefined;
+      const tabId = typeof req.query.tabId === 'string' ? req.query.tabId : undefined;
+      const taskId = typeof req.query.taskId === 'string' ? req.query.taskId : undefined;
+      const stepId = typeof req.query.stepId === 'string' ? req.query.stepId : undefined;
+
+      const handoffs = ctx.handoffManager.list({
+        openOnly,
+        status,
+        workspaceId,
+        tabId,
+        taskId,
+        stepId,
+      }).map(handoff => serializeHandoff(ctx, handoff));
+
+      res.json({ handoffs });
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+
+  router.get('/handoffs/:id', (req: Request, res: Response) => {
+    try {
+      const handoffId = req.params.id as string;
+      const handoff = ctx.handoffManager.get(handoffId);
+      if (!handoff) {
+        res.status(404).json({ error: 'Handoff not found' });
+        return;
+      }
+      res.json(serializeHandoff(ctx, handoff));
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+
+  router.post('/handoffs', (req: Request, res: Response) => {
+    try {
+      const {
+        status,
+        title,
+        body,
+        reason,
+        workspaceId,
+        tabId,
+        agentId,
+        source,
+        actionLabel,
+        taskId,
+        stepId,
+        open,
+        notify,
+      } = req.body as Record<string, unknown>;
+
+      if (!isHandoffStatus(status)) {
+        res.status(400).json({ error: `status must be one of: ${HANDOFF_STATUSES.join(', ')}` });
+        return;
+      }
+      if (typeof title !== 'string' || title.trim().length === 0) {
+        res.status(400).json({ error: 'title is required' });
+        return;
+      }
+      if (body !== undefined && typeof body !== 'string') {
+        res.status(400).json({ error: 'body must be a string' });
+        return;
+      }
+      if (reason !== undefined && typeof reason !== 'string') {
+        res.status(400).json({ error: 'reason must be a string' });
+        return;
+      }
+      for (const [field, value] of Object.entries({ workspaceId, tabId, agentId, source, actionLabel, taskId, stepId })) {
+        if (!isOptionalStringInput(value)) {
+          res.status(400).json({ error: `${field} must be a string when provided` });
+          return;
+        }
+      }
+
+      const target = resolveTargetContext(
+        ctx,
+        getOptionalString(workspaceId),
+        getOptionalString(tabId),
+      );
+
+      const handoff = ctx.handoffManager.create({
+        status,
+        title,
+        body: typeof body === 'string' ? body : undefined,
+        reason: typeof reason === 'string' ? reason : undefined,
+        workspaceId: target.workspaceId,
+        tabId: target.tabId,
+        agentId: getOptionalString(agentId),
+        source: getOptionalString(source),
+        actionLabel: getOptionalString(actionLabel),
+        taskId: getOptionalString(taskId),
+        stepId: getOptionalString(stepId),
+        open: typeof open === 'boolean' ? open : undefined,
+      });
+
+      if (notify === true) {
+        wingmanAlert(handoff.title, handoff.body || handoff.reason);
+      }
+
+      res.json(serializeHandoff(ctx, handoff));
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+
+  router.patch('/handoffs/:id', (req: Request, res: Response) => {
+    try {
+      const patchSource = req.body as Record<string, unknown>;
+      const patch: UpdateHandoffInput = {};
+
+      if (patchSource.status !== undefined) {
+        if (!isHandoffStatus(patchSource.status)) {
+          res.status(400).json({ error: `status must be one of: ${HANDOFF_STATUSES.join(', ')}` });
+          return;
+        }
+        patch.status = patchSource.status;
+      }
+
+      if (patchSource.title !== undefined) {
+        if (typeof patchSource.title !== 'string' || patchSource.title.trim().length === 0) {
+          res.status(400).json({ error: 'title must be a non-empty string' });
+          return;
+        }
+        patch.title = patchSource.title;
+      }
+
+      if (patchSource.body !== undefined) {
+        if (typeof patchSource.body !== 'string') {
+          res.status(400).json({ error: 'body must be a string' });
+          return;
+        }
+        patch.body = patchSource.body;
+      }
+
+      if (patchSource.reason !== undefined) {
+        if (typeof patchSource.reason !== 'string') {
+          res.status(400).json({ error: 'reason must be a string' });
+          return;
+        }
+        patch.reason = patchSource.reason;
+      }
+      for (const field of ['workspaceId', 'tabId', 'agentId', 'source', 'actionLabel', 'taskId', 'stepId'] as const) {
+        if (!isOptionalStringInput(patchSource[field])) {
+          res.status(400).json({ error: `${field} must be a string when provided` });
+          return;
+        }
+      }
+
+      if (patchSource.open !== undefined) {
+        if (typeof patchSource.open !== 'boolean') {
+          res.status(400).json({ error: 'open must be a boolean' });
+          return;
+        }
+        patch.open = patchSource.open;
+      }
+
+      const target = resolveTargetContext(
+        ctx,
+        getOptionalString(patchSource.workspaceId),
+        getOptionalString(patchSource.tabId),
+      );
+
+      if (patchSource.workspaceId !== undefined) {
+        patch.workspaceId = target.workspaceId;
+      }
+      if (patchSource.tabId !== undefined) {
+        patch.tabId = target.tabId;
+      }
+      if (patchSource.agentId !== undefined) {
+        patch.agentId = getOptionalString(patchSource.agentId);
+      }
+      if (patchSource.source !== undefined) {
+        patch.source = getOptionalString(patchSource.source);
+      }
+      if (patchSource.actionLabel !== undefined) {
+        patch.actionLabel = getOptionalString(patchSource.actionLabel);
+      }
+      if (patchSource.taskId !== undefined) {
+        patch.taskId = getOptionalString(patchSource.taskId);
+      }
+      if (patchSource.stepId !== undefined) {
+        patch.stepId = getOptionalString(patchSource.stepId);
+      }
+
+      const handoffId = req.params.id as string;
+      const handoff = ctx.handoffManager.update(handoffId, patch);
+      if (!handoff) {
+        res.status(404).json({ error: 'Handoff not found' });
+        return;
+      }
+
+      res.json(serializeHandoff(ctx, handoff));
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+
+  router.post('/handoffs/:id/resolve', (req: Request, res: Response) => {
+    try {
+      const handoffId = req.params.id as string;
+      const handoff = ctx.handoffManager.resolve(handoffId);
+      if (!handoff) {
+        res.status(404).json({ error: 'Handoff not found' });
+        return;
+      }
+      res.json(serializeHandoff(ctx, handoff));
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+
+  router.post('/handoffs/:id/activate', async (req: Request, res: Response) => {
+    try {
+      const handoffId = req.params.id as string;
+      const handoff = ctx.handoffManager.get(handoffId);
+      if (!handoff) {
+        res.status(404).json({ error: 'Handoff not found' });
+        return;
+      }
+
+      const tabs = ctx.tabManager.listTabs();
+      let focusedTabId: string | null = null;
+
+      if (handoff.workspaceId) {
+        const workspace = ctx.workspaceManager.get(handoff.workspaceId);
+        if (workspace) {
+          ctx.workspaceManager.switch(workspace.id);
+        }
+      }
+
+      if (handoff.tabId) {
+        const tab = tabs.find(candidate => candidate.id === handoff.tabId);
+        if (tab) {
+          await ctx.tabManager.focusTab(tab.id);
+          focusedTabId = tab.id;
+        }
+      } else if (handoff.workspaceId) {
+        const workspace = ctx.workspaceManager.get(handoff.workspaceId);
+        const targetTab = workspace?.tabIds
+          .map(webContentsId => tabs.find(tab => tab.webContentsId === webContentsId) ?? null)
+          .find((tab): tab is NonNullable<typeof tab> => Boolean(tab));
+        if (targetTab) {
+          await ctx.tabManager.focusTab(targetTab.id);
+          focusedTabId = targetTab.id;
+        }
+      }
+
+      res.json({
+        ok: true,
+        handoff: serializeHandoff(ctx, handoff),
+        activeWorkspaceId: ctx.workspaceManager.getActiveId(),
+        focusedTabId,
+      });
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+}

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -22,6 +22,7 @@ import { registerDataRoutes } from './routes/data';
 import { registerContentRoutes } from './routes/content';
 import { registerMediaRoutes } from './routes/media';
 import { registerMiscRoutes } from './routes/misc';
+import { registerHandoffRoutes } from './routes/handoffs';
 import { registerSidebarRoutes } from './routes/sidebar';
 import { registerWorkspaceRoutes } from './routes/workspaces';
 import { registerSyncRoutes } from './routes/sync';
@@ -424,6 +425,7 @@ export class TandemAPI {
     registerContentRoutes(router, ctx);
     registerMediaRoutes(router, ctx);
     registerMiscRoutes(router, ctx);
+    registerHandoffRoutes(router, ctx);
     registerSidebarRoutes(router, ctx);
     registerWorkspaceRoutes(router, ctx);
     registerSyncRoutes(router, ctx);

--- a/src/api/tests/helpers.ts
+++ b/src/api/tests/helpers.ts
@@ -377,6 +377,34 @@ export function createMockContext(): RouteContext {
       sseHandler: vi.fn(),
       getRecent: vi.fn().mockReturnValue([]),
       subscribe: vi.fn().mockReturnValue(() => {}),
+      handleHandoffEvent: vi.fn(),
+    } as any,
+
+    // ── handoffManager ──────────────────────────
+    handoffManager: {
+      list: vi.fn().mockReturnValue([]),
+      get: vi.fn().mockReturnValue(null),
+      create: vi.fn().mockReturnValue({
+        id: 'handoff-1',
+        status: 'needs_human',
+        title: 'Need help',
+        body: '',
+        reason: 'human_help',
+        workspaceId: null,
+        tabId: null,
+        agentId: null,
+        source: null,
+        actionLabel: null,
+        taskId: null,
+        stepId: null,
+        open: true,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }),
+      update: vi.fn().mockReturnValue(null),
+      resolve: vi.fn().mockReturnValue(null),
+      findOpenByTaskStep: vi.fn().mockReturnValue(null),
+      on: vi.fn(),
     } as any,
 
     // ── taskManager ─────────────────────────────

--- a/src/api/tests/routes/browser.test.ts
+++ b/src/api/tests/routes/browser.test.ts
@@ -1264,6 +1264,34 @@ describe('Browser Routes', () => {
       expect(ctx.workspaceManager.switch).not.toHaveBeenCalled();
       expect(wingmanAlert).not.toHaveBeenCalled();
     });
+
+    it('returns 400 when tabId is not a string', async () => {
+      const res = await request(app)
+        .post('/wingman-alert')
+        .send({ tabId: 42 });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('tabId must be a tab ID string');
+      expect(ctx.handoffManager.create).not.toHaveBeenCalled();
+      expect(wingmanAlert).not.toHaveBeenCalled();
+    });
+
+    it('stores legacy defaults for handoff metadata when optional fields are omitted', async () => {
+      const res = await request(app)
+        .post('/wingman-alert')
+        .send({ title: 'Captcha detected' });
+
+      expect(res.status).toBe(200);
+      expect(ctx.handoffManager.create).toHaveBeenCalledWith(expect.objectContaining({
+        title: 'Captcha detected',
+        reason: 'legacy_alert',
+        workspaceId: null,
+        tabId: null,
+        agentId: null,
+        source: 'wingman-alert',
+        actionLabel: null,
+      }));
+    });
   });
 
   // ═══════════════════════════════════════════════

--- a/src/api/tests/routes/browser.test.ts
+++ b/src/api/tests/routes/browser.test.ts
@@ -1220,6 +1220,11 @@ describe('Browser Routes', () => {
 
       expect(res.status).toBe(200);
       expect(res.body).toEqual({ ok: true, sent: true });
+      expect(ctx.handoffManager.create).toHaveBeenCalledWith(expect.objectContaining({
+        status: 'needs_human',
+        title: 'Attention',
+        body: 'Something happened',
+      }));
       expect(wingmanAlert).toHaveBeenCalledWith('Attention', 'Something happened');
     });
 
@@ -1228,6 +1233,11 @@ describe('Browser Routes', () => {
 
       expect(res.status).toBe(200);
       expect(res.body).toEqual({ ok: true, sent: true });
+      expect(ctx.handoffManager.create).toHaveBeenCalledWith(expect.objectContaining({
+        status: 'needs_human',
+        title: 'Need help',
+        body: '',
+      }));
       expect(wingmanAlert).toHaveBeenCalledWith('Need help', '');
     });
 
@@ -1238,6 +1248,9 @@ describe('Browser Routes', () => {
 
       expect(res.status).toBe(200);
       expect(ctx.workspaceManager.switch).toHaveBeenCalledWith('ws-ai');
+      expect(ctx.handoffManager.create).toHaveBeenCalledWith(expect.objectContaining({
+        workspaceId: 'ws-ai',
+      }));
       expect(wingmanAlert).toHaveBeenCalledWith('Captcha', 'Please take over');
     });
 

--- a/src/api/tests/routes/handoffs.test.ts
+++ b/src/api/tests/routes/handoffs.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+
+vi.mock('electron', () => ({
+  BrowserWindow: vi.fn(),
+  session: {},
+  webContents: {
+    fromId: vi.fn(),
+    getAllWebContents: vi.fn().mockReturnValue([]),
+  },
+}));
+
+import { registerHandoffRoutes } from '../../routes/handoffs';
+import { createMockContext, createTestApp } from '../helpers';
+import type { RouteContext } from '../../context';
+
+describe('Handoff Routes', () => {
+  let ctx: RouteContext;
+  let app: ReturnType<typeof createTestApp>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ctx = createMockContext();
+    app = createTestApp(registerHandoffRoutes, ctx);
+  });
+
+  describe('GET /handoffs', () => {
+    it('lists open handoffs with serialized context', async () => {
+      vi.mocked(ctx.handoffManager.list).mockReturnValue([
+        {
+          id: 'handoff-1',
+          status: 'needs_human',
+          title: 'Captcha detected',
+          body: 'Please solve the captcha',
+          reason: 'captcha',
+          workspaceId: 'ws-1',
+          tabId: 'tab-1',
+          agentId: 'claude',
+          source: 'claude',
+          actionLabel: 'Solve captcha and resume',
+          taskId: null,
+          stepId: null,
+          open: true,
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      ] as any);
+      vi.mocked(ctx.workspaceManager.get).mockReturnValue({
+        id: 'ws-1',
+        name: 'AI Workspace',
+        icon: 'sparkles',
+        color: '#fff',
+        tabIds: [100],
+      } as any);
+
+      const res = await request(app).get('/handoffs?openOnly=true');
+
+      expect(res.status).toBe(200);
+      expect(ctx.handoffManager.list).toHaveBeenCalledWith(expect.objectContaining({ openOnly: true }));
+      expect(res.body.handoffs[0]).toEqual(expect.objectContaining({
+        id: 'handoff-1',
+        actionable: true,
+        workspaceName: 'AI Workspace',
+        tabTitle: 'Example',
+        tabUrl: 'https://example.com',
+      }));
+    });
+  });
+
+  describe('POST /handoffs', () => {
+    it('creates a handoff and infers workspace from tab context', async () => {
+      vi.mocked(ctx.workspaceManager.getWorkspaceIdForTab).mockReturnValue('ws-1');
+      vi.mocked(ctx.workspaceManager.get).mockReturnValue({
+        id: 'ws-1',
+        name: 'AI Workspace',
+        icon: 'sparkles',
+        color: '#fff',
+        tabIds: [100],
+      } as any);
+      vi.mocked(ctx.handoffManager.create).mockReturnValue({
+        id: 'handoff-2',
+        status: 'blocked',
+        title: 'Login required',
+        body: 'Please sign in',
+        reason: 'login_required',
+        workspaceId: 'ws-1',
+        tabId: 'tab-1',
+        agentId: 'claude',
+        source: 'claude',
+        actionLabel: 'Log in and continue',
+        taskId: null,
+        stepId: null,
+        open: true,
+        createdAt: 1,
+        updatedAt: 1,
+      } as any);
+
+      const res = await request(app)
+        .post('/handoffs')
+        .send({
+          status: 'blocked',
+          title: 'Login required',
+          body: 'Please sign in',
+          reason: 'login_required',
+          tabId: 'tab-1',
+          source: 'claude',
+        });
+
+      expect(res.status).toBe(200);
+      expect(ctx.handoffManager.create).toHaveBeenCalledWith(expect.objectContaining({
+        status: 'blocked',
+        title: 'Login required',
+        workspaceId: 'ws-1',
+        tabId: 'tab-1',
+      }));
+      expect(res.body.workspaceName).toBe('AI Workspace');
+    });
+
+    it('returns 400 when status is invalid', async () => {
+      const res = await request(app)
+        .post('/handoffs')
+        .send({ status: 'oops', title: 'Broken' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('status must be one of');
+    });
+  });
+
+  describe('PATCH /handoffs/:id', () => {
+    it('updates a handoff status', async () => {
+      vi.mocked(ctx.handoffManager.update).mockReturnValue({
+        id: 'handoff-3',
+        status: 'ready_to_resume',
+        title: 'Captcha solved',
+        body: 'Agent can continue',
+        reason: 'captcha',
+        workspaceId: null,
+        tabId: null,
+        agentId: 'claude',
+        source: 'claude',
+        actionLabel: 'Resume agent',
+        taskId: null,
+        stepId: null,
+        open: true,
+        createdAt: 1,
+        updatedAt: 2,
+      } as any);
+
+      const res = await request(app)
+        .patch('/handoffs/handoff-3')
+        .send({ status: 'ready_to_resume', actionLabel: 'Resume agent' });
+
+      expect(res.status).toBe(200);
+      expect(ctx.handoffManager.update).toHaveBeenCalledWith('handoff-3', expect.objectContaining({
+        status: 'ready_to_resume',
+        actionLabel: 'Resume agent',
+      }));
+    });
+  });
+
+  describe('POST /handoffs/:id/activate', () => {
+    it('switches workspace and focuses the targeted tab', async () => {
+      vi.mocked(ctx.handoffManager.get).mockReturnValue({
+        id: 'handoff-4',
+        status: 'needs_human',
+        title: 'Review this tab',
+        body: '',
+        reason: 'review',
+        workspaceId: 'ws-1',
+        tabId: 'tab-1',
+        agentId: null,
+        source: 'claude',
+        actionLabel: null,
+        taskId: null,
+        stepId: null,
+        open: true,
+        createdAt: 1,
+        updatedAt: 2,
+      } as any);
+      vi.mocked(ctx.workspaceManager.get).mockReturnValue({
+        id: 'ws-1',
+        name: 'AI Workspace',
+        icon: 'sparkles',
+        color: '#fff',
+        tabIds: [100],
+      } as any);
+
+      const res = await request(app).post('/handoffs/handoff-4/activate');
+
+      expect(res.status).toBe(200);
+      expect(ctx.workspaceManager.switch).toHaveBeenCalledWith('ws-1');
+      expect(ctx.tabManager.focusTab).toHaveBeenCalledWith('tab-1');
+      expect(res.body.focusedTabId).toBe('tab-1');
+    });
+  });
+});

--- a/src/api/tests/routes/handoffs.test.ts
+++ b/src/api/tests/routes/handoffs.test.ts
@@ -10,9 +10,14 @@ vi.mock('electron', () => ({
   },
 }));
 
+vi.mock('../../../notifications/alert', () => ({
+  wingmanAlert: vi.fn(),
+}));
+
 import { registerHandoffRoutes } from '../../routes/handoffs';
 import { createMockContext, createTestApp } from '../helpers';
 import type { RouteContext } from '../../context';
+import { wingmanAlert } from '../../../notifications/alert';
 
 describe('Handoff Routes', () => {
   let ctx: RouteContext;
@@ -64,6 +69,22 @@ describe('Handoff Routes', () => {
         tabTitle: 'Example',
         tabUrl: 'https://example.com',
       }));
+    });
+
+    it('returns 400 when the status filter is invalid', async () => {
+      const res = await request(app).get('/handoffs?status=oops');
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('status must be one of');
+    });
+  });
+
+  describe('GET /handoffs/:id', () => {
+    it('returns 404 when the handoff is missing', async () => {
+      const res = await request(app).get('/handoffs/missing');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Handoff not found');
     });
   });
 
@@ -124,6 +145,73 @@ describe('Handoff Routes', () => {
       expect(res.status).toBe(400);
       expect(res.body.error).toContain('status must be one of');
     });
+
+    it('notifies Wingman when requested and normalizes optional metadata', async () => {
+      vi.mocked(ctx.handoffManager.create).mockReturnValue({
+        id: 'handoff-5',
+        status: 'waiting_approval',
+        title: 'Need approval',
+        body: 'Please confirm',
+        reason: 'approval_required',
+        workspaceId: null,
+        tabId: null,
+        agentId: null,
+        source: null,
+        actionLabel: null,
+        taskId: null,
+        stepId: null,
+        open: true,
+        createdAt: 1,
+        updatedAt: 1,
+      } as any);
+
+      const res = await request(app)
+        .post('/handoffs')
+        .send({
+          status: 'waiting_approval',
+          title: 'Need approval',
+          body: 'Please confirm',
+          reason: 'approval_required',
+          source: '  ',
+          actionLabel: '  ',
+          notify: true,
+        });
+
+      expect(res.status).toBe(200);
+      expect(ctx.handoffManager.create).toHaveBeenCalledWith(expect.objectContaining({
+        source: null,
+        actionLabel: null,
+      }));
+      expect(wingmanAlert).toHaveBeenCalledWith('Need approval', 'Please confirm');
+    });
+
+    it('returns 400 when an optional metadata field is not a string', async () => {
+      const res = await request(app)
+        .post('/handoffs')
+        .send({
+          status: 'needs_human',
+          title: 'Bad source',
+          source: 42,
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('source must be a string when provided');
+    });
+
+    it('returns 500 when the requested workspace does not exist', async () => {
+      vi.mocked(ctx.workspaceManager.get).mockReturnValue(undefined);
+
+      const res = await request(app)
+        .post('/handoffs')
+        .send({
+          status: 'needs_human',
+          title: 'Missing workspace',
+          workspaceId: 'ws-missing',
+        });
+
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe('Workspace ws-missing not found');
+    });
   });
 
   describe('PATCH /handoffs/:id', () => {
@@ -155,6 +243,65 @@ describe('Handoff Routes', () => {
         status: 'ready_to_resume',
         actionLabel: 'Resume agent',
       }));
+    });
+
+    it('returns 400 when open is not a boolean', async () => {
+      const res = await request(app)
+        .patch('/handoffs/handoff-3')
+        .send({ open: 'yes' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('open must be a boolean');
+    });
+
+    it('returns 404 when the handoff cannot be updated', async () => {
+      vi.mocked(ctx.handoffManager.update).mockReturnValue(null);
+
+      const res = await request(app)
+        .patch('/handoffs/missing')
+        .send({ status: 'resolved' });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Handoff not found');
+    });
+  });
+
+  describe('POST /handoffs/:id/resolve', () => {
+    it('resolves an open handoff', async () => {
+      vi.mocked(ctx.handoffManager.resolve).mockReturnValue({
+        id: 'handoff-6',
+        status: 'resolved',
+        title: 'All set',
+        body: '',
+        reason: 'done',
+        workspaceId: null,
+        tabId: null,
+        agentId: null,
+        source: 'claude',
+        actionLabel: null,
+        taskId: null,
+        stepId: null,
+        open: false,
+        createdAt: 1,
+        updatedAt: 2,
+        resolvedAt: 2,
+      } as any);
+
+      const res = await request(app).post('/handoffs/handoff-6/resolve');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(expect.objectContaining({
+        id: 'handoff-6',
+        actionable: false,
+        status: 'resolved',
+      }));
+    });
+
+    it('returns 404 when resolving a missing handoff', async () => {
+      const res = await request(app).post('/handoffs/missing/resolve');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Handoff not found');
     });
   });
 
@@ -191,6 +338,46 @@ describe('Handoff Routes', () => {
       expect(ctx.workspaceManager.switch).toHaveBeenCalledWith('ws-1');
       expect(ctx.tabManager.focusTab).toHaveBeenCalledWith('tab-1');
       expect(res.body.focusedTabId).toBe('tab-1');
+    });
+
+    it('focuses the first tab in the workspace when no tabId is attached', async () => {
+      vi.mocked(ctx.handoffManager.get).mockReturnValue({
+        id: 'handoff-7',
+        status: 'needs_human',
+        title: 'Workspace review',
+        body: '',
+        reason: 'review',
+        workspaceId: 'ws-1',
+        tabId: null,
+        agentId: null,
+        source: 'claude',
+        actionLabel: null,
+        taskId: null,
+        stepId: null,
+        open: true,
+        createdAt: 1,
+        updatedAt: 2,
+      } as any);
+      vi.mocked(ctx.workspaceManager.get).mockReturnValue({
+        id: 'ws-1',
+        name: 'AI Workspace',
+        icon: 'sparkles',
+        color: '#fff',
+        tabIds: [100],
+      } as any);
+
+      const res = await request(app).post('/handoffs/handoff-7/activate');
+
+      expect(res.status).toBe(200);
+      expect(ctx.tabManager.focusTab).toHaveBeenCalledWith('tab-1');
+      expect(res.body.focusedTabId).toBe('tab-1');
+    });
+
+    it('returns 404 when activating a missing handoff', async () => {
+      const res = await request(app).post('/handoffs/missing/activate');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('Handoff not found');
     });
   });
 });

--- a/src/bootstrap/runtime.ts
+++ b/src/bootstrap/runtime.ts
@@ -17,6 +17,7 @@ import { DevToolsManager } from '../devtools/manager';
 import { DeviceEmulator } from '../device/emulator';
 import { DownloadManager } from '../downloads/manager';
 import { EventStreamManager } from '../events/stream';
+import { HandoffManager, type Handoff } from '../handoffs/manager';
 import { ChromeImporter } from '../import/chrome-importer';
 import type { Logger } from '../utils/logger';
 import type { ManagerRegistry } from '../registry';
@@ -98,6 +99,35 @@ function wireTaskManagerEvents(win: BrowserWindow, taskManager: TaskManager, can
   });
 }
 
+function wireHandoffManagerEvents(
+  win: BrowserWindow,
+  handoffManager: HandoffManager,
+  eventStream: EventStreamManager,
+  panelManager: PanelManager,
+  canUseWindow: (win: BrowserWindow | null) => win is BrowserWindow,
+): void {
+  const emitRendererUpdate = (kind: 'created' | 'updated', handoff: Handoff) => {
+    eventStream.handleHandoffEvent(kind, handoff);
+    panelManager.logActivity('handoff', {
+      title: handoff.title,
+      status: handoff.status,
+      source: handoff.source ?? handoff.agentId ?? 'agent',
+    });
+
+    if (canUseWindow(win)) {
+      win.webContents.send(IpcChannels.HANDOFF_UPDATED, { kind, handoff });
+    }
+  };
+
+  handoffManager.on('handoff-created', (handoff: Handoff) => {
+    emitRendererUpdate('created', handoff);
+  });
+
+  handoffManager.on('handoff-updated', (handoff: Handoff) => {
+    emitRendererUpdate('updated', handoff);
+  });
+}
+
 async function configureNativeMessagingHostDirectories(log: Logger): Promise<void> {
   try {
     const os = await import('os');
@@ -162,6 +192,7 @@ export async function initializeRuntimeManagers(opts: InitializeRuntimeOptions):
   runtime.extensionToolbar = new ExtensionToolbar(runtime.extensionManager);
   runtime.claroNoteManager = new ClaroNoteManager();
   runtime.eventStream = new EventStreamManager();
+  runtime.handoffManager = new HandoffManager();
   runtime.taskManager = new TaskManager();
   runtime.tabLockManager = new TabLockManager();
   runtime.devToolsManager = new DevToolsManager(runtime.tabManager);
@@ -231,6 +262,68 @@ export async function initializeRuntimeManagers(opts: InitializeRuntimeOptions):
 
   runtime.contextBridge.connectEventStream(runtime.eventStream);
   wireTaskManagerEvents(win, runtime.taskManager, canUseWindow);
+  wireHandoffManagerEvents(
+    win,
+    runtime.handoffManager,
+    runtime.eventStream,
+    runtime.panelManager,
+    canUseWindow,
+  );
+
+  runtime.taskManager.on('approval-request', (data: Record<string, unknown>) => {
+    const taskId = typeof data.taskId === 'string' ? data.taskId : null;
+    const stepId = typeof data.stepId === 'string' ? data.stepId : null;
+    const task = taskId ? runtime.taskManager.getTask(taskId) : null;
+    const action = data.action && typeof data.action === 'object'
+      ? data.action as { params?: Record<string, unknown> }
+      : null;
+    const params = action?.params ?? {};
+
+    const existing = taskId && stepId
+      ? runtime.handoffManager.findOpenByTaskStep(taskId, stepId)
+      : null;
+
+    const payload = {
+      status: 'waiting_approval',
+      title: 'Approval needed',
+      body: typeof data.description === 'string' ? data.description : 'Agent action requires review.',
+      reason: 'approval_required',
+      actionLabel: 'Approve or reject this action',
+      source: task?.createdBy ?? 'wingman',
+      agentId: task?.assignedTo ?? null,
+      taskId,
+      stepId,
+      workspaceId: typeof params.workspaceId === 'string' ? params.workspaceId : null,
+      tabId: typeof params.tabId === 'string' ? params.tabId : null,
+    } as const;
+
+    if (existing) {
+      runtime.handoffManager.update(existing.id, payload);
+    } else {
+      runtime.handoffManager.create(payload);
+    }
+  });
+
+  runtime.taskManager.on('approval-response', (data: { requestId: string; approved: boolean }) => {
+    const [taskId, stepId] = data.requestId.split(':');
+    if (!taskId || !stepId) {
+      return;
+    }
+
+    const handoff = runtime.handoffManager.findOpenByTaskStep(taskId, stepId);
+    if (!handoff) {
+      return;
+    }
+
+    runtime.handoffManager.update(handoff.id, {
+      status: 'resolved',
+      open: false,
+      actionLabel: data.approved ? 'Approval granted' : 'Approval rejected',
+      body: data.approved
+        ? `${handoff.body}\n\nApproval granted.`
+        : `${handoff.body}\n\nApproval rejected.`,
+    });
+  });
 
   const ses = session.fromPartition(DEFAULT_PARTITION);
   runtime.downloadManager.hookSession(ses, win);
@@ -323,6 +416,7 @@ export function createManagerRegistry(runtime: RuntimeManagers): ManagerRegistry
     workflowEngine: runtime.workflowEngine,
     loginManager: runtime.loginManager,
     eventStream: runtime.eventStream,
+    handoffManager: runtime.handoffManager,
     taskManager: runtime.taskManager,
     tabLockManager: runtime.tabLockManager,
     devToolsManager: runtime.devToolsManager,

--- a/src/bootstrap/types.ts
+++ b/src/bootstrap/types.ts
@@ -22,6 +22,7 @@ import type { ExtensionManager } from '../extensions/manager';
 import type { ExtensionToolbar } from '../extensions/toolbar';
 import type { ClaroNoteManager } from '../claronote/manager';
 import type { EventStreamManager } from '../events/stream';
+import type { HandoffManager } from '../handoffs/manager';
 import type { TaskManager } from '../agents/task-manager';
 import type { TabLockManager } from '../agents/tab-lock-manager';
 import type { ContextMenuManager } from '../context-menu/manager';
@@ -73,6 +74,7 @@ export interface RuntimeManagers {
   extensionToolbar: ExtensionToolbar;
   claroNoteManager: ClaroNoteManager;
   eventStream: EventStreamManager;
+  handoffManager: HandoffManager;
   taskManager: TaskManager;
   tabLockManager: TabLockManager;
   contextMenuManager: ContextMenuManager;

--- a/src/events/stream.ts
+++ b/src/events/stream.ts
@@ -1,5 +1,6 @@
 import type { Request, Response } from 'express';
 import { buildTabOwnershipContext, type TabOwnershipContext } from '../tabs/context';
+import type { Handoff } from '../handoffs/manager';
 
 // ─── Types ──────────────────────────────────────────────────────────
 
@@ -7,7 +8,8 @@ export type BrowserEventType =
   | 'navigation'     | 'page-loaded'   | 'tab-opened'
   | 'tab-closed'     | 'tab-focused'   | 'click'
   | 'form-submit'    | 'scroll'        | 'voice-input'
-  | 'screenshot'     | 'error';
+  | 'screenshot'     | 'error'
+  | 'handoff-created' | 'handoff-updated';
 
 export interface BrowserEvent {
   id: number;
@@ -151,6 +153,26 @@ export class EventStreamManager {
   handleError(message: string, data?: Record<string, unknown>, context?: TabOwnershipContext): void {
     this.emit(this.createEvent('error', {
       data: { message, ...data },
+      context,
+    }));
+  }
+
+  /** Emit a structured handoff lifecycle event. */
+  handleHandoffEvent(kind: 'created' | 'updated', handoff: Handoff, context?: TabOwnershipContext): void {
+    this.emit(this.createEvent(kind === 'created' ? 'handoff-created' : 'handoff-updated', {
+      tabId: handoff.tabId ?? undefined,
+      data: {
+        handoffId: handoff.id,
+        status: handoff.status,
+        title: handoff.title,
+        reason: handoff.reason,
+        open: handoff.open,
+        workspaceId: handoff.workspaceId,
+        tabId: handoff.tabId,
+        source: handoff.source,
+        agentId: handoff.agentId,
+        actionLabel: handoff.actionLabel,
+      },
       context,
     }));
   }

--- a/src/handoffs/manager.ts
+++ b/src/handoffs/manager.ts
@@ -1,0 +1,306 @@
+import fs from 'fs';
+import { EventEmitter } from 'events';
+import { ensureDir, tandemDir } from '../utils/paths';
+
+export const HANDOFF_STATUSES = [
+  'needs_human',
+  'blocked',
+  'waiting_approval',
+  'ready_to_resume',
+  'completed_review',
+  'resolved',
+] as const;
+
+export type HandoffStatus = (typeof HANDOFF_STATUSES)[number];
+
+export interface Handoff {
+  id: string;
+  status: HandoffStatus;
+  title: string;
+  body: string;
+  reason: string;
+  workspaceId: string | null;
+  tabId: string | null;
+  agentId: string | null;
+  source: string | null;
+  actionLabel: string | null;
+  taskId: string | null;
+  stepId: string | null;
+  open: boolean;
+  createdAt: number;
+  updatedAt: number;
+  resolvedAt?: number;
+}
+
+export interface CreateHandoffInput {
+  status: HandoffStatus;
+  title: string;
+  body?: string;
+  reason?: string;
+  workspaceId?: string | null;
+  tabId?: string | null;
+  agentId?: string | null;
+  source?: string | null;
+  actionLabel?: string | null;
+  taskId?: string | null;
+  stepId?: string | null;
+  open?: boolean;
+}
+
+export interface UpdateHandoffInput {
+  status?: HandoffStatus;
+  title?: string;
+  body?: string;
+  reason?: string;
+  workspaceId?: string | null;
+  tabId?: string | null;
+  agentId?: string | null;
+  source?: string | null;
+  actionLabel?: string | null;
+  taskId?: string | null;
+  stepId?: string | null;
+  open?: boolean;
+}
+
+export interface HandoffListFilters {
+  openOnly?: boolean;
+  status?: HandoffStatus;
+  workspaceId?: string;
+  tabId?: string;
+  taskId?: string;
+  stepId?: string;
+}
+
+function isHandoffStatus(value: unknown): value is HandoffStatus {
+  return typeof value === 'string' && HANDOFF_STATUSES.includes(value as HandoffStatus);
+}
+
+function trimText(value: unknown, fallback = ''): string {
+  return typeof value === 'string' ? value.trim() : fallback;
+}
+
+function nullableText(value: unknown): string | null {
+  const trimmed = trimText(value);
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function cloneHandoff(handoff: Handoff): Handoff {
+  return { ...handoff };
+}
+
+function isOpenStatus(status: HandoffStatus): boolean {
+  return status !== 'resolved';
+}
+
+function sanitizeHandoff(raw: unknown): Handoff | null {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return null;
+  }
+
+  const value = raw as Partial<Record<keyof Handoff, unknown>>;
+  if (!isHandoffStatus(value.status)) {
+    return null;
+  }
+
+  const id = trimText(value.id);
+  const title = trimText(value.title);
+  if (!id || !title) {
+    return null;
+  }
+
+  const createdAt = typeof value.createdAt === 'number' ? value.createdAt : Date.now();
+  const updatedAt = typeof value.updatedAt === 'number' ? value.updatedAt : createdAt;
+  const status = value.status;
+  const open = typeof value.open === 'boolean' ? value.open : isOpenStatus(status);
+
+  const handoff: Handoff = {
+    id,
+    status,
+    title,
+    body: trimText(value.body),
+    reason: trimText(value.reason, 'human_help'),
+    workspaceId: nullableText(value.workspaceId),
+    tabId: nullableText(value.tabId),
+    agentId: nullableText(value.agentId),
+    source: nullableText(value.source),
+    actionLabel: nullableText(value.actionLabel),
+    taskId: nullableText(value.taskId),
+    stepId: nullableText(value.stepId),
+    open: status === 'resolved' ? false : open,
+    createdAt,
+    updatedAt,
+  };
+
+  if (typeof value.resolvedAt === 'number') {
+    handoff.resolvedAt = value.resolvedAt;
+  } else if (!handoff.open) {
+    handoff.resolvedAt = updatedAt;
+  }
+
+  return handoff;
+}
+
+/**
+ * HandoffManager — durable human↔agent escalation records shared across HTTP, MCP, and UI.
+ */
+export class HandoffManager extends EventEmitter {
+  private readonly handoffsPath: string;
+  private readonly handoffs = new Map<string, Handoff>();
+
+  constructor() {
+    super();
+    ensureDir(tandemDir());
+    this.handoffsPath = tandemDir('handoffs.json');
+    this.loadFromDisk();
+  }
+
+  list(filters: HandoffListFilters = {}): Handoff[] {
+    let handoffs = Array.from(this.handoffs.values());
+
+    if (filters.openOnly) {
+      handoffs = handoffs.filter(handoff => handoff.open);
+    }
+    if (filters.status) {
+      handoffs = handoffs.filter(handoff => handoff.status === filters.status);
+    }
+    if (filters.workspaceId) {
+      handoffs = handoffs.filter(handoff => handoff.workspaceId === filters.workspaceId);
+    }
+    if (filters.tabId) {
+      handoffs = handoffs.filter(handoff => handoff.tabId === filters.tabId);
+    }
+    if (filters.taskId) {
+      handoffs = handoffs.filter(handoff => handoff.taskId === filters.taskId);
+    }
+    if (filters.stepId) {
+      handoffs = handoffs.filter(handoff => handoff.stepId === filters.stepId);
+    }
+
+    return handoffs
+      .sort((a, b) => {
+        if (a.open !== b.open) {
+          return a.open ? -1 : 1;
+        }
+        return b.updatedAt - a.updatedAt;
+      })
+      .map(cloneHandoff);
+  }
+
+  get(id: string): Handoff | null {
+    const handoff = this.handoffs.get(id);
+    return handoff ? cloneHandoff(handoff) : null;
+  }
+
+  create(input: CreateHandoffInput): Handoff {
+    const now = Date.now();
+    const status = input.status;
+    const open = status === 'resolved'
+      ? false
+      : typeof input.open === 'boolean'
+        ? input.open
+        : isOpenStatus(status);
+
+    const handoff: Handoff = {
+      id: `handoff-${now}-${Math.random().toString(36).slice(2, 8)}`,
+      status,
+      title: trimText(input.title, 'Agent handoff'),
+      body: trimText(input.body),
+      reason: trimText(input.reason, 'human_help'),
+      workspaceId: nullableText(input.workspaceId),
+      tabId: nullableText(input.tabId),
+      agentId: nullableText(input.agentId),
+      source: nullableText(input.source),
+      actionLabel: nullableText(input.actionLabel),
+      taskId: nullableText(input.taskId),
+      stepId: nullableText(input.stepId),
+      open,
+      createdAt: now,
+      updatedAt: now,
+      resolvedAt: open ? undefined : now,
+    };
+
+    this.handoffs.set(handoff.id, handoff);
+    this.saveToDisk();
+    this.emit('handoff-created', cloneHandoff(handoff));
+    return cloneHandoff(handoff);
+  }
+
+  update(id: string, patch: UpdateHandoffInput): Handoff | null {
+    const existing = this.handoffs.get(id);
+    if (!existing) {
+      return null;
+    }
+
+    const nextStatus = patch.status ?? existing.status;
+    const nextOpen = nextStatus === 'resolved'
+      ? false
+      : typeof patch.open === 'boolean'
+        ? patch.open
+        : existing.open;
+
+    const updated: Handoff = {
+      ...existing,
+      status: nextStatus,
+      title: patch.title !== undefined ? trimText(patch.title, existing.title) : existing.title,
+      body: patch.body !== undefined ? trimText(patch.body) : existing.body,
+      reason: patch.reason !== undefined ? trimText(patch.reason, existing.reason) : existing.reason,
+      workspaceId: patch.workspaceId !== undefined ? nullableText(patch.workspaceId) : existing.workspaceId,
+      tabId: patch.tabId !== undefined ? nullableText(patch.tabId) : existing.tabId,
+      agentId: patch.agentId !== undefined ? nullableText(patch.agentId) : existing.agentId,
+      source: patch.source !== undefined ? nullableText(patch.source) : existing.source,
+      actionLabel: patch.actionLabel !== undefined ? nullableText(patch.actionLabel) : existing.actionLabel,
+      taskId: patch.taskId !== undefined ? nullableText(patch.taskId) : existing.taskId,
+      stepId: patch.stepId !== undefined ? nullableText(patch.stepId) : existing.stepId,
+      open: nextOpen,
+      updatedAt: Date.now(),
+      resolvedAt: nextOpen ? undefined : (existing.resolvedAt ?? Date.now()),
+    };
+
+    this.handoffs.set(id, updated);
+    this.saveToDisk();
+    this.emit('handoff-updated', cloneHandoff(updated));
+    return cloneHandoff(updated);
+  }
+
+  resolve(id: string): Handoff | null {
+    return this.update(id, { status: 'resolved', open: false });
+  }
+
+  findOpenByTaskStep(taskId: string, stepId: string): Handoff | null {
+    const match = Array.from(this.handoffs.values()).find(handoff =>
+      handoff.open && handoff.taskId === taskId && handoff.stepId === stepId,
+    );
+    return match ? cloneHandoff(match) : null;
+  }
+
+  private loadFromDisk(): void {
+    try {
+      if (!fs.existsSync(this.handoffsPath)) {
+        return;
+      }
+
+      const raw = JSON.parse(fs.readFileSync(this.handoffsPath, 'utf-8'));
+      if (!Array.isArray(raw)) {
+        return;
+      }
+
+      for (const item of raw) {
+        const handoff = sanitizeHandoff(item);
+        if (handoff) {
+          this.handoffs.set(handoff.id, handoff);
+        }
+      }
+    } catch {
+      this.handoffs.clear();
+    }
+  }
+
+  private saveToDisk(): void {
+    const serialized = JSON.stringify(
+      Array.from(this.handoffs.values()).sort((a, b) => b.updatedAt - a.updatedAt),
+      null,
+      2,
+    );
+    fs.writeFileSync(this.handoffsPath, serialized);
+  }
+}

--- a/src/handoffs/manager.ts
+++ b/src/handoffs/manager.ts
@@ -79,6 +79,11 @@ function trimText(value: unknown, fallback = ''): string {
   return typeof value === 'string' ? value.trim() : fallback;
 }
 
+function textOrFallback(value: unknown, fallback: string): string {
+  const trimmed = trimText(value);
+  return trimmed.length > 0 ? trimmed : fallback;
+}
+
 function nullableText(value: unknown): string | null {
   const trimmed = trimText(value);
   return trimmed.length > 0 ? trimmed : null;
@@ -103,7 +108,7 @@ function sanitizeHandoff(raw: unknown): Handoff | null {
   }
 
   const id = trimText(value.id);
-  const title = trimText(value.title);
+  const title = textOrFallback(value.title, 'Agent handoff');
   if (!id || !title) {
     return null;
   }
@@ -118,7 +123,7 @@ function sanitizeHandoff(raw: unknown): Handoff | null {
     status,
     title,
     body: trimText(value.body),
-    reason: trimText(value.reason, 'human_help'),
+    reason: textOrFallback(value.reason, 'human_help'),
     workspaceId: nullableText(value.workspaceId),
     tabId: nullableText(value.tabId),
     agentId: nullableText(value.agentId),
@@ -203,9 +208,9 @@ export class HandoffManager extends EventEmitter {
     const handoff: Handoff = {
       id: `handoff-${now}-${Math.random().toString(36).slice(2, 8)}`,
       status,
-      title: trimText(input.title, 'Agent handoff'),
+      title: textOrFallback(input.title, 'Agent handoff'),
       body: trimText(input.body),
-      reason: trimText(input.reason, 'human_help'),
+      reason: textOrFallback(input.reason, 'human_help'),
       workspaceId: nullableText(input.workspaceId),
       tabId: nullableText(input.tabId),
       agentId: nullableText(input.agentId),
@@ -241,9 +246,9 @@ export class HandoffManager extends EventEmitter {
     const updated: Handoff = {
       ...existing,
       status: nextStatus,
-      title: patch.title !== undefined ? trimText(patch.title, existing.title) : existing.title,
+      title: patch.title !== undefined ? textOrFallback(patch.title, existing.title) : existing.title,
       body: patch.body !== undefined ? trimText(patch.body) : existing.body,
-      reason: patch.reason !== undefined ? trimText(patch.reason, existing.reason) : existing.reason,
+      reason: patch.reason !== undefined ? textOrFallback(patch.reason, existing.reason) : existing.reason,
       workspaceId: patch.workspaceId !== undefined ? nullableText(patch.workspaceId) : existing.workspaceId,
       tabId: patch.tabId !== undefined ? nullableText(patch.tabId) : existing.tabId,
       agentId: patch.agentId !== undefined ? nullableText(patch.agentId) : existing.agentId,

--- a/src/handoffs/tests/manager.test.ts
+++ b/src/handoffs/tests/manager.test.ts
@@ -1,0 +1,227 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fsState = vi.hoisted(() => ({
+  exists: false,
+  readText: '[]',
+}));
+
+vi.mock('fs', () => {
+  const existsSync = vi.fn(() => fsState.exists);
+  const readFileSync = vi.fn(() => fsState.readText);
+  const writeFileSync = vi.fn();
+  return {
+    default: { existsSync, readFileSync, writeFileSync },
+    existsSync,
+    readFileSync,
+    writeFileSync,
+  };
+});
+
+vi.mock('../../utils/paths', () => ({
+  ensureDir: vi.fn(),
+  tandemDir: vi.fn((...parts: string[]) => `/tmp/tandem/${parts.join('/')}`),
+}));
+
+import fs from 'fs';
+import { HandoffManager } from '../manager';
+
+describe('HandoffManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fsState.exists = false;
+    fsState.readText = '[]';
+  });
+
+  it('loads sanitized handoffs from disk and applies filters with open-first sorting', () => {
+    fsState.exists = true;
+    fsState.readText = JSON.stringify([
+      {
+        id: 'resolved-1',
+        status: 'resolved',
+        title: 'Already handled',
+        body: 'Done',
+        reason: 'done',
+        workspaceId: 'ws-1',
+        tabId: 'tab-1',
+        open: true,
+        createdAt: 10,
+        updatedAt: 30,
+      },
+      {
+        id: 'open-1',
+        status: 'needs_human',
+        title: ' Need review ',
+        body: ' Please review ',
+        reason: ' human_help ',
+        workspaceId: ' ws-1 ',
+        tabId: ' tab-2 ',
+        taskId: 'task-1',
+        stepId: 'step-1',
+        createdAt: 1,
+        updatedAt: 20,
+      },
+      {
+        id: 'open-2',
+        status: 'blocked',
+        title: 'Second',
+        createdAt: 2,
+        updatedAt: 40,
+      },
+      {
+        id: 'broken-1',
+        status: 'oops',
+        title: 'Invalid',
+      },
+    ]);
+
+    const manager = new HandoffManager();
+
+    expect(manager.list().map(handoff => handoff.id)).toEqual([
+      'open-2',
+      'open-1',
+      'resolved-1',
+    ]);
+    expect(manager.list({ openOnly: true }).map(handoff => handoff.id)).toEqual([
+      'open-2',
+      'open-1',
+    ]);
+    expect(manager.list({ workspaceId: 'ws-1', taskId: 'task-1', stepId: 'step-1' })).toEqual([
+      expect.objectContaining({
+        id: 'open-1',
+        workspaceId: 'ws-1',
+        tabId: 'tab-2',
+        open: true,
+      }),
+    ]);
+    expect(manager.get('resolved-1')).toEqual(expect.objectContaining({
+      open: false,
+      resolvedAt: 30,
+    }));
+
+    const copy = manager.get('open-1');
+    expect(copy).not.toBeNull();
+    copy!.title = 'Changed externally';
+    expect(manager.get('open-1')?.title).toBe('Need review');
+  });
+
+  it('creates handoffs with trimmed values, fallback defaults, persistence, and events', () => {
+    const manager = new HandoffManager();
+    const createdListener = vi.fn();
+    manager.on('handoff-created', createdListener);
+
+    const handoff = manager.create({
+      status: 'resolved',
+      title: '   ',
+      body: '  Review done  ',
+      reason: '   ',
+      workspaceId: ' ws-9 ',
+      tabId: ' tab-9 ',
+      agentId: ' agent-1 ',
+      source: ' source-1 ',
+      actionLabel: '   ',
+      taskId: ' task-9 ',
+      stepId: ' step-9 ',
+    });
+
+    expect(handoff).toEqual(expect.objectContaining({
+      status: 'resolved',
+      title: 'Agent handoff',
+      body: 'Review done',
+      reason: 'human_help',
+      workspaceId: 'ws-9',
+      tabId: 'tab-9',
+      agentId: 'agent-1',
+      source: 'source-1',
+      actionLabel: null,
+      taskId: 'task-9',
+      stepId: 'step-9',
+      open: false,
+    }));
+    expect(handoff.resolvedAt).toBeTypeOf('number');
+    expect(createdListener).toHaveBeenCalledWith(expect.objectContaining({
+      id: handoff.id,
+      open: false,
+    }));
+    expect(vi.mocked(fs.writeFileSync)).toHaveBeenCalledWith(
+      '/tmp/tandem/handoffs.json',
+      expect.stringContaining('"status": "resolved"'),
+    );
+  });
+
+  it('updates, reopens, resolves, and finds open handoffs by task step', () => {
+    const manager = new HandoffManager();
+    const updatedListener = vi.fn();
+    manager.on('handoff-updated', updatedListener);
+
+    const first = manager.create({
+      status: 'blocked',
+      title: 'Login required',
+      reason: 'login_required',
+      workspaceId: 'ws-1',
+      tabId: 'tab-1',
+      source: 'claude',
+      taskId: 'task-1',
+      stepId: 'step-1',
+    });
+    manager.create({
+      status: 'resolved',
+      title: 'Done',
+      taskId: 'task-1',
+      stepId: 'step-1',
+    });
+
+    expect(manager.findOpenByTaskStep('task-1', 'step-1')?.id).toBe(first.id);
+
+    const paused = manager.update(first.id, {
+      title: '   ',
+      body: '  Sign in first  ',
+      reason: '   ',
+      workspaceId: '',
+      tabId: '',
+      source: '',
+      open: false,
+    });
+    expect(paused).toEqual(expect.objectContaining({
+      title: 'Login required',
+      body: 'Sign in first',
+      reason: 'login_required',
+      workspaceId: null,
+      tabId: null,
+      source: null,
+      open: false,
+    }));
+    expect(paused?.resolvedAt).toBeTypeOf('number');
+
+    const reopened = manager.update(first.id, {
+      status: 'ready_to_resume',
+      open: true,
+      actionLabel: 'Resume agent',
+    });
+    expect(reopened).toEqual(expect.objectContaining({
+      status: 'ready_to_resume',
+      open: true,
+      actionLabel: 'Resume agent',
+      resolvedAt: undefined,
+    }));
+
+    const resolved = manager.resolve(first.id);
+    expect(resolved).toEqual(expect.objectContaining({
+      status: 'resolved',
+      open: false,
+    }));
+    expect(manager.findOpenByTaskStep('task-1', 'step-1')).toBeNull();
+    expect(manager.resolve('missing')).toBeNull();
+    expect(manager.update('missing', { open: false })).toBeNull();
+    expect(updatedListener).toHaveBeenCalled();
+  });
+
+  it('recovers from malformed disk state without throwing', () => {
+    fsState.exists = true;
+    fsState.readText = '{not-json';
+
+    const manager = new HandoffManager();
+
+    expect(manager.list()).toEqual([]);
+    expect(vi.mocked(fs.readFileSync)).toHaveBeenCalledWith('/tmp/tandem/handoffs.json', 'utf-8');
+  });
+});

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -24,6 +24,7 @@ import { registerBookmarkTools } from './tools/bookmarks.js';
 import { registerHistoryTools } from './tools/history.js';
 import { registerChatTools } from './tools/chat.js';
 import { registerTaskTools } from './tools/tasks.js';
+import { registerHandoffTools } from './tools/handoffs.js';
 import { registerWorkflowTools } from './tools/workflows.js';
 import { registerExtensionTools } from './tools/extensions.js';
 import { registerDeviceTools } from './tools/devices.js';
@@ -68,6 +69,7 @@ registerBookmarkTools(server);
 registerHistoryTools(server);
 registerChatTools(server);
 registerTaskTools(server);
+registerHandoffTools(server);
 registerWorkflowTools(server);
 registerExtensionTools(server);
 registerDeviceTools(server);
@@ -150,6 +152,35 @@ server.resource(
       text += `[${time}] ${msg.from}: ${msg.text}\n`;
     }
     return { contents: [{ uri: 'tandem://chat/history', mimeType: 'text/plain', text }] };
+  }
+);
+
+server.resource(
+  'handoffs-open',
+  'tandem://handoffs/open',
+  { description: 'Open human↔agent handoffs that still need attention or review' },
+  async () => {
+    const data = await apiCall('GET', '/handoffs?openOnly=true');
+    const handoffs: Array<{
+      id: string;
+      status: string;
+      title: string;
+      reason?: string | null;
+      workspaceName?: string | null;
+      tabTitle?: string | null;
+    }> = data.handoffs || [];
+
+    let text = `Open handoffs (${handoffs.length}):\n\n`;
+    for (const handoff of handoffs) {
+      const details = [
+        `status=${handoff.status}`,
+        handoff.reason ? `reason=${handoff.reason}` : null,
+        handoff.workspaceName ? `workspace=${handoff.workspaceName}` : null,
+        handoff.tabTitle ? `tab=${handoff.tabTitle}` : null,
+      ].filter(Boolean).join(' | ');
+      text += `- [${handoff.id}] ${handoff.title}${details ? ` (${details})` : ''}\n`;
+    }
+    return { contents: [{ uri: 'tandem://handoffs/open', mimeType: 'text/plain', text }] };
   }
 );
 
@@ -255,12 +286,15 @@ function startEventListener(): void {
             try {
               const event = JSON.parse(line.slice(6));
               // Send MCP notifications for meaningful events
-              if (['navigation', 'page-loaded', 'tab-focused'].includes(event.type)) {
+              if (['navigation', 'page-loaded', 'tab-focused', 'handoff-created', 'handoff-updated'].includes(event.type)) {
                 server.server.sendResourceUpdated({ uri: 'tandem://page/current' }).catch(e => log.warn('sendResourceUpdated page/current failed:', e instanceof Error ? e.message : e));
                 server.server.sendResourceUpdated({ uri: 'tandem://context' }).catch(e => log.warn('sendResourceUpdated context failed:', e instanceof Error ? e.message : e));
               }
               if (['tab-opened', 'tab-closed', 'tab-focused'].includes(event.type)) {
                 server.server.sendResourceUpdated({ uri: 'tandem://tabs/list' }).catch(e => log.warn('sendResourceUpdated tabs/list failed:', e instanceof Error ? e.message : e));
+              }
+              if (['handoff-created', 'handoff-updated'].includes(event.type)) {
+                server.server.sendResourceUpdated({ uri: 'tandem://handoffs/open' }).catch(e => log.warn('sendResourceUpdated handoffs/open failed:', e instanceof Error ? e.message : e));
               }
             } catch {
               // Ignore parse errors (comments, heartbeats)

--- a/src/mcp/tests/handoffs.test.ts
+++ b/src/mcp/tests/handoffs.test.ts
@@ -57,6 +57,34 @@ describe('MCP handoff tools', () => {
     expect(mockApiCall).toHaveBeenCalledWith('GET', '/handoffs?openOnly=true');
   });
 
+  it('lists handoffs with explicit filters and openOnly disabled', async () => {
+    const handler = getHandler(tools, 'tandem_handoff_list');
+    mockApiCall.mockResolvedValueOnce({ handoffs: [{ id: 'handoff-2' }] });
+
+    const result = await handler({
+      openOnly: false,
+      status: 'blocked',
+      workspaceId: 'ws-1',
+      tabId: 'tab-1',
+    });
+
+    expectTextContent(result, 'handoff-2');
+    expect(mockApiCall).toHaveBeenCalledWith(
+      'GET',
+      '/handoffs?status=blocked&workspaceId=ws-1&tabId=tab-1',
+    );
+  });
+
+  it('fetches a single handoff', async () => {
+    const handler = getHandler(tools, 'tandem_handoff_get');
+    mockApiCall.mockResolvedValueOnce({ id: 'handoff-1', status: 'needs_human' });
+
+    const result = await handler({ id: 'handoff-1' });
+
+    expectTextContent(result, '"id": "handoff-1"');
+    expect(mockApiCall).toHaveBeenCalledWith('GET', '/handoffs/handoff-1');
+  });
+
   it('updates a handoff', async () => {
     const handler = getHandler(tools, 'tandem_handoff_update');
     mockApiCall.mockResolvedValueOnce({ id: 'handoff-1', status: 'ready_to_resume' });
@@ -69,6 +97,7 @@ describe('MCP handoff tools', () => {
       status: 'ready_to_resume',
       open: true,
     });
+    expect(mockLogActivity).toHaveBeenCalledWith('handoff_update', 'handoff-1: ready_to_resume');
   });
 
   it('resolves a handoff', async () => {
@@ -80,5 +109,27 @@ describe('MCP handoff tools', () => {
 
     expectTextContent(result, 'Handoff resolved: handoff-1');
     expect(mockApiCall).toHaveBeenCalledWith('POST', '/handoffs/handoff-1/resolve');
+  });
+
+  it('passes notify and action hints through on create', async () => {
+    const handler = getHandler(tools, 'tandem_handoff_create');
+    mockApiCall.mockResolvedValueOnce({ id: 'handoff-9', status: 'waiting_approval', title: 'Need approval' });
+    mockLogActivity.mockResolvedValueOnce(undefined);
+
+    await handler({
+      status: 'waiting_approval',
+      title: 'Need approval',
+      actionLabel: 'Approve action',
+      notify: true,
+      agentId: 'agent-7',
+      workspaceId: 'ws-7',
+    });
+
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/handoffs', expect.objectContaining({
+      actionLabel: 'Approve action',
+      notify: true,
+      agentId: 'agent-7',
+      workspaceId: 'ws-7',
+    }));
   });
 });

--- a/src/mcp/tests/handoffs.test.ts
+++ b/src/mcp/tests/handoffs.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  getMcpSource: vi.fn(() => 'wingman'),
+  logActivity: vi.fn(),
+}));
+
+vi.mock('../coerce.js', async (importOriginal) => importOriginal());
+
+import { apiCall, getMcpSource, logActivity } from '../api-client.js';
+import { registerHandoffTools } from '../tools/handoffs.js';
+import { createMockServer, expectTextContent, getHandler } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+const mockGetMcpSource = vi.mocked(getMcpSource);
+const mockLogActivity = vi.mocked(logActivity);
+
+describe('MCP handoff tools', () => {
+  const { server, tools } = createMockServer();
+  registerHandoffTools(server);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetMcpSource.mockReturnValue('claude');
+  });
+
+  it('creates an explicit handoff', async () => {
+    const handler = getHandler(tools, 'tandem_handoff_create');
+    mockApiCall.mockResolvedValueOnce({ id: 'handoff-1', status: 'needs_human', title: 'Captcha detected' });
+    mockLogActivity.mockResolvedValueOnce(undefined);
+
+    const result = await handler({
+      status: 'needs_human',
+      title: 'Captcha detected',
+      body: 'Please solve it',
+      reason: 'captcha',
+      tabId: 'tab-1',
+    });
+
+    expectTextContent(result, 'Handoff created: handoff-1');
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/handoffs', expect.objectContaining({
+      status: 'needs_human',
+      title: 'Captcha detected',
+      source: 'claude',
+      tabId: 'tab-1',
+    }));
+  });
+
+  it('lists open handoffs by default', async () => {
+    const handler = getHandler(tools, 'tandem_handoff_list');
+    mockApiCall.mockResolvedValueOnce({ handoffs: [{ id: 'handoff-1' }] });
+
+    const result = await handler({});
+
+    expectTextContent(result, 'handoff-1');
+    expect(mockApiCall).toHaveBeenCalledWith('GET', '/handoffs?openOnly=true');
+  });
+
+  it('updates a handoff', async () => {
+    const handler = getHandler(tools, 'tandem_handoff_update');
+    mockApiCall.mockResolvedValueOnce({ id: 'handoff-1', status: 'ready_to_resume' });
+    mockLogActivity.mockResolvedValueOnce(undefined);
+
+    const result = await handler({ id: 'handoff-1', status: 'ready_to_resume', open: true });
+
+    expectTextContent(result, 'ready_to_resume');
+    expect(mockApiCall).toHaveBeenCalledWith('PATCH', '/handoffs/handoff-1', {
+      status: 'ready_to_resume',
+      open: true,
+    });
+  });
+
+  it('resolves a handoff', async () => {
+    const handler = getHandler(tools, 'tandem_handoff_resolve');
+    mockApiCall.mockResolvedValueOnce({ id: 'handoff-1' });
+    mockLogActivity.mockResolvedValueOnce(undefined);
+
+    const result = await handler({ id: 'handoff-1' });
+
+    expectTextContent(result, 'Handoff resolved: handoff-1');
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/handoffs/handoff-1/resolve');
+  });
+});

--- a/src/mcp/tools/chat.ts
+++ b/src/mcp/tools/chat.ts
@@ -77,7 +77,7 @@ export function registerChatTools(server: McpServer): void {
 
   server.tool(
     'tandem_wingman_alert',
-    'Show a native OS notification alert to the user via the Wingman system',
+    'Legacy compatibility alert: show a native Wingman alert and create an open needs_human handoff for the user',
     {
       message: z.string().describe('Alert message to display'),
       level: z.enum(['info', 'warning', 'error']).optional().describe('Alert level (default: info)'),

--- a/src/mcp/tools/handoffs.ts
+++ b/src/mcp/tools/handoffs.ts
@@ -1,0 +1,123 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { apiCall, getMcpSource, logActivity } from '../api-client.js';
+import { coerceShape } from '../coerce.js';
+
+const handoffStatusSchema = z.enum([
+  'needs_human',
+  'blocked',
+  'waiting_approval',
+  'ready_to_resume',
+  'completed_review',
+  'resolved',
+]);
+
+export function registerHandoffTools(server: McpServer): void {
+  server.tool(
+    'tandem_handoff_create',
+    'Create an explicit human↔agent handoff that appears in Tandem for the user to review, approve, or resume.',
+    coerceShape({
+      status: handoffStatusSchema.describe('Handoff state: needs_human, blocked, waiting_approval, ready_to_resume, completed_review, or resolved'),
+      title: z.string().describe('Short handoff title shown to the human'),
+      body: z.string().optional().describe('Detailed handoff explanation and what the human should do next'),
+      reason: z.string().optional().describe('Structured reason such as captcha, login_required, approval_required, or task_completed'),
+      workspaceId: z.string().optional().describe('Optional workspace ID to point the user to'),
+      tabId: z.string().optional().describe('Optional tab ID to point the user to'),
+      agentId: z.string().optional().describe('Optional agent identifier'),
+      actionLabel: z.string().optional().describe('Optional next-step hint such as "Solve captcha and resume"'),
+      notify: z.boolean().optional().describe('Also raise a visible Wingman alert/notification'),
+    }),
+    async ({ status, title, body, reason, workspaceId, tabId, agentId, actionLabel, notify }) => {
+      const handoff = await apiCall('POST', '/handoffs', {
+        status,
+        title,
+        body,
+        reason,
+        workspaceId,
+        tabId,
+        agentId,
+        actionLabel,
+        source: getMcpSource(),
+        notify,
+      });
+
+      await logActivity('handoff_create', `${handoff.id}: ${title}`);
+      return {
+        content: [{
+          type: 'text',
+          text: `Handoff created: ${handoff.id}\nStatus: ${handoff.status}\nTitle: ${handoff.title}`,
+        }],
+      };
+    },
+  );
+
+  server.tool(
+    'tandem_handoff_list',
+    'List handoffs that are open or recently updated. Use this to see what needs human attention.',
+    coerceShape({
+      openOnly: z.boolean().optional().default(true).describe('Only return open/actionable handoffs (default: true)'),
+      status: handoffStatusSchema.optional().describe('Optional status filter'),
+      workspaceId: z.string().optional().describe('Optional workspace filter'),
+      tabId: z.string().optional().describe('Optional tab filter'),
+    }),
+    async ({ openOnly, status, workspaceId, tabId }) => {
+      const params = new URLSearchParams();
+      if (openOnly !== false) params.set('openOnly', 'true');
+      if (status) params.set('status', status);
+      if (workspaceId) params.set('workspaceId', workspaceId);
+      if (tabId) params.set('tabId', tabId);
+      const endpoint = params.toString() ? `/handoffs?${params}` : '/handoffs';
+      const data = await apiCall('GET', endpoint);
+      return { content: [{ type: 'text', text: JSON.stringify(data.handoffs || [], null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'tandem_handoff_get',
+    'Get the full details for a specific handoff.',
+    {
+      id: z.string().describe('The handoff ID'),
+    },
+    async ({ id }) => {
+      const handoff = await apiCall('GET', `/handoffs/${encodeURIComponent(id)}`);
+      return { content: [{ type: 'text', text: JSON.stringify(handoff, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'tandem_handoff_update',
+    'Update a handoff status or message when the agent is unblocked, waiting again, ready to resume, or done for review.',
+    coerceShape({
+      id: z.string().describe('The handoff ID'),
+      status: handoffStatusSchema.optional().describe('Updated handoff status'),
+      title: z.string().optional().describe('Optional updated title'),
+      body: z.string().optional().describe('Optional updated body'),
+      reason: z.string().optional().describe('Optional updated reason'),
+      actionLabel: z.string().optional().describe('Optional updated next-step hint'),
+      open: z.boolean().optional().describe('Override whether the handoff stays open/actionable'),
+    }),
+    async ({ id, ...patch }) => {
+      const handoff = await apiCall('PATCH', `/handoffs/${encodeURIComponent(id)}`, patch);
+      await logActivity('handoff_update', `${id}: ${handoff.status}`);
+      return { content: [{ type: 'text', text: JSON.stringify(handoff, null, 2) }] };
+    },
+  );
+
+  server.tool(
+    'tandem_handoff_resolve',
+    'Mark a handoff as resolved so it leaves the open handoff inbox.',
+    {
+      id: z.string().describe('The handoff ID'),
+    },
+    async ({ id }) => {
+      const handoff = await apiCall('POST', `/handoffs/${encodeURIComponent(id)}/resolve`);
+      await logActivity('handoff_resolve', id);
+      return {
+        content: [{
+          type: 'text',
+          text: `Handoff resolved: ${handoff.id}`,
+        }],
+      };
+    },
+  );
+}

--- a/src/panel/manager.ts
+++ b/src/panel/manager.ts
@@ -13,7 +13,7 @@ const log = createLogger('PanelManager');
 
 export interface ActivityEvent {
   id: number;
-  type: 'navigate' | 'click' | 'scroll' | 'input' | 'tab-switch' | 'tab-open' | 'tab-close' | 'press-key' | 'press-key-combo';
+  type: 'navigate' | 'click' | 'scroll' | 'input' | 'tab-switch' | 'tab-open' | 'tab-close' | 'press-key' | 'press-key-combo' | 'handoff';
   timestamp: number;
   data: Record<string, unknown>;
 }

--- a/src/preload/panel.ts
+++ b/src/preload/panel.ts
@@ -65,6 +65,11 @@ export function createPanelApi() {
       ipcRenderer.on(IpcChannels.APPROVAL_REQUEST, handler);
       return () => ipcRenderer.removeListener(IpcChannels.APPROVAL_REQUEST, handler);
     },
+    onHandoffUpdated: (callback: (data: { kind: 'created' | 'updated'; handoff: Record<string, unknown> }) => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, data: { kind: 'created' | 'updated'; handoff: Record<string, unknown> }) => callback(data);
+      ipcRenderer.on(IpcChannels.HANDOFF_UPDATED, handler);
+      return () => ipcRenderer.removeListener(IpcChannels.HANDOFF_UPDATED, handler);
+    },
     onLiveModeChanged: (callback: (data: { enabled: boolean }) => void) => {
       const handler = (_event: Electron.IpcRendererEvent, data: { enabled: boolean }) => callback(data);
       ipcRenderer.on(IpcChannels.LIVE_MODE_CHANGED, handler);

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -30,6 +30,7 @@ import type { ContentExtractor } from './content/extractor';
 import type { WorkflowEngine } from './workflow/engine';
 import type { LoginManager } from './auth/login-manager';
 import type { EventStreamManager } from './events/stream';
+import type { HandoffManager } from './handoffs/manager';
 import type { TaskManager } from './agents/task-manager';
 import type { TabLockManager } from './agents/tab-lock-manager';
 import type { DevToolsManager } from './devtools/manager';
@@ -102,6 +103,8 @@ export interface ManagerRegistry {
   loginManager: LoginManager;
   /** In-memory stream of browser events (navigation, clicks, etc). See src/events/stream.ts */
   eventStream: EventStreamManager;
+  /** Explicit human↔agent handoffs with durable status and targeting context. See src/handoffs/manager.ts */
+  handoffManager: HandoffManager;
   /** AI agent task management with approval workflow and emergency stop. See src/agents/task-manager.ts */
   taskManager: TaskManager;
   /** Prevents multiple agents from controlling the same tab with timeout locks. See src/agents/tab-lock-manager.ts */

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -115,6 +115,7 @@ export const IpcChannels = {
   EMERGENCY_STOP: 'emergency-stop',
   APPROVAL_REQUEST: 'approval-request',
   TASK_UPDATED: 'task-updated',
+  HANDOFF_UPDATED: 'handoff-updated',
 
   // Shortcuts
   SHORTCUT: 'shortcut',


### PR DESCRIPTION
## Summary
- add a durable handoff model with explicit statuses and persistence shared across HTTP, MCP, live events, and the Wingman UI
- add handoff API routes and MCP tools/resources for create/list/get/update/resolve/activate flows
- add a visible open-handoffs inbox in the Wingman Activity tab and keep `/wingman-alert` as a compatibility wrapper over the new system

## Why
Tandem needs a first-class human↔agent handoff surface so agents can explicitly escalate captchas, approvals, login/MFA, resume points, and completed work without relying on transient alerts or ad-hoc chat messages.

## Validation
- `npx tsc --noEmit`
- `npx vitest run`
- `npm start`
- live API validation for captcha, approval-needed, and task-completed handoffs
- live UI validation for inbox visibility, workspace/tab targeting, and resolving an open handoff
