### PR TITLE
[codex] refine Wingman handoffs and sync version metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ how it works, and why it exists.
 
 - **Repo:** `hydro13/tandem-browser` (GitHub: hydro13)
 - **Stack:** Electron 40 + TypeScript + Express.js API (`localhost:8765`) +
-  MCP server (244 tools)
+  MCP server (248 tools)
 - **Goal:** An agent-first browser where any AI (via MCP, HTTP API, or
   WebSocket) and a human browse together
 - **Philosophy:** Local-first, privacy-first, no cloud dependencies in the
@@ -39,7 +39,7 @@ tandem-browser/
 │   ├── snapshot/                 # Accessibility tree with @refs
 │   ├── network/                  # Inspector + mocking
 │   ├── sessions/                 # Multi-session isolation
-│   ├── mcp/                      # MCP server (244 tools, full API parity)
+│   ├── mcp/                      # MCP server (248 tools, full API parity)
 │   │   ├── server.ts             # MCP server entry point
 │   │   └── tools/                # Tool definitions (one file per domain)
 │   ├── agents/                   # TaskManager, X-Scout, TabLockManager

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to Tandem Browser will be documented in this file.
 - New MCP tools for the same handoff system: `tandem_handoff_create`, `tandem_handoff_list`, `tandem_handoff_get`, `tandem_handoff_update`, and `tandem_handoff_resolve`
 - New MCP resource `tandem://handoffs/open` plus SSE handoff events so open handoffs can be observed live
 - A real Wingman Activity inbox for open handoffs, including workspace/tab context, action hints, open-context targeting, and resolve/mark-ready actions
+- A shared `TaskHandoffCoordinator` plus explicit handoff actions for `ready`, `resume`, `approve`, and `reject`, so task-linked handoffs can now pause tasks, move into `ready-to-resume`, and hand execution back to the agent cleanly
 
 ### Changed
 
@@ -20,6 +21,7 @@ All notable changes to Tandem Browser will be documented in this file.
 - Task approval requests now also appear as structured handoffs instead of only transient approval cards, keeping human attention requests visible in one place
 - Wingman Activity logging now records handoff lifecycle updates so the user can see when a handoff was created, updated, or resolved
 - Handoff metadata normalization now treats blank titles/reasons as defaults, and focused route/MCP/manager tests cover the new handoff lifecycle more thoroughly so coverage matches the added product surface
+- The Wingman Activity inbox now surfaces status-aware actions: approval handoffs show `Approve` / `Reject`, human-blocked handoffs show `Mark Ready`, and `ready_to_resume` handoffs show `Resume Agent`
 
 ## [v0.71.4] - 2026-04-13
 

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -10,7 +10,7 @@ bicycle: two riders, one machine, each contributing what the other can't do
 alone.
 
 The browser runs two things in parallel. The human uses it like any other browser
-while AI agents operate through a built-in **MCP server** (244 tools) or a full
+while AI agents operate through a built-in **MCP server** (248 tools) or a full
 local **HTTP API** on `127.0.0.1:8765` with 300+ endpoints for navigation,
 interaction, data extraction, automation, sessions, sync, extensions, and
 developer tooling. Websites see a normal Chrome browser on macOS. They don't see

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Coverage](https://codecov.io/gh/hydro13/tandem-browser/branch/main/graph/badge.svg)](https://codecov.io/gh/hydro13/tandem-browser)
 [![Ask a question](https://img.shields.io/badge/discussions-Q%26A-blue)](https://github.com/hydro13/tandem-browser/discussions/categories/q-a)
 
-**244 MCP tools. Plug in any AI. No scraping. No API wrangling.**
+**248 MCP tools. Plug in any AI. No scraping. No API wrangling.**
 
 Tandem is a local-first Electron browser where a human and an AI agent browse
 together. The agent sees what you see, navigates your tabs, reads your pages,
@@ -50,7 +50,7 @@ Want the fastest path in?
 | **System** | 6 | Browser status, headless mode, Google Photos, security overrides |
 | **Awareness** | 2 | Activity digest, real-time focus detection — the AI knows what you're doing |
 
-**244 tools total** — full parity with the HTTP API.
+**248 tools total** — full parity with the HTTP API.
 
 ## Why Not Just Use Playwright?
 
@@ -121,7 +121,7 @@ Add to your MCP configuration:
 }
 ```
 
-Start Tandem, and 244 tools are available immediately.
+Start Tandem, and 248 tools are available immediately.
 
 ### Cursor / Windsurf / Other MCP Clients
 

--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,7 @@ Last updated: April 13, 2026
 ## Current Snapshot
 
 - Current app version: `0.70.0`
-- MCP server: 244 tools (full API parity + awareness)
+- MCP server: 248 tools (full API parity + awareness)
 - The codebase scope is larger than this backlog summary and includes major subsystems such as `sidebar`, `workspaces`, `pinboards`, `sync`, `headless`, and `sessions`.
 - Scheduled browsing already exists in baseline form via `WatchManager` and the `/watch/*` API routes.
 - Session isolation already exists in baseline form via `SessionManager` and the `/sessions/*` API routes.
@@ -60,7 +60,7 @@ Last updated: April 13, 2026
 - [ ] Investigate strict Gatekeeper fallback blocking mainstream site scripts when the local agent bridge is unavailable; manual startup checks on March 14, 2026 showed GitHub asset scripts being denied under `strict_low_trust_script`
 - [ ] Investigate the remaining 1Password MV3 service-worker startup noise (`DidStartWorkerFail ...: 5` and policy calculation errors) and determine whether it affects any real user-facing behavior; the old `__tandemExtensionHeaders` background error is fixed, and current manual checks indicate the extension still works for normal use
 - [ ] Make `ContextBridge` summaries natively actor/workspace-aware so `/context/summary` and other non-MCP consumers stop relying on MCP-side enrichment for ownership context
-- [ ] Expand the new handoff system with richer task linkage, agent-side resume signals, and a dedicated handoff history/detail view beyond the first Activity-tab inbox
+- [ ] Expand the new handoff system beyond the first Activity-tab inbox with a dedicated handoff history/detail view; task-linked ready/resume/approve/reject actions now flow through a shared task↔handoff coordinator
 - [x] Add GitHub Actions verification for `npm run verify` on pushes and pull requests
 
 ## Later

--- a/docs/api.html
+++ b/docs/api.html
@@ -117,7 +117,7 @@ footer a:hover{color:var(--text2)}
 <div class="hero-stats">
 <div class="stat"><span class="stat-num">280+</span><span class="stat-label">Endpoints</span></div>
 <div class="stat"><span class="stat-num">19</span><span class="stat-label">Domains</span></div>
-<div class="stat"><span class="stat-num">244</span><span class="stat-label">MCP tools</span></div>
+<div class="stat"><span class="stat-num">248</span><span class="stat-label">MCP tools</span></div>
 </div>
 </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,9 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Tandem Browser — The AI browser where human and AI work as one</title>
-<meta name="description" content="Tandem Browser is the local-first browser for real human-AI collaboration. 513 GitHub stars, 244 MCP tools, 300+ HTTP endpoints, strong security boundaries, open source MIT developer preview.">
+<meta name="description" content="Tandem Browser is the local-first browser for real human-AI collaboration. 513 GitHub stars, 248 MCP tools, 300+ HTTP endpoints, strong security boundaries, open source MIT developer preview.">
 <meta property="og:title" content="Tandem Browser">
-<meta property="og:description" content="Local-first browser for real human-AI collaboration. 513 GitHub stars, 244 MCP tools, 300+ HTTP endpoints, MIT developer preview.">
+<meta property="og:description" content="Local-first browser for real human-AI collaboration. 513 GitHub stars, 248 MCP tools, 300+ HTTP endpoints, MIT developer preview.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://tandembrowser.org">
 <link rel="canonical" href="https://tandembrowser.org">
@@ -145,7 +145,7 @@ footer a:hover{color:var(--text2)}
 <p>Tandem Browser gives AI agents secure access to a real human browser. No API wrappers, no scraping, no bot detection. The accessibility tree becomes the universal interaction layer. The AI rides alongside you, same tabs, same session, same screen.</p>
 <div class="hero-stats">
 <div class="stat"><span class="stat-num">513</span><span class="stat-label">GitHub stars</span></div>
-<div class="stat"><span class="stat-num">244</span><span class="stat-label">MCP tools</span></div>
+<div class="stat"><span class="stat-num">248</span><span class="stat-label">MCP tools</span></div>
 <div class="stat"><span class="stat-num">300+</span><span class="stat-label">HTTP endpoints</span></div>
 <div class="stat"><span class="stat-num">8</span><span class="stat-label">Security layers</span></div>
 </div>

--- a/docs/public-launch.md
+++ b/docs/public-launch.md
@@ -5,7 +5,7 @@ repository to the public.
 
 ## GitHub Repository Description
 
-Agent-first browser for human-AI collaboration — 244 MCP tools, 300+ HTTP endpoints, built-in security.
+Agent-first browser for human-AI collaboration — 248 MCP tools, 300+ HTTP endpoints, built-in security.
 
 ## Short Tagline
 
@@ -13,14 +13,14 @@ An agent-first browser for human-AI collaboration.
 
 ## Social / Announcement One-Liner
 
-Tandem Browser is now public: an agent-first browser for human-AI collaboration with 244 MCP tools and 300+ HTTP endpoints, released as a developer preview.
+Tandem Browser is now public: an agent-first browser for human-AI collaboration with 248 MCP tools and 300+ HTTP endpoints, released as a developer preview.
 
 ## Launch Post
 
 Tandem Browser is now public.
 
 Tandem is an agent-first browser built for human-AI collaboration on the local
-machine. The human browses normally. Any AI agent that speaks MCP (244 tools) or
+machine. The human browses normally. Any AI agent that speaks MCP (248 tools) or
 HTTP (300+ endpoints) gets full browser control for navigation, extraction,
 automation, screenshots, session work, and observability, while websites
 continue to see a normal Chromium browser instead of an "AI browser" fingerprint.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tandem-browser",
   "version": "0.70.0",
-  "description": "Local-first Electron browser for human-AI collaboration with 244-tool MCP server, 300+ endpoint HTTP API, and built-in security controls",
+  "description": "Local-first Electron browser for human-AI collaboration with 248-tool MCP server, 300+ endpoint HTTP API, and built-in security controls",
   "main": "dist/main.js",
   "author": "Tandem Browser contributors",
   "license": "MIT",

--- a/shell/js/wingman.js
+++ b/shell/js/wingman.js
@@ -240,6 +240,22 @@
         await fetch(`http://localhost:8765/handoffs/${handoffId}/resolve`, { method: 'POST' });
       }
 
+      async function markHandoffReady(handoffId) {
+        await fetch(`http://localhost:8765/handoffs/${handoffId}/ready`, { method: 'POST' });
+      }
+
+      async function resumeHandoff(handoffId) {
+        await fetch(`http://localhost:8765/handoffs/${handoffId}/resume`, { method: 'POST' });
+      }
+
+      async function approveHandoff(handoffId) {
+        await fetch(`http://localhost:8765/handoffs/${handoffId}/approve`, { method: 'POST' });
+      }
+
+      async function rejectHandoff(handoffId) {
+        await fetch(`http://localhost:8765/handoffs/${handoffId}/reject`, { method: 'POST' });
+      }
+
       async function hydrateHandoff(handoff) {
         if (!handoff || !handoff.id) return handoff;
         if (handoff.workspaceName || handoff.tabTitle || handoff.tabUrl) return handoff;
@@ -271,6 +287,17 @@
           if (handoff.source || handoff.agentId) meta.push(`<span class="handoff-pill">Source: ${escapeHtml(handoff.source || handoff.agentId)}</span>`);
           if (handoff.actionLabel) meta.push(`<span class="handoff-pill">${escapeHtml(handoff.actionLabel)}</span>`);
 
+          const actionButtons = ['<button class="primary" data-action="open">Open Context</button>'];
+          if (handoff.status === 'waiting_approval') {
+            actionButtons.push('<button data-action="approve">Approve</button>');
+            actionButtons.push('<button data-action="reject">Reject</button>');
+          } else if (handoff.status === 'ready_to_resume') {
+            actionButtons.push('<button data-action="resume">Resume Agent</button>');
+          } else if (handoff.status === 'needs_human' || handoff.status === 'blocked') {
+            actionButtons.push('<button data-action="ready">Mark Ready</button>');
+          }
+          actionButtons.push(`<button data-action="resolve">${handoff.status === 'completed_review' ? 'Mark Reviewed' : 'Resolve'}</button>`);
+
           card.innerHTML = `
             <div class="handoff-topline">
               <span class="handoff-status">${escapeHtml(formatHandoffStatus(handoff.status))}</span>
@@ -280,9 +307,7 @@
             <div class="handoff-body">${escapeHtml(handoff.body || '')}</div>
             <div class="handoff-meta">${meta.join('')}</div>
             <div class="handoff-actions">
-              <button class="primary" data-action="open">Open Context</button>
-              <button data-action="ready">Mark Ready</button>
-              <button data-action="resolve">${handoff.status === 'completed_review' ? 'Mark Reviewed' : 'Resolve'}</button>
+              ${actionButtons.join('')}
             </div>
           `;
 
@@ -294,13 +319,49 @@
             }
           });
 
-          card.querySelector('[data-action="ready"]').addEventListener('click', async () => {
-            try {
-              await updateHandoffStatus(handoff.id, { status: 'ready_to_resume', open: true });
-            } catch (e) {
-              console.error('updateHandoffStatus failed:', e);
-            }
-          });
+          const readyButton = card.querySelector('[data-action="ready"]');
+          if (readyButton) {
+            readyButton.addEventListener('click', async () => {
+              try {
+                await markHandoffReady(handoff.id);
+              } catch (e) {
+                console.error('markHandoffReady failed:', e);
+              }
+            });
+          }
+
+          const resumeButton = card.querySelector('[data-action="resume"]');
+          if (resumeButton) {
+            resumeButton.addEventListener('click', async () => {
+              try {
+                await resumeHandoff(handoff.id);
+              } catch (e) {
+                console.error('resumeHandoff failed:', e);
+              }
+            });
+          }
+
+          const approveButton = card.querySelector('[data-action="approve"]');
+          if (approveButton) {
+            approveButton.addEventListener('click', async () => {
+              try {
+                await approveHandoff(handoff.id);
+              } catch (e) {
+                console.error('approveHandoff failed:', e);
+              }
+            });
+          }
+
+          const rejectButton = card.querySelector('[data-action="reject"]');
+          if (rejectButton) {
+            rejectButton.addEventListener('click', async () => {
+              try {
+                await rejectHandoff(handoff.id);
+              } catch (e) {
+                console.error('rejectHandoff failed:', e);
+              }
+            });
+          }
 
           card.querySelector('[data-action="resolve"]').addEventListener('click', async () => {
             try {

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -22,7 +22,7 @@ instead of a sandbox browser, especially for:
 
 ### Option 1: MCP Server (recommended)
 
-The MCP server exposes 244 tools with full API parity. Add to your MCP client
+The MCP server exposes 248 tools with full API parity. Add to your MCP client
 configuration (e.g. `~/.claude/settings.json` for Claude Code):
 
 ```json
@@ -36,7 +36,7 @@ configuration (e.g. `~/.claude/settings.json` for Claude Code):
 }
 ```
 
-Start Tandem (`npm start`), and the agent has 244 tools available immediately.
+Start Tandem (`npm start`), and the agent has 248 tools available immediately.
 All MCP tools mirror the HTTP API below, so the same capabilities are available
 through either connection method.
 

--- a/src/agents/task-handoff-coordinator.ts
+++ b/src/agents/task-handoff-coordinator.ts
@@ -1,0 +1,214 @@
+import type { Handoff, HandoffManager } from '../handoffs/manager';
+import type { TaskManager } from './task-manager';
+
+function appendHandoffNote(body: string, note: string): string {
+  const trimmedBody = body.trim();
+  return trimmedBody ? `${trimmedBody}\n\n${note}` : note;
+}
+
+/**
+ * Keeps task execution state and durable human↔agent handoffs in sync.
+ */
+export class TaskHandoffCoordinator {
+  constructor(
+    private readonly taskManager: TaskManager,
+    private readonly handoffManager: HandoffManager,
+  ) {}
+
+  handleApprovalRequest(data: Record<string, unknown>): Handoff | null {
+    const taskId = typeof data.taskId === 'string' ? data.taskId : null;
+    const stepId = typeof data.stepId === 'string' ? data.stepId : null;
+    const task = taskId ? this.taskManager.getTask(taskId) : null;
+    const action = data.action && typeof data.action === 'object'
+      ? data.action as { params?: Record<string, unknown> }
+      : null;
+    const params = action?.params ?? {};
+
+    const existing = taskId && stepId
+      ? this.handoffManager.findOpenByTaskStep(taskId, stepId)
+      : null;
+
+    const payload = {
+      status: 'waiting_approval' as const,
+      title: 'Approval needed',
+      body: typeof data.description === 'string' ? data.description : 'Agent action requires review.',
+      reason: 'approval_required',
+      actionLabel: 'Approve or reject this action',
+      source: task?.createdBy ?? 'wingman',
+      agentId: task?.assignedTo ?? null,
+      taskId,
+      stepId,
+      workspaceId: typeof params.workspaceId === 'string' ? params.workspaceId : null,
+      tabId: typeof params.tabId === 'string' ? params.tabId : null,
+    };
+
+    const handoff = existing
+      ? this.handoffManager.update(existing.id, payload)
+      : this.handoffManager.create(payload);
+
+    if (!handoff) {
+      return null;
+    }
+
+    this.syncHandoffState(handoff);
+    return handoff;
+  }
+
+  handleApprovalResponse(data: { requestId: string; approved: boolean }): Handoff | null {
+    const [taskId, stepId] = data.requestId.split(':');
+    if (!taskId || !stepId) {
+      return null;
+    }
+
+    const handoff = this.findLinkedHandoff(taskId, stepId);
+    if (!handoff) {
+      return null;
+    }
+
+    const updated = this.handoffManager.update(handoff.id, {
+      status: 'resolved',
+      open: false,
+      actionLabel: data.approved ? 'Approval granted' : 'Approval rejected',
+      body: appendHandoffNote(
+        handoff.body,
+        data.approved ? 'Approval granted.' : 'Approval rejected.',
+      ),
+    });
+
+    if (!updated) {
+      return null;
+    }
+
+    this.syncHandoffState(updated);
+    return updated;
+  }
+
+  syncHandoffState(handoffOrId: string | Handoff): Handoff | null {
+    const handoff = typeof handoffOrId === 'string'
+      ? this.handoffManager.get(handoffOrId)
+      : handoffOrId;
+    if (!handoff) {
+      return null;
+    }
+    if (!handoff.taskId || !handoff.stepId) {
+      return handoff;
+    }
+
+    switch (handoff.status) {
+      case 'waiting_approval':
+        this.taskManager.pauseTaskForHandoff(handoff.taskId, handoff.stepId, handoff.id, 'approval');
+        break;
+      case 'needs_human':
+      case 'blocked':
+        this.taskManager.pauseTaskForHandoff(handoff.taskId, handoff.stepId, handoff.id, 'human');
+        break;
+      case 'completed_review':
+        this.taskManager.linkStepHandoff(handoff.taskId, handoff.stepId, handoff.id, 'review');
+        break;
+      case 'ready_to_resume':
+        this.taskManager.markTaskReadyToResume(handoff.taskId, handoff.stepId, handoff.id);
+        break;
+      case 'resolved':
+        this.taskManager.clearStepHandoff(handoff.taskId, handoff.stepId, handoff.id);
+        break;
+      default:
+        break;
+    }
+
+    return handoff;
+  }
+
+  markReady(handoffId: string): Handoff | null {
+    const handoff = this.handoffManager.update(handoffId, {
+      status: 'ready_to_resume',
+      open: true,
+      actionLabel: 'Resume agent',
+      body: appendHandoffNote(
+        this.requireHandoff(handoffId)?.body ?? '',
+        'Human marked this task ready for the agent to resume.',
+      ),
+    });
+    if (!handoff) {
+      return null;
+    }
+    this.syncHandoffState(handoff);
+    return handoff;
+  }
+
+  resume(handoffId: string): Handoff | null {
+    const handoff = this.requireHandoff(handoffId);
+    if (!handoff) {
+      return null;
+    }
+
+    if (handoff.taskId && handoff.stepId) {
+      const resumed = this.taskManager.resumeTask(handoff.taskId, handoff.stepId, handoff.id);
+      if (!resumed) {
+        throw new Error(`Task ${handoff.taskId} step ${handoff.stepId} is not resumable`);
+      }
+    }
+
+    const resolved = this.handoffManager.update(handoff.id, {
+      status: 'resolved',
+      open: false,
+      actionLabel: 'Agent resumed',
+      body: appendHandoffNote(handoff.body, 'Agent resumed from this handoff.'),
+    });
+    if (!resolved) {
+      return null;
+    }
+
+    this.syncHandoffState(resolved);
+    return resolved;
+  }
+
+  approve(handoffId: string): Handoff | null {
+    const handoff = this.requireTaskLinkedHandoff(handoffId, 'approve');
+    if (!handoff) {
+      return null;
+    }
+
+    this.taskManager.respondToApproval(handoff.taskId as string, handoff.stepId as string, true);
+    return this.handoffManager.get(handoffId);
+  }
+
+  reject(handoffId: string): Handoff | null {
+    const handoff = this.requireTaskLinkedHandoff(handoffId, 'reject');
+    if (!handoff) {
+      return null;
+    }
+
+    this.taskManager.respondToApproval(handoff.taskId as string, handoff.stepId as string, false);
+    return this.handoffManager.get(handoffId);
+  }
+
+  private findLinkedHandoff(taskId: string, stepId: string): Handoff | null {
+    const taskContext = this.taskManager.getStep(taskId, stepId);
+    const handoffId = taskContext?.step.handoffId;
+    if (handoffId) {
+      const linked = this.handoffManager.get(handoffId);
+      if (linked) {
+        return linked;
+      }
+    }
+    return this.handoffManager.findOpenByTaskStep(taskId, stepId);
+  }
+
+  private requireHandoff(handoffId: string): Handoff | null {
+    return this.handoffManager.get(handoffId);
+  }
+
+  private requireTaskLinkedHandoff(handoffId: string, verb: string): Handoff | null {
+    const handoff = this.requireHandoff(handoffId);
+    if (!handoff) {
+      return null;
+    }
+    if (!handoff.taskId || !handoff.stepId) {
+      throw new Error(`Cannot ${verb} a handoff that is not linked to a task step`);
+    }
+    if (!this.taskManager.getStep(handoff.taskId, handoff.stepId)) {
+      throw new Error(`Linked task ${handoff.taskId} step ${handoff.stepId} was not found`);
+    }
+    return handoff;
+  }
+}

--- a/src/agents/task-manager.ts
+++ b/src/agents/task-manager.ts
@@ -19,8 +19,9 @@ import { assertSinglePathSegment, hostnameMatches, resolvePathWithinRoot, tryPar
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 export type RiskLevel = 'none' | 'low' | 'medium' | 'high';
-export type TaskStatus = 'pending' | 'running' | 'paused' | 'waiting-approval' | 'done' | 'failed' | 'cancelled';
+export type TaskStatus = 'pending' | 'running' | 'paused' | 'waiting-approval' | 'ready-to-resume' | 'done' | 'failed' | 'cancelled';
 export type StepStatus = 'pending' | 'running' | 'done' | 'skipped' | 'rejected';
+export type StepWaitState = 'approval' | 'human' | 'review';
 
 export interface TaskStep {
   id: string;
@@ -32,6 +33,9 @@ export interface TaskStep {
   result?: unknown;
   startedAt?: number;
   completedAt?: number;
+  handoffId?: string;
+  waitingOn?: StepWaitState;
+  readyToResumeAt?: number;
 }
 
 export interface AITask {
@@ -332,6 +336,119 @@ export class TaskManager extends EventEmitter {
       approved,
       approvedBy: 'user',
     });
+  }
+
+  getStep(taskId: string, stepId: string): { task: AITask; step: TaskStep; stepIndex: number } | null {
+    const task = this.getTask(taskId);
+    if (!task) return null;
+
+    const stepIndex = task.steps.findIndex(step => step.id === stepId);
+    if (stepIndex < 0) return null;
+
+    const step = task.steps[stepIndex];
+    if (!step) return null;
+
+    return { task, step, stepIndex };
+  }
+
+  pauseTaskForHandoff(taskId: string, stepId: string, handoffId: string, waitingOn: Extract<StepWaitState, 'approval' | 'human'>): AITask | null {
+    const context = this.getStep(taskId, stepId);
+    if (!context) return null;
+
+    const { task, step } = context;
+    step.handoffId = handoffId;
+    step.waitingOn = waitingOn;
+    delete step.readyToResumeAt;
+
+    if (step.status === 'running') {
+      step.status = 'pending';
+    }
+
+    task.status = waitingOn === 'approval' ? 'waiting-approval' : 'paused';
+    this.saveTask(task);
+    this.emit('task-updated', task);
+    return task;
+  }
+
+  linkStepHandoff(taskId: string, stepId: string, handoffId: string, waitingOn: StepWaitState): AITask | null {
+    const context = this.getStep(taskId, stepId);
+    if (!context) return null;
+
+    const { task, step } = context;
+    step.handoffId = handoffId;
+    step.waitingOn = waitingOn;
+    if (waitingOn !== 'human') {
+      delete step.readyToResumeAt;
+    }
+
+    this.saveTask(task);
+    this.emit('task-updated', task);
+    return task;
+  }
+
+  markTaskReadyToResume(taskId: string, stepId: string, handoffId: string): AITask | null {
+    const context = this.getStep(taskId, stepId);
+    if (!context) return null;
+
+    const { task, step } = context;
+    if (step.status === 'done' || step.status === 'skipped' || step.status === 'rejected') {
+      return task;
+    }
+
+    step.handoffId = handoffId;
+    delete step.waitingOn;
+    step.readyToResumeAt = Date.now();
+    if (step.status === 'running') {
+      step.status = 'pending';
+    }
+
+    task.status = 'ready-to-resume';
+    this.saveTask(task);
+    this.emit('task-updated', task);
+    return task;
+  }
+
+  resumeTask(taskId: string, stepId: string, handoffId?: string): AITask | null {
+    const context = this.getStep(taskId, stepId);
+    if (!context) return null;
+
+    const { task, step } = context;
+    if (step.status === 'done' || step.status === 'skipped' || step.status === 'rejected') {
+      return null;
+    }
+
+    if (handoffId && step.handoffId && step.handoffId !== handoffId) {
+      return null;
+    }
+
+    step.status = 'running';
+    step.startedAt = Date.now();
+    delete step.waitingOn;
+    delete step.readyToResumeAt;
+    delete step.handoffId;
+
+    task.status = 'running';
+    this.saveTask(task);
+    this.emit('task-updated', task);
+    return task;
+  }
+
+  clearStepHandoff(taskId: string, stepId: string, handoffId?: string): AITask | null {
+    const context = this.getStep(taskId, stepId);
+    if (!context) return null;
+
+    const { task, step } = context;
+    if (handoffId && step.handoffId && step.handoffId !== handoffId) {
+      return null;
+    }
+
+    delete step.handoffId;
+    delete step.waitingOn;
+    delete step.readyToResumeAt;
+
+    this.saveTask(task);
+    this.emit('task-updated', task);
+    return task;
   }
 
   // ── Task Execution Updates ──

--- a/src/agents/tests/task-handoff-coordinator.test.ts
+++ b/src/agents/tests/task-handoff-coordinator.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TaskHandoffCoordinator } from '../task-handoff-coordinator';
+
+function createHandoff(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'handoff-1',
+    status: 'needs_human',
+    title: 'Need help',
+    body: 'Solve captcha',
+    reason: 'captcha',
+    workspaceId: null,
+    tabId: null,
+    agentId: 'claude',
+    source: 'claude',
+    actionLabel: null,
+    taskId: 'task-1',
+    stepId: 'step-1',
+    open: true,
+    createdAt: 1,
+    updatedAt: 2,
+    ...overrides,
+  };
+}
+
+describe('TaskHandoffCoordinator', () => {
+  const taskManager = {
+    getTask: vi.fn(),
+    getStep: vi.fn(),
+    pauseTaskForHandoff: vi.fn(),
+    linkStepHandoff: vi.fn(),
+    markTaskReadyToResume: vi.fn(),
+    resumeTask: vi.fn(),
+    clearStepHandoff: vi.fn(),
+    respondToApproval: vi.fn(),
+  } as any;
+
+  const handoffManager = {
+    findOpenByTaskStep: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    get: vi.fn(),
+  } as any;
+
+  let coordinator: TaskHandoffCoordinator;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    coordinator = new TaskHandoffCoordinator(taskManager, handoffManager);
+  });
+
+  it('creates approval handoffs and pauses the linked task step for approval', () => {
+    taskManager.getTask.mockReturnValue({ createdBy: 'user', assignedTo: 'claude' });
+    handoffManager.create.mockReturnValue(createHandoff({ status: 'waiting_approval', reason: 'approval_required' }));
+
+    const handoff = coordinator.handleApprovalRequest({
+      taskId: 'task-1',
+      stepId: 'step-1',
+      description: 'Delete all rows',
+      action: { params: { workspaceId: 'ws-1', tabId: 'tab-1' } },
+    });
+
+    expect(handoffManager.create).toHaveBeenCalledWith(expect.objectContaining({
+      status: 'waiting_approval',
+      workspaceId: 'ws-1',
+      tabId: 'tab-1',
+      source: 'user',
+    }));
+    expect(taskManager.pauseTaskForHandoff).toHaveBeenCalledWith('task-1', 'step-1', 'handoff-1', 'approval');
+    expect(handoff?.status).toBe('waiting_approval');
+  });
+
+  it('marks human-blocked handoffs ready and transitions the task to resumable state', () => {
+    const updated = createHandoff({
+      status: 'ready_to_resume',
+      actionLabel: 'Resume agent',
+      body: 'Solve captcha\n\nHuman marked this task ready for the agent to resume.',
+    });
+    handoffManager.get.mockReturnValue(createHandoff());
+    handoffManager.update.mockReturnValue(updated);
+
+    const handoff = coordinator.markReady('handoff-1');
+
+    expect(handoffManager.update).toHaveBeenCalledWith('handoff-1', expect.objectContaining({
+      status: 'ready_to_resume',
+      open: true,
+      actionLabel: 'Resume agent',
+    }));
+    expect(taskManager.markTaskReadyToResume).toHaveBeenCalledWith('task-1', 'step-1', 'handoff-1');
+    expect(handoff?.status).toBe('ready_to_resume');
+  });
+
+  it('resumes a linked task and resolves the handoff', () => {
+    handoffManager.get.mockReturnValue(createHandoff({ status: 'ready_to_resume' }));
+    taskManager.resumeTask.mockReturnValue({ id: 'task-1', status: 'running' });
+    handoffManager.update.mockReturnValue(createHandoff({
+      status: 'resolved',
+      open: false,
+      actionLabel: 'Agent resumed',
+      resolvedAt: 3,
+    }));
+
+    const handoff = coordinator.resume('handoff-1');
+
+    expect(taskManager.resumeTask).toHaveBeenCalledWith('task-1', 'step-1', 'handoff-1');
+    expect(handoffManager.update).toHaveBeenCalledWith('handoff-1', expect.objectContaining({
+      status: 'resolved',
+      open: false,
+      actionLabel: 'Agent resumed',
+    }));
+    expect(taskManager.clearStepHandoff).toHaveBeenCalledWith('task-1', 'step-1', 'handoff-1');
+    expect(handoff?.status).toBe('resolved');
+  });
+
+  it('approves and rejects waiting handoffs through the linked task step', () => {
+    const waiting = createHandoff({ status: 'waiting_approval', reason: 'approval_required' });
+    handoffManager.get.mockReturnValue(waiting);
+    taskManager.getStep.mockReturnValue({ task: { id: 'task-1' }, step: { id: 'step-1' }, stepIndex: 0 });
+
+    coordinator.approve('handoff-1');
+    coordinator.reject('handoff-1');
+
+    expect(taskManager.respondToApproval).toHaveBeenNthCalledWith(1, 'task-1', 'step-1', true);
+    expect(taskManager.respondToApproval).toHaveBeenNthCalledWith(2, 'task-1', 'step-1', false);
+  });
+
+  it('syncs resolved handoffs by clearing linked step metadata', () => {
+    const handoff = createHandoff({ status: 'resolved', open: false });
+
+    coordinator.syncHandoffState(handoff);
+
+    expect(taskManager.clearStepHandoff).toHaveBeenCalledWith('task-1', 'step-1', 'handoff-1');
+  });
+});

--- a/src/agents/tests/task-handoff-coordinator.test.ts
+++ b/src/agents/tests/task-handoff-coordinator.test.ts
@@ -69,6 +69,44 @@ describe('TaskHandoffCoordinator', () => {
     expect(handoff?.status).toBe('waiting_approval');
   });
 
+  it('updates an existing approval handoff instead of creating a duplicate', () => {
+    taskManager.getTask.mockReturnValue({ createdBy: 'openclaw', assignedTo: 'claude' });
+    handoffManager.findOpenByTaskStep.mockReturnValue(createHandoff({ id: 'handoff-existing' }));
+    handoffManager.update.mockReturnValue(createHandoff({
+      id: 'handoff-existing',
+      status: 'waiting_approval',
+      reason: 'approval_required',
+    }));
+
+    const handoff = coordinator.handleApprovalRequest({
+      taskId: 'task-1',
+      stepId: 'step-1',
+      action: null,
+    });
+
+    expect(handoffManager.update).toHaveBeenCalledWith('handoff-existing', expect.objectContaining({
+      source: 'openclaw',
+      body: 'Agent action requires review.',
+      workspaceId: null,
+      tabId: null,
+    }));
+    expect(handoffManager.create).not.toHaveBeenCalled();
+    expect(handoff?.id).toBe('handoff-existing');
+  });
+
+  it('returns null when approval handoff creation/update fails', () => {
+    handoffManager.findOpenByTaskStep.mockReturnValue(null);
+    handoffManager.create.mockReturnValue(null);
+
+    const handoff = coordinator.handleApprovalRequest({
+      taskId: 'task-1',
+      stepId: 'step-1',
+    });
+
+    expect(handoff).toBeNull();
+    expect(taskManager.pauseTaskForHandoff).not.toHaveBeenCalled();
+  });
+
   it('marks human-blocked handoffs ready and transitions the task to resumable state', () => {
     const updated = createHandoff({
       status: 'ready_to_resume',
@@ -87,6 +125,14 @@ describe('TaskHandoffCoordinator', () => {
     }));
     expect(taskManager.markTaskReadyToResume).toHaveBeenCalledWith('task-1', 'step-1', 'handoff-1');
     expect(handoff?.status).toBe('ready_to_resume');
+  });
+
+  it('returns null when markReady cannot update the handoff', () => {
+    handoffManager.get.mockReturnValue(null);
+    handoffManager.update.mockReturnValue(null);
+
+    expect(coordinator.markReady('handoff-missing')).toBeNull();
+    expect(taskManager.markTaskReadyToResume).not.toHaveBeenCalled();
   });
 
   it('resumes a linked task and resolves the handoff', () => {
@@ -111,10 +157,42 @@ describe('TaskHandoffCoordinator', () => {
     expect(handoff?.status).toBe('resolved');
   });
 
+  it('resolves non-task handoffs without trying to resume a task', () => {
+    handoffManager.get.mockReturnValue(createHandoff({ taskId: null, stepId: null, body: '' }));
+    handoffManager.update.mockReturnValue(createHandoff({
+      taskId: null,
+      stepId: null,
+      status: 'resolved',
+      open: false,
+      actionLabel: 'Agent resumed',
+      body: 'Agent resumed from this handoff.',
+      resolvedAt: 3,
+    }));
+
+    const handoff = coordinator.resume('handoff-1');
+
+    expect(taskManager.resumeTask).not.toHaveBeenCalled();
+    expect(handoff?.status).toBe('resolved');
+  });
+
+  it('throws when a linked task handoff is not resumable', () => {
+    handoffManager.get.mockReturnValue(createHandoff({ status: 'ready_to_resume' }));
+    taskManager.resumeTask.mockReturnValue(null);
+
+    expect(() => coordinator.resume('handoff-1')).toThrow('Task task-1 step step-1 is not resumable');
+  });
+
+  it('returns null when resume cannot find a handoff', () => {
+    handoffManager.get.mockReturnValue(null);
+
+    expect(coordinator.resume('handoff-missing')).toBeNull();
+  });
+
   it('approves and rejects waiting handoffs through the linked task step', () => {
     const waiting = createHandoff({ status: 'waiting_approval', reason: 'approval_required' });
     handoffManager.get.mockReturnValue(waiting);
     taskManager.getStep.mockReturnValue({ task: { id: 'task-1' }, step: { id: 'step-1' }, stepIndex: 0 });
+    handoffManager.get.mockReturnValueOnce(waiting).mockReturnValueOnce(waiting).mockReturnValueOnce(waiting).mockReturnValueOnce(waiting);
 
     coordinator.approve('handoff-1');
     coordinator.reject('handoff-1');
@@ -123,11 +201,87 @@ describe('TaskHandoffCoordinator', () => {
     expect(taskManager.respondToApproval).toHaveBeenNthCalledWith(2, 'task-1', 'step-1', false);
   });
 
+  it('returns null when approve cannot find a handoff', () => {
+    handoffManager.get.mockReturnValue(null);
+
+    expect(coordinator.approve('handoff-missing')).toBeNull();
+  });
+
+  it('throws when approve/reject target is not linked to a task step', () => {
+    handoffManager.get.mockReturnValue(createHandoff({ taskId: null, stepId: null }));
+
+    expect(() => coordinator.approve('handoff-1')).toThrow('Cannot approve a handoff that is not linked to a task step');
+    expect(() => coordinator.reject('handoff-1')).toThrow('Cannot reject a handoff that is not linked to a task step');
+  });
+
+  it('throws when approve/reject target task step is missing', () => {
+    handoffManager.get.mockReturnValue(createHandoff());
+    taskManager.getStep.mockReturnValue(null);
+
+    expect(() => coordinator.approve('handoff-1')).toThrow('Linked task task-1 step step-1 was not found');
+  });
+
   it('syncs resolved handoffs by clearing linked step metadata', () => {
     const handoff = createHandoff({ status: 'resolved', open: false });
 
     coordinator.syncHandoffState(handoff);
 
     expect(taskManager.clearStepHandoff).toHaveBeenCalledWith('task-1', 'step-1', 'handoff-1');
+  });
+
+  it('syncs completed-review handoffs', () => {
+    const review = createHandoff({ id: 'handoff-review', status: 'completed_review' });
+    handoffManager.get.mockReturnValue(review);
+
+    expect(coordinator.syncHandoffState('handoff-review')).toEqual(review);
+    expect(taskManager.linkStepHandoff).toHaveBeenCalledWith('task-1', 'step-1', 'handoff-review', 'review');
+  });
+
+  it('falls back to lookup by task/step when linked handoff id is stale', () => {
+    const review = createHandoff({ id: 'handoff-review', status: 'completed_review' });
+    taskManager.getStep.mockReturnValue({ task: { id: 'task-1' }, step: { id: 'step-1', handoffId: 'handoff-stale' }, stepIndex: 0 });
+    handoffManager.get.mockReturnValue(null);
+    handoffManager.findOpenByTaskStep.mockReturnValue(review);
+    handoffManager.update.mockReturnValue(createHandoff({
+      id: 'handoff-review',
+      status: 'resolved',
+      open: false,
+      actionLabel: 'Approval rejected',
+      resolvedAt: 3,
+    }));
+
+    const found = coordinator.handleApprovalResponse({ requestId: 'task-1:step-1', approved: false });
+    expect(handoffManager.update).toHaveBeenCalledWith('handoff-review', expect.objectContaining({
+      actionLabel: 'Approval rejected',
+    }));
+    expect(found?.id).toBe('handoff-review');
+  });
+
+  it('returns null for invalid approval-response payloads or missing handoffs', () => {
+    expect(coordinator.handleApprovalResponse({ requestId: 'task-only', approved: true })).toBeNull();
+
+    taskManager.getStep.mockReturnValue(null);
+    handoffManager.findOpenByTaskStep.mockReturnValue(null);
+    expect(coordinator.handleApprovalResponse({ requestId: 'task-1:step-1', approved: true })).toBeNull();
+  });
+
+  it('returns null when approval-response cannot update the handoff', () => {
+    const waiting = createHandoff({ status: 'waiting_approval', reason: 'approval_required' });
+    taskManager.getStep.mockReturnValue({ task: { id: 'task-1' }, step: { id: 'step-1', handoffId: 'handoff-1' }, stepIndex: 0 });
+    handoffManager.get.mockReturnValueOnce(waiting).mockReturnValueOnce(null);
+    handoffManager.update.mockReturnValue(null);
+
+    expect(coordinator.handleApprovalResponse({ requestId: 'task-1:step-1', approved: true })).toBeNull();
+  });
+
+  it('returns null when syncing a missing handoff id and no-ops for non-task statuses', () => {
+    handoffManager.get.mockReturnValue(null);
+    expect(coordinator.syncHandoffState('missing')).toBeNull();
+
+    const ready = createHandoff({ taskId: null, stepId: null, status: 'ready_to_resume' });
+    expect(coordinator.syncHandoffState(ready)).toEqual(ready);
+
+    const unknown = createHandoff({ status: 'resolved', taskId: 'task-1', stepId: 'step-1' });
+    expect(coordinator.syncHandoffState(unknown)).toEqual(unknown);
   });
 });

--- a/src/agents/tests/task-manager.test.ts
+++ b/src/agents/tests/task-manager.test.ts
@@ -234,6 +234,49 @@ describe('TaskManager', () => {
         expect.objectContaining({ approved: true })
       );
     });
+
+    it('requestApproval returns false for an invalid step index', async () => {
+      await expect(tm.requestApproval({
+        id: 'task-1',
+        description: 'Task',
+        createdBy: 'user',
+        assignedTo: 'claude',
+        status: 'pending',
+        steps: [],
+        currentStep: 0,
+        results: [],
+        createdAt: 1,
+        updatedAt: 1,
+      }, 3)).resolves.toBe(false);
+    });
+
+    it('requestApproval resolves once the matching approval-response arrives', async () => {
+      const task = tm.createTask('Task', 'user', 'claude', [
+        { description: 'Step', action: { type: 'click', params: {} }, riskLevel: 'medium', requiresApproval: true },
+      ]);
+
+      const promise = tm.requestApproval(task, 0);
+      tm.emit('approval-response', { requestId: `${task.id}:${task.steps[0].id}`, approved: true });
+
+      await expect(promise).resolves.toBe(true);
+    });
+
+    it('respondToApproval no-ops when the task or step is missing', () => {
+      const writesBeforeMissingTask = vi.mocked(fs.writeFileSync).mock.calls.length;
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      tm.respondToApproval('missing-task', 'step-1', true);
+      expect(vi.mocked(fs.writeFileSync).mock.calls.length).toBe(writesBeforeMissingTask);
+
+      const task = tm.createTask('Task', 'user', 'claude', [
+        { description: 'Step', action: { type: 'click', params: {} }, riskLevel: 'medium', requiresApproval: true },
+      ]);
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(task));
+
+      const writesBeforeMissingStep = vi.mocked(fs.writeFileSync).mock.calls.length;
+      tm.respondToApproval(task.id, 'missing-step', true);
+      expect(vi.mocked(fs.writeFileSync).mock.calls.length).toBe(writesBeforeMissingStep);
+    });
   });
 
   describe('task lifecycle', () => {
@@ -291,6 +334,53 @@ describe('TaskManager', () => {
       }));
     });
 
+    it('pauses running steps for approval handoffs and exposes step lookup helpers', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        ...task,
+        status: 'running',
+        steps: [
+          task.steps[0],
+          { ...task.steps[1], status: 'running' },
+        ],
+      }));
+
+      const updated = tm.pauseTaskForHandoff(task.id, task.steps[1].id, 'handoff-approval', 'approval');
+      expect(updated?.status).toBe('waiting-approval');
+      expect(updated?.steps[1].status).toBe('pending');
+
+      const stepContext = tm.getStep(task.id, task.steps[1].id);
+      expect(stepContext?.stepIndex).toBe(1);
+      expect(tm.getStep(task.id, 'missing-step')).toBeNull();
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      expect(tm.getStep('missing-task', task.steps[1].id)).toBeNull();
+    });
+
+    it('links step handoffs and clears readiness only for non-human waits', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        ...task,
+        steps: [
+          task.steps[0],
+          { ...task.steps[1], handoffId: 'handoff-1', readyToResumeAt: 123, waitingOn: 'human' },
+        ],
+      }));
+
+      const humanLinked = tm.linkStepHandoff(task.id, task.steps[1].id, 'handoff-human', 'human');
+      expect(humanLinked?.steps[1].readyToResumeAt).toBe(123);
+      expect(humanLinked?.steps[1].waitingOn).toBe('human');
+
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        ...task,
+        steps: [
+          task.steps[0],
+          { ...task.steps[1], handoffId: 'handoff-1', readyToResumeAt: 123, waitingOn: 'human' },
+        ],
+      }));
+
+      const reviewLinked = tm.linkStepHandoff(task.id, task.steps[1].id, 'handoff-review', 'review');
+      expect(reviewLinked?.steps[1].readyToResumeAt).toBeUndefined();
+      expect(reviewLinked?.steps[1].waitingOn).toBe('review');
+    });
+
     it('marks a paused task ready to resume and can resume it', () => {
       tm.pauseTaskForHandoff(task.id, task.steps[1].id, 'handoff-1', 'human');
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
@@ -326,6 +416,60 @@ describe('TaskManager', () => {
         status: 'running',
       }));
       expect(resumed?.steps[1].handoffId).toBeUndefined();
+    });
+
+    it('does not move terminal steps into ready-to-resume or running again', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        ...task,
+        status: 'paused',
+        steps: [
+          task.steps[0],
+          { ...task.steps[1], status: 'done', handoffId: 'handoff-1' },
+        ],
+      }));
+
+      const ready = tm.markTaskReadyToResume(task.id, task.steps[1].id, 'handoff-1');
+      expect(ready?.status).toBe('paused');
+      expect(ready?.steps[1].status).toBe('done');
+
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        ...task,
+        status: 'ready-to-resume',
+        steps: [
+          task.steps[0],
+          { ...task.steps[1], status: 'rejected', handoffId: 'handoff-1' },
+        ],
+      }));
+
+      expect(tm.resumeTask(task.id, task.steps[1].id, 'handoff-1')).toBeNull();
+    });
+
+    it('guards resume and clear operations when handoff ids do not match', () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        ...task,
+        status: 'ready-to-resume',
+        steps: [
+          task.steps[0],
+          { ...task.steps[1], status: 'pending', handoffId: 'handoff-expected', readyToResumeAt: 123 },
+        ],
+      }));
+
+      expect(tm.resumeTask(task.id, task.steps[1].id, 'handoff-other')).toBeNull();
+
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        ...task,
+        status: 'paused',
+        steps: [
+          task.steps[0],
+          { ...task.steps[1], handoffId: 'handoff-expected', waitingOn: 'human', readyToResumeAt: 123 },
+        ],
+      }));
+
+      expect(tm.clearStepHandoff(task.id, task.steps[1].id, 'handoff-other')).toBeNull();
+      const cleared = tm.clearStepHandoff(task.id, task.steps[1].id, 'handoff-expected');
+      expect(cleared?.steps[1].handoffId).toBeUndefined();
+      expect(cleared?.steps[1].waitingOn).toBeUndefined();
+      expect(cleared?.steps[1].readyToResumeAt).toBeUndefined();
     });
   });
 });

--- a/src/agents/tests/task-manager.test.ts
+++ b/src/agents/tests/task-manager.test.ts
@@ -280,5 +280,52 @@ describe('TaskManager', () => {
       expect(written.status).toBe('failed');
       expect(written.results).toContainEqual({ error: 'Something went wrong' });
     });
+
+    it('pauses a task for a human handoff and records step metadata', () => {
+      const updated = tm.pauseTaskForHandoff(task.id, task.steps[1].id, 'handoff-1', 'human');
+
+      expect(updated?.status).toBe('paused');
+      expect(updated?.steps[1]).toEqual(expect.objectContaining({
+        handoffId: 'handoff-1',
+        waitingOn: 'human',
+      }));
+    });
+
+    it('marks a paused task ready to resume and can resume it', () => {
+      tm.pauseTaskForHandoff(task.id, task.steps[1].id, 'handoff-1', 'human');
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        ...task,
+        status: 'paused',
+        steps: [
+          task.steps[0],
+          { ...task.steps[1], handoffId: 'handoff-1', waitingOn: 'human' },
+        ],
+      }));
+
+      const ready = tm.markTaskReadyToResume(task.id, task.steps[1].id, 'handoff-1');
+      expect(ready?.status).toBe('ready-to-resume');
+      expect(ready?.steps[1].readyToResumeAt).toBeDefined();
+
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
+        ...task,
+        status: 'ready-to-resume',
+        steps: [
+          task.steps[0],
+          {
+            ...task.steps[1],
+            status: 'pending',
+            handoffId: 'handoff-1',
+            readyToResumeAt: Date.now(),
+          },
+        ],
+      }));
+
+      const resumed = tm.resumeTask(task.id, task.steps[1].id, 'handoff-1');
+      expect(resumed?.status).toBe('running');
+      expect(resumed?.steps[1]).toEqual(expect.objectContaining({
+        status: 'running',
+      }));
+      expect(resumed?.steps[1].handoffId).toBeUndefined();
+    });
   });
 });

--- a/src/api/routes/handoffs.ts
+++ b/src/api/routes/handoffs.ts
@@ -189,6 +189,8 @@ export function registerHandoffRoutes(router: Router, ctx: RouteContext): void {
         wingmanAlert(handoff.title, handoff.body || handoff.reason);
       }
 
+      ctx.taskHandoffCoordinator.syncHandoffState(handoff);
+
       res.json(serializeHandoff(ctx, handoff));
     } catch (e) {
       handleRouteError(res, e);
@@ -281,6 +283,7 @@ export function registerHandoffRoutes(router: Router, ctx: RouteContext): void {
         return;
       }
 
+      ctx.taskHandoffCoordinator.syncHandoffState(handoff);
       res.json(serializeHandoff(ctx, handoff));
     } catch (e) {
       handleRouteError(res, e);
@@ -291,6 +294,63 @@ export function registerHandoffRoutes(router: Router, ctx: RouteContext): void {
     try {
       const handoffId = req.params.id as string;
       const handoff = ctx.handoffManager.resolve(handoffId);
+      if (!handoff) {
+        res.status(404).json({ error: 'Handoff not found' });
+        return;
+      }
+      ctx.taskHandoffCoordinator.syncHandoffState(handoff);
+      res.json(serializeHandoff(ctx, handoff));
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+
+  router.post('/handoffs/:id/ready', (req: Request, res: Response) => {
+    try {
+      const handoffId = req.params.id as string;
+      const handoff = ctx.taskHandoffCoordinator.markReady(handoffId);
+      if (!handoff) {
+        res.status(404).json({ error: 'Handoff not found' });
+        return;
+      }
+      res.json(serializeHandoff(ctx, handoff));
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+
+  router.post('/handoffs/:id/resume', (req: Request, res: Response) => {
+    try {
+      const handoffId = req.params.id as string;
+      const handoff = ctx.taskHandoffCoordinator.resume(handoffId);
+      if (!handoff) {
+        res.status(404).json({ error: 'Handoff not found' });
+        return;
+      }
+      res.json(serializeHandoff(ctx, handoff));
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+
+  router.post('/handoffs/:id/approve', (req: Request, res: Response) => {
+    try {
+      const handoffId = req.params.id as string;
+      const handoff = ctx.taskHandoffCoordinator.approve(handoffId);
+      if (!handoff) {
+        res.status(404).json({ error: 'Handoff not found' });
+        return;
+      }
+      res.json(serializeHandoff(ctx, handoff));
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+
+  router.post('/handoffs/:id/reject', (req: Request, res: Response) => {
+    try {
+      const handoffId = req.params.id as string;
+      const handoff = ctx.taskHandoffCoordinator.reject(handoffId);
       if (!handoff) {
         res.status(404).json({ error: 'Handoff not found' });
         return;

--- a/src/api/tests/helpers.ts
+++ b/src/api/tests/helpers.ts
@@ -411,11 +411,17 @@ export function createMockContext(): RouteContext {
     taskManager: {
       listTasks: vi.fn().mockReturnValue([]),
       getTask: vi.fn().mockReturnValue(null),
+      getStep: vi.fn().mockReturnValue(null),
       createTask: vi.fn().mockReturnValue({ id: 'task-1', description: '', steps: [] }),
       respondToApproval: vi.fn(),
       markTaskRunning: vi.fn(),
       markTaskDone: vi.fn(),
       markTaskFailed: vi.fn(),
+      pauseTaskForHandoff: vi.fn().mockReturnValue(null),
+      linkStepHandoff: vi.fn().mockReturnValue(null),
+      markTaskReadyToResume: vi.fn().mockReturnValue(null),
+      resumeTask: vi.fn().mockReturnValue(null),
+      clearStepHandoff: vi.fn().mockReturnValue(null),
       updateStepStatus: vi.fn(),
       emergencyStop: vi.fn().mockReturnValue({ stopped: 0 }),
       requestApproval: vi.fn().mockResolvedValue(true),
@@ -590,6 +596,16 @@ export function createMockContext(): RouteContext {
       setState: vi.fn(),
       setActiveItem: vi.fn(),
       destroy: vi.fn(),
+    } as any,
+
+    taskHandoffCoordinator: {
+      handleApprovalRequest: vi.fn().mockReturnValue(null),
+      handleApprovalResponse: vi.fn().mockReturnValue(null),
+      syncHandoffState: vi.fn().mockReturnValue(null),
+      markReady: vi.fn().mockReturnValue(null),
+      resume: vi.fn().mockReturnValue(null),
+      approve: vi.fn().mockReturnValue(null),
+      reject: vi.fn().mockReturnValue(null),
     } as any,
 
     // ── workspaceManager ────────────────────────

--- a/src/api/tests/routes/handoffs.test.ts
+++ b/src/api/tests/routes/handoffs.test.ts
@@ -134,6 +134,9 @@ describe('Handoff Routes', () => {
         workspaceId: 'ws-1',
         tabId: 'tab-1',
       }));
+      expect(ctx.taskHandoffCoordinator.syncHandoffState).toHaveBeenCalledWith(expect.objectContaining({
+        id: 'handoff-2',
+      }));
       expect(res.body.workspaceName).toBe('AI Workspace');
     });
 
@@ -181,6 +184,9 @@ describe('Handoff Routes', () => {
       expect(ctx.handoffManager.create).toHaveBeenCalledWith(expect.objectContaining({
         source: null,
         actionLabel: null,
+      }));
+      expect(ctx.taskHandoffCoordinator.syncHandoffState).toHaveBeenCalledWith(expect.objectContaining({
+        id: 'handoff-5',
       }));
       expect(wingmanAlert).toHaveBeenCalledWith('Need approval', 'Please confirm');
     });
@@ -243,6 +249,9 @@ describe('Handoff Routes', () => {
         status: 'ready_to_resume',
         actionLabel: 'Resume agent',
       }));
+      expect(ctx.taskHandoffCoordinator.syncHandoffState).toHaveBeenCalledWith(expect.objectContaining({
+        id: 'handoff-3',
+      }));
     });
 
     it('returns 400 when open is not a boolean', async () => {
@@ -295,6 +304,9 @@ describe('Handoff Routes', () => {
         actionable: false,
         status: 'resolved',
       }));
+      expect(ctx.taskHandoffCoordinator.syncHandoffState).toHaveBeenCalledWith(expect.objectContaining({
+        id: 'handoff-6',
+      }));
     });
 
     it('returns 404 when resolving a missing handoff', async () => {
@@ -302,6 +314,119 @@ describe('Handoff Routes', () => {
 
       expect(res.status).toBe(404);
       expect(res.body.error).toBe('Handoff not found');
+    });
+  });
+
+  describe('POST /handoffs/:id/ready', () => {
+    it('marks a handoff ready to resume', async () => {
+      vi.mocked(ctx.taskHandoffCoordinator.markReady).mockReturnValue({
+        id: 'handoff-ready',
+        status: 'ready_to_resume',
+        title: 'Captcha solved',
+        body: 'Ready now',
+        reason: 'captcha',
+        workspaceId: null,
+        tabId: null,
+        agentId: 'claude',
+        source: 'claude',
+        actionLabel: 'Resume agent',
+        taskId: 'task-1',
+        stepId: 'step-1',
+        open: true,
+        createdAt: 1,
+        updatedAt: 2,
+      } as any);
+
+      const res = await request(app).post('/handoffs/handoff-ready/ready');
+
+      expect(res.status).toBe(200);
+      expect(ctx.taskHandoffCoordinator.markReady).toHaveBeenCalledWith('handoff-ready');
+      expect(res.body.status).toBe('ready_to_resume');
+    });
+  });
+
+  describe('POST /handoffs/:id/resume', () => {
+    it('resumes a handoff-linked task', async () => {
+      vi.mocked(ctx.taskHandoffCoordinator.resume).mockReturnValue({
+        id: 'handoff-resume',
+        status: 'resolved',
+        title: 'Resume task',
+        body: 'Resumed',
+        reason: 'human_help',
+        workspaceId: null,
+        tabId: null,
+        agentId: 'claude',
+        source: 'claude',
+        actionLabel: 'Agent resumed',
+        taskId: 'task-1',
+        stepId: 'step-1',
+        open: false,
+        createdAt: 1,
+        updatedAt: 2,
+        resolvedAt: 2,
+      } as any);
+
+      const res = await request(app).post('/handoffs/handoff-resume/resume');
+
+      expect(res.status).toBe(200);
+      expect(ctx.taskHandoffCoordinator.resume).toHaveBeenCalledWith('handoff-resume');
+      expect(res.body.status).toBe('resolved');
+    });
+  });
+
+  describe('POST /handoffs/:id/approve', () => {
+    it('approves a waiting handoff', async () => {
+      vi.mocked(ctx.taskHandoffCoordinator.approve).mockReturnValue({
+        id: 'handoff-approve',
+        status: 'resolved',
+        title: 'Approve delete',
+        body: 'Approval granted.',
+        reason: 'approval_required',
+        workspaceId: null,
+        tabId: null,
+        agentId: 'claude',
+        source: 'claude',
+        actionLabel: 'Approval granted',
+        taskId: 'task-1',
+        stepId: 'step-1',
+        open: false,
+        createdAt: 1,
+        updatedAt: 2,
+        resolvedAt: 2,
+      } as any);
+
+      const res = await request(app).post('/handoffs/handoff-approve/approve');
+
+      expect(res.status).toBe(200);
+      expect(ctx.taskHandoffCoordinator.approve).toHaveBeenCalledWith('handoff-approve');
+    });
+  });
+
+  describe('POST /handoffs/:id/reject', () => {
+    it('rejects a waiting handoff', async () => {
+      vi.mocked(ctx.taskHandoffCoordinator.reject).mockReturnValue({
+        id: 'handoff-reject',
+        status: 'resolved',
+        title: 'Reject delete',
+        body: 'Approval rejected.',
+        reason: 'approval_required',
+        workspaceId: null,
+        tabId: null,
+        agentId: 'claude',
+        source: 'claude',
+        actionLabel: 'Approval rejected',
+        taskId: 'task-1',
+        stepId: 'step-1',
+        open: false,
+        createdAt: 1,
+        updatedAt: 2,
+        resolvedAt: 2,
+      } as any);
+
+      const res = await request(app).post('/handoffs/handoff-reject/reject');
+
+      expect(res.status).toBe(200);
+      expect(ctx.taskHandoffCoordinator.reject).toHaveBeenCalledWith('handoff-reject');
     });
   });
 

--- a/src/api/tests/routes/handoffs.test.ts
+++ b/src/api/tests/routes/handoffs.test.ts
@@ -273,6 +273,76 @@ describe('Handoff Routes', () => {
       expect(res.status).toBe(404);
       expect(res.body.error).toBe('Handoff not found');
     });
+
+    it('returns 400 when title is empty or reason/body types are invalid', async () => {
+      const emptyTitle = await request(app)
+        .patch('/handoffs/handoff-3')
+        .send({ title: '   ' });
+      expect(emptyTitle.status).toBe(400);
+      expect(emptyTitle.body.error).toBe('title must be a non-empty string');
+
+      const badBody = await request(app)
+        .patch('/handoffs/handoff-3')
+        .send({ body: 42 });
+      expect(badBody.status).toBe(400);
+      expect(badBody.body.error).toBe('body must be a string');
+
+      const badReason = await request(app)
+        .patch('/handoffs/handoff-3')
+        .send({ reason: 42 });
+      expect(badReason.status).toBe(400);
+      expect(badReason.body.error).toBe('reason must be a string');
+    });
+
+    it('validates optional metadata fields and syncs patched task-linked handoffs', async () => {
+      vi.mocked(ctx.workspaceManager.getWorkspaceIdForTab).mockReturnValue('ws-1');
+      vi.mocked(ctx.workspaceManager.get).mockReturnValue({
+        id: 'ws-1',
+        name: 'AI Workspace',
+        icon: 'sparkles',
+        color: '#fff',
+        tabIds: [100],
+      } as any);
+      vi.mocked(ctx.handoffManager.update).mockReturnValue({
+        id: 'handoff-3',
+        status: 'blocked',
+        title: 'Updated',
+        body: 'Updated body',
+        reason: 'human_help',
+        workspaceId: 'ws-1',
+        tabId: 'tab-1',
+        agentId: null,
+        source: null,
+        actionLabel: null,
+        taskId: 'task-1',
+        stepId: 'step-1',
+        open: true,
+        createdAt: 1,
+        updatedAt: 2,
+      } as any);
+
+      const res = await request(app)
+        .patch('/handoffs/handoff-3')
+        .send({ workspaceId: 'ws-1', tabId: 'tab-1', source: '  ', agentId: '  ' });
+
+      expect(res.status).toBe(200);
+      expect(ctx.handoffManager.update).toHaveBeenCalledWith('handoff-3', expect.objectContaining({
+        workspaceId: 'ws-1',
+        tabId: 'tab-1',
+        source: null,
+        agentId: null,
+      }));
+      expect(ctx.taskHandoffCoordinator.syncHandoffState).toHaveBeenCalledWith(expect.objectContaining({
+        taskId: 'task-1',
+        stepId: 'step-1',
+      }));
+
+      const badSource = await request(app)
+        .patch('/handoffs/handoff-3')
+        .send({ source: 42 });
+      expect(badSource.status).toBe(400);
+      expect(badSource.body.error).toBe('source must be a string when provided');
+    });
   });
 
   describe('POST /handoffs/:id/resolve', () => {
@@ -343,6 +413,20 @@ describe('Handoff Routes', () => {
       expect(ctx.taskHandoffCoordinator.markReady).toHaveBeenCalledWith('handoff-ready');
       expect(res.body.status).toBe('ready_to_resume');
     });
+
+    it('returns 404 and surfaces coordinator errors for ready actions', async () => {
+      vi.mocked(ctx.taskHandoffCoordinator.markReady).mockReturnValueOnce(null);
+      const missing = await request(app).post('/handoffs/missing/ready');
+      expect(missing.status).toBe(404);
+      expect(missing.body.error).toBe('Handoff not found');
+
+      vi.mocked(ctx.taskHandoffCoordinator.markReady).mockImplementationOnce(() => {
+        throw new Error('handoff not resumable yet');
+      });
+      const failing = await request(app).post('/handoffs/handoff-ready/ready');
+      expect(failing.status).toBe(500);
+      expect(failing.body.error).toBe('handoff not resumable yet');
+    });
   });
 
   describe('POST /handoffs/:id/resume', () => {
@@ -372,6 +456,19 @@ describe('Handoff Routes', () => {
       expect(ctx.taskHandoffCoordinator.resume).toHaveBeenCalledWith('handoff-resume');
       expect(res.body.status).toBe('resolved');
     });
+
+    it('returns 404 and 500 variants for resume actions', async () => {
+      vi.mocked(ctx.taskHandoffCoordinator.resume).mockReturnValueOnce(null);
+      const missing = await request(app).post('/handoffs/missing/resume');
+      expect(missing.status).toBe(404);
+
+      vi.mocked(ctx.taskHandoffCoordinator.resume).mockImplementationOnce(() => {
+        throw new Error('Task task-1 step step-1 is not resumable');
+      });
+      const failing = await request(app).post('/handoffs/handoff-resume/resume');
+      expect(failing.status).toBe(500);
+      expect(failing.body.error).toContain('not resumable');
+    });
   });
 
   describe('POST /handoffs/:id/approve', () => {
@@ -400,6 +497,12 @@ describe('Handoff Routes', () => {
       expect(res.status).toBe(200);
       expect(ctx.taskHandoffCoordinator.approve).toHaveBeenCalledWith('handoff-approve');
     });
+
+    it('returns 404 when approval handoff is missing', async () => {
+      vi.mocked(ctx.taskHandoffCoordinator.approve).mockReturnValueOnce(null);
+      const res = await request(app).post('/handoffs/missing/approve');
+      expect(res.status).toBe(404);
+    });
   });
 
   describe('POST /handoffs/:id/reject', () => {
@@ -427,6 +530,12 @@ describe('Handoff Routes', () => {
 
       expect(res.status).toBe(200);
       expect(ctx.taskHandoffCoordinator.reject).toHaveBeenCalledWith('handoff-reject');
+    });
+
+    it('returns 404 when rejection handoff is missing', async () => {
+      vi.mocked(ctx.taskHandoffCoordinator.reject).mockReturnValueOnce(null);
+      const res = await request(app).post('/handoffs/missing/reject');
+      expect(res.status).toBe(404);
     });
   });
 

--- a/src/bootstrap/runtime.ts
+++ b/src/bootstrap/runtime.ts
@@ -4,6 +4,7 @@ import type { TandemAPI } from '../api/server';
 import { ActivityTracker } from '../activity/tracker';
 import { WingmanStream } from '../activity/wingman-stream';
 import { TaskManager } from '../agents/task-manager';
+import { TaskHandoffCoordinator } from '../agents/task-handoff-coordinator';
 import { TabLockManager } from '../agents/tab-lock-manager';
 import { LoginManager } from '../auth/login-manager';
 import { GooglePhotosManager } from '../integrations/google-photos';
@@ -194,6 +195,7 @@ export async function initializeRuntimeManagers(opts: InitializeRuntimeOptions):
   runtime.eventStream = new EventStreamManager();
   runtime.handoffManager = new HandoffManager();
   runtime.taskManager = new TaskManager();
+  runtime.taskHandoffCoordinator = new TaskHandoffCoordinator(runtime.taskManager, runtime.handoffManager);
   runtime.tabLockManager = new TabLockManager();
   runtime.devToolsManager = new DevToolsManager(runtime.tabManager);
   runtime.snapshotManager = new SnapshotManager(runtime.devToolsManager);
@@ -271,58 +273,11 @@ export async function initializeRuntimeManagers(opts: InitializeRuntimeOptions):
   );
 
   runtime.taskManager.on('approval-request', (data: Record<string, unknown>) => {
-    const taskId = typeof data.taskId === 'string' ? data.taskId : null;
-    const stepId = typeof data.stepId === 'string' ? data.stepId : null;
-    const task = taskId ? runtime.taskManager.getTask(taskId) : null;
-    const action = data.action && typeof data.action === 'object'
-      ? data.action as { params?: Record<string, unknown> }
-      : null;
-    const params = action?.params ?? {};
-
-    const existing = taskId && stepId
-      ? runtime.handoffManager.findOpenByTaskStep(taskId, stepId)
-      : null;
-
-    const payload = {
-      status: 'waiting_approval',
-      title: 'Approval needed',
-      body: typeof data.description === 'string' ? data.description : 'Agent action requires review.',
-      reason: 'approval_required',
-      actionLabel: 'Approve or reject this action',
-      source: task?.createdBy ?? 'wingman',
-      agentId: task?.assignedTo ?? null,
-      taskId,
-      stepId,
-      workspaceId: typeof params.workspaceId === 'string' ? params.workspaceId : null,
-      tabId: typeof params.tabId === 'string' ? params.tabId : null,
-    } as const;
-
-    if (existing) {
-      runtime.handoffManager.update(existing.id, payload);
-    } else {
-      runtime.handoffManager.create(payload);
-    }
+    runtime.taskHandoffCoordinator.handleApprovalRequest(data);
   });
 
   runtime.taskManager.on('approval-response', (data: { requestId: string; approved: boolean }) => {
-    const [taskId, stepId] = data.requestId.split(':');
-    if (!taskId || !stepId) {
-      return;
-    }
-
-    const handoff = runtime.handoffManager.findOpenByTaskStep(taskId, stepId);
-    if (!handoff) {
-      return;
-    }
-
-    runtime.handoffManager.update(handoff.id, {
-      status: 'resolved',
-      open: false,
-      actionLabel: data.approved ? 'Approval granted' : 'Approval rejected',
-      body: data.approved
-        ? `${handoff.body}\n\nApproval granted.`
-        : `${handoff.body}\n\nApproval rejected.`,
-    });
+    runtime.taskHandoffCoordinator.handleApprovalResponse(data);
   });
 
   const ses = session.fromPartition(DEFAULT_PARTITION);
@@ -418,6 +373,7 @@ export function createManagerRegistry(runtime: RuntimeManagers): ManagerRegistry
     eventStream: runtime.eventStream,
     handoffManager: runtime.handoffManager,
     taskManager: runtime.taskManager,
+    taskHandoffCoordinator: runtime.taskHandoffCoordinator,
     tabLockManager: runtime.tabLockManager,
     devToolsManager: runtime.devToolsManager,
     wingmanStream: runtime.wingmanStream,

--- a/src/bootstrap/types.ts
+++ b/src/bootstrap/types.ts
@@ -24,6 +24,7 @@ import type { ClaroNoteManager } from '../claronote/manager';
 import type { EventStreamManager } from '../events/stream';
 import type { HandoffManager } from '../handoffs/manager';
 import type { TaskManager } from '../agents/task-manager';
+import type { TaskHandoffCoordinator } from '../agents/task-handoff-coordinator';
 import type { TabLockManager } from '../agents/tab-lock-manager';
 import type { ContextMenuManager } from '../context-menu/manager';
 import type { DevToolsManager } from '../devtools/manager';
@@ -76,6 +77,7 @@ export interface RuntimeManagers {
   eventStream: EventStreamManager;
   handoffManager: HandoffManager;
   taskManager: TaskManager;
+  taskHandoffCoordinator: TaskHandoffCoordinator;
   tabLockManager: TabLockManager;
   contextMenuManager: ContextMenuManager;
   devToolsManager: DevToolsManager;

--- a/src/mcp/tests/handoffs.test.ts
+++ b/src/mcp/tests/handoffs.test.ts
@@ -111,6 +111,50 @@ describe('MCP handoff tools', () => {
     expect(mockApiCall).toHaveBeenCalledWith('POST', '/handoffs/handoff-1/resolve');
   });
 
+  it('marks a handoff ready to resume', async () => {
+    const handler = getHandler(tools, 'tandem_handoff_ready');
+    mockApiCall.mockResolvedValueOnce({ id: 'handoff-1', status: 'ready_to_resume' });
+    mockLogActivity.mockResolvedValueOnce(undefined);
+
+    const result = await handler({ id: 'handoff-1' });
+
+    expectTextContent(result, 'Handoff ready: handoff-1');
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/handoffs/handoff-1/ready');
+  });
+
+  it('resumes a handoff-linked task', async () => {
+    const handler = getHandler(tools, 'tandem_handoff_resume');
+    mockApiCall.mockResolvedValueOnce({ id: 'handoff-1', status: 'resolved' });
+    mockLogActivity.mockResolvedValueOnce(undefined);
+
+    const result = await handler({ id: 'handoff-1' });
+
+    expectTextContent(result, 'Handoff resumed: handoff-1');
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/handoffs/handoff-1/resume');
+  });
+
+  it('approves a waiting handoff', async () => {
+    const handler = getHandler(tools, 'tandem_handoff_approve');
+    mockApiCall.mockResolvedValueOnce({ id: 'handoff-1', status: 'resolved' });
+    mockLogActivity.mockResolvedValueOnce(undefined);
+
+    const result = await handler({ id: 'handoff-1' });
+
+    expectTextContent(result, 'Handoff approved: handoff-1');
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/handoffs/handoff-1/approve');
+  });
+
+  it('rejects a waiting handoff', async () => {
+    const handler = getHandler(tools, 'tandem_handoff_reject');
+    mockApiCall.mockResolvedValueOnce({ id: 'handoff-1', status: 'resolved' });
+    mockLogActivity.mockResolvedValueOnce(undefined);
+
+    const result = await handler({ id: 'handoff-1' });
+
+    expectTextContent(result, 'Handoff rejected: handoff-1');
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/handoffs/handoff-1/reject');
+  });
+
   it('passes notify and action hints through on create', async () => {
     const handler = getHandler(tools, 'tandem_handoff_create');
     mockApiCall.mockResolvedValueOnce({ id: 'handoff-9', status: 'waiting_approval', title: 'Need approval' });

--- a/src/mcp/tools/handoffs.ts
+++ b/src/mcp/tools/handoffs.ts
@@ -120,4 +120,76 @@ export function registerHandoffTools(server: McpServer): void {
       };
     },
   );
+
+  server.tool(
+    'tandem_handoff_ready',
+    'Mark a human-blocked handoff as ready to resume so the linked task moves into a resumable state.',
+    {
+      id: z.string().describe('The handoff ID'),
+    },
+    async ({ id }) => {
+      const handoff = await apiCall('POST', `/handoffs/${encodeURIComponent(id)}/ready`);
+      await logActivity('handoff_ready', id);
+      return {
+        content: [{
+          type: 'text',
+          text: `Handoff ready: ${handoff.id}\nStatus: ${handoff.status}`,
+        }],
+      };
+    },
+  );
+
+  server.tool(
+    'tandem_handoff_resume',
+    'Resume the linked agent task from a ready handoff and resolve the handoff in the inbox.',
+    {
+      id: z.string().describe('The handoff ID'),
+    },
+    async ({ id }) => {
+      const handoff = await apiCall('POST', `/handoffs/${encodeURIComponent(id)}/resume`);
+      await logActivity('handoff_resume', id);
+      return {
+        content: [{
+          type: 'text',
+          text: `Handoff resumed: ${handoff.id}\nStatus: ${handoff.status}`,
+        }],
+      };
+    },
+  );
+
+  server.tool(
+    'tandem_handoff_approve',
+    'Approve a waiting-approval handoff and let the linked task step continue.',
+    {
+      id: z.string().describe('The handoff ID'),
+    },
+    async ({ id }) => {
+      const handoff = await apiCall('POST', `/handoffs/${encodeURIComponent(id)}/approve`);
+      await logActivity('handoff_approve', id);
+      return {
+        content: [{
+          type: 'text',
+          text: `Handoff approved: ${handoff.id}\nStatus: ${handoff.status}`,
+        }],
+      };
+    },
+  );
+
+  server.tool(
+    'tandem_handoff_reject',
+    'Reject a waiting-approval handoff and keep the linked task paused.',
+    {
+      id: z.string().describe('The handoff ID'),
+    },
+    async ({ id }) => {
+      const handoff = await apiCall('POST', `/handoffs/${encodeURIComponent(id)}/reject`);
+      await logActivity('handoff_reject', id);
+      return {
+        content: [{
+          type: 'text',
+          text: `Handoff rejected: ${handoff.id}\nStatus: ${handoff.status}`,
+        }],
+      };
+    },
+  );
 }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -32,6 +32,7 @@ import type { LoginManager } from './auth/login-manager';
 import type { EventStreamManager } from './events/stream';
 import type { HandoffManager } from './handoffs/manager';
 import type { TaskManager } from './agents/task-manager';
+import type { TaskHandoffCoordinator } from './agents/task-handoff-coordinator';
 import type { TabLockManager } from './agents/tab-lock-manager';
 import type { DevToolsManager } from './devtools/manager';
 import type { WingmanStream } from './activity/wingman-stream';
@@ -107,6 +108,8 @@ export interface ManagerRegistry {
   handoffManager: HandoffManager;
   /** AI agent task management with approval workflow and emergency stop. See src/agents/task-manager.ts */
   taskManager: TaskManager;
+  /** Synchronizes task execution state with explicit human↔agent handoffs. See src/agents/task-handoff-coordinator.ts */
+  taskHandoffCoordinator: TaskHandoffCoordinator;
   /** Prevents multiple agents from controlling the same tab with timeout locks. See src/agents/tab-lock-manager.ts */
   tabLockManager: TabLockManager;
   /** Chrome DevTools Protocol (CDP) access to webview tabs. See src/devtools/manager.ts */


### PR DESCRIPTION
## What changed

This branch now covers the full handoff follow-through polish from the live Tandem test, plus the version-consistency fix that surfaced right after it.

### Wingman handoff attention

- keeps a durable closed-panel attention state on the Wingman button when open handoffs still need action
- escalates that visual state after a short delay instead of replaying popup or audio spam
- adds an explicit handoff `attentionLevel` so renderer policy stays readable and testable

### Handoff response flow

- `/wingman-alert` no longer drags the human into the agent workspace by default
- opening Wingman while open handoffs exist now lands on `Activity` instead of `Chat`
- standalone `waiting_approval` handoffs now resolve correctly on `Approve` / `Reject`, even when no paused task step is linked
- the open handoff list has more vertical room so common two-card cases do not feel cramped

### Version consistency

- bumps the app to `0.72.2`
- syncs package metadata, README, PROJECT, TODO, landing page copy, and MCP version reporting
- makes the MCP server read its version from `package.json` instead of carrying a stale hardcoded string
- extends `scripts/check-consistency.js` so future version drift is caught automatically

## Why

The durable handoff model was already working, but the live Tandem test exposed a few concrete regressions in the last mile:

- the browser still pulled the human into the agent workspace too aggressively
- Wingman opened on the wrong tab for a handoff response flow
- generic approval requests looked broken because their buttons did nothing
- version reporting in startup/docs had drifted behind the changelog

This update fixes those issues without changing the shared handoff model or falling back to popup/audio spam.

## Validation

- `node scripts/check-consistency.js`
- `npx tsc`
- `npx vitest run`
- Live Tandem validation with Robin:
  - popup + one-shot audio ping still worked
  - closed-panel Wingman button kept a persistent attention state
  - opening Wingman stayed in the human workspace and opened on `Activity`
  - `Open Context`, `Mark Ready`, and `Resume` worked
  - standalone `Approve` / `Reject` worked after the follow-up fix

## Notes

- `skill/SKILL.md` and `docs/plans/tab-emojis-design.md` were intentionally left out of this PR.
- The currently running local Tandem instance still reports the old version until it is restarted; the code in this branch fixes the source-of-truth and runtime path for the next launch.