### PR TITLE
fix: refine Wingman handoff follow-through and sync version metadata …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to Tandem Browser will be documented in this file.
 
+## [v0.72.2] - 2026-04-14
+
+- fix: smooth Wingman handoff follow-through and restore version consistency
+
+### Fixed
+
+- `POST /wingman-alert` no longer pulls the human out of their current workspace by default, while explicit context activation remains available for the few flows that really need it
+- Opening the Wingman panel with open handoffs now lands on `Activity` instead of `Chat`, so the user sees the actionable inbox immediately when responding to a handoff cue
+- Standalone `waiting_approval` handoffs now resolve correctly on `Approve` and `Reject` even when they are not linked to a paused task step, so generic approval requests no longer appear to do nothing
+- The Wingman handoff list now gives open cards enough vertical room for common two-item cases, removing the cramped internal scrollbar seen during live testing
+- Version metadata now stays aligned across `package.json`, `package-lock.json`, repo docs, the landing page, and the MCP server, with `scripts/check-consistency.js` extended to catch future drift automatically
+
+## [v0.72.1] - 2026-04-14
+
+- fix: keep handoff attention visible when the Wingman panel is closed
+
+### Changed
+
+- The closed Wingman badge and panel toggle now enter a durable handoff attention state with a visible count whenever open handoffs still need action, so the UI keeps saying "the agent still needs you" after the transient popup expires
+- New handoffs escalate in layers instead of replaying popup/audio loops: the existing popup + sound still fire once, while the closed-panel affordances keep a calmer persistent state and strengthen visually after roughly 12 seconds if the handoff remains unseen
+- Opening the Wingman panel now acknowledges current handoffs and resets the stronger alert state, while unresolved handoffs still remain visible in a quieter pending style when the panel is closed again
+- Handoff serialization and renderer IPC now include a derived `attentionLevel` (`review`, `action`, `urgent`) so UI policy can stay explicit without changing the durable handoff persistence model
+- Added focused unit coverage for the new handoff attention-level mapping and extended route assertions so the extra metadata remains stable across the API surface
+
 ## [v0.72.0] - 2026-04-13
 
 - feat: add explicit human↔agent handoffs across API, MCP, events, and Wingman UI
@@ -22,6 +46,7 @@ All notable changes to Tandem Browser will be documented in this file.
 - Wingman Activity logging now records handoff lifecycle updates so the user can see when a handoff was created, updated, or resolved
 - Handoff metadata normalization now treats blank titles/reasons as defaults, and focused route/MCP/manager tests cover the new handoff lifecycle more thoroughly so coverage matches the added product surface
 - The Wingman Activity inbox now surfaces status-aware actions: approval handoffs show `Approve` / `Reject`, human-blocked handoffs show `Mark Ready`, and `ready_to_resume` handoffs show `Resume Agent`
+- `skill/SKILL.md` now teaches agents the real runtime model more explicitly: Tandem must already be running, some clients are effectively MCP-first, durable handoffs are preferred over transient alerts for resumable blockers, interaction completion should be verified explicitly, and DevTools/network observation should stay tab-aware
 
 ## [v0.71.4] - 2026-04-13
 

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -25,7 +25,7 @@ The security layer exists because when an AI has access to your browser, your th
 Data stays local. Sessions are isolated. Nothing leaves the machine through Tandem without going through a filter first.
 
 **GitHub:** `hydro13/tandem-browser`  
-**Current version:** `0.70.0`  
+**Current version:** `0.72.2`  
 **Repository status:** Public developer preview  
 **Started:** February 11, 2026
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,8 @@ contributors, not yet a polished mass-user release.
 - Secondary platform: Linux
 - Windows: not actively validated
 - Binaries: not published yet (source-only)
-- Current version: see [package.json](package.json)
+- Current version: `0.72.2`
+- Package metadata: [package.json](package.json)
 
 ## Community
 

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@
 > Historical release summaries belong in `CHANGELOG.md`.
 > Architecture and product context belong in `PROJECT.md`.
 
-Last updated: April 13, 2026
+Last updated: April 14, 2026
 
 ## Purpose
 
@@ -14,7 +14,7 @@ Last updated: April 13, 2026
 
 ## Current Snapshot
 
-- Current app version: `0.70.0`
+- Current app version: `0.72.2`
 - MCP server: 248 tools (full API parity + awareness)
 - The codebase scope is larger than this backlog summary and includes major subsystems such as `sidebar`, `workspaces`, `pinboards`, `sync`, `headless`, and `sessions`.
 - Scheduled browsing already exists in baseline form via `WatchManager` and the `/watch/*` API routes.
@@ -25,7 +25,7 @@ Last updated: April 13, 2026
 
 ### Product Features
 
-- [ ] Update `skill/SKILL.md` to document MCP as a first-class connection method alongside direct HTTP, with examples for Claude Code, Cursor, and other MCP clients
+- [x] Update `skill/SKILL.md` so MCP-first clients, direct-HTTP clients, and the new durable handoff model are all documented with the current Tandem behavior
 - [ ] Remove the remaining legacy OpenClaw compatibility IPC and unused webhook chat code after the signed gateway-chat path has shipped for a release or two
 - [ ] `WebSocket /watch/live` for live watch updates
 - [ ] Expose `captureApplicationScreenshot` and `captureRegionScreenshot` as HTTP API endpoints (e.g. `POST /screenshot/application`, `POST /screenshot/region`) so OpenClaw agents can trigger full-window and region captures programmatically without requiring IPC or human interaction
@@ -90,6 +90,8 @@ Last updated: April 13, 2026
 
 ## Recently Completed
 
+- [x] Version consistency sweep: package metadata, MCP server version reporting, README / PROJECT / landing-page version labels, and the consistency checker now stay aligned so startup and docs stop lagging behind the changelog
+- [x] Closed-panel Wingman handoff attention state: open handoffs now keep a durable toolbar/toggle cue with count, status-derived urgency, and a non-spammy delayed escalation state so "the agent still needs you" stays visible after the transient popup disappears
 - [x] Explicit human↔agent handoffs: durable handoff records with statuses (`needs_human`, `blocked`, `waiting_approval`, `ready_to_resume`, `completed_review`, `resolved`) now exist across HTTP API, MCP tools, live event surfaces, and the Wingman Activity inbox, with workspace/tab targeting and resolve/resume actions
 - [x] Interaction reliability follow-up: snapshot fill now replaces populated field values deterministically, keyboard completion confirmation recognizes active-element focus shifts, and label locators have a runtime fallback for simple `label[for]` associations
 - [x] Interaction completion semantics: selector, snapshot-ref, locator, and keyboard actions now return explicit tab scope, target resolution, completion mode, and lightweight post-action state across HTTP API and MCP

--- a/docs/index.html
+++ b/docs/index.html
@@ -140,7 +140,7 @@ footer a:hover{color:var(--text2)}
 </header>
 
 <div class="hero">
-<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v0.70.0</div>
+<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v0.72.2</div>
 <h1>The local-first browser where human and AI work <em>as one</em></h1>
 <p>Tandem Browser gives AI agents secure access to a real human browser. No API wrappers, no scraping, no bot detection. The accessibility tree becomes the universal interaction layer. The AI rides alongside you, same tabs, same session, same screen.</p>
 <div class="hero-stats">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tandem-browser",
-  "version": "0.70.0",
+  "version": "0.72.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tandem-browser",
-      "version": "0.70.0",
+      "version": "0.72.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-browser",
-  "version": "0.70.0",
+  "version": "0.72.2",
   "description": "Local-first Electron browser for human-AI collaboration with 248-tool MCP server, 300+ endpoint HTTP API, and built-in security controls",
   "main": "dist/main.js",
   "author": "Tandem Browser contributors",

--- a/scripts/check-consistency.js
+++ b/scripts/check-consistency.js
@@ -46,17 +46,24 @@ const TOOL_HTML_STAT = /(<span class="stat-num">)(\d+)(<\/span><span class="stat
 
 /** TODO.md summary line: "MCP server: 236 tools" */
 const TOOL_TODO_SUMMARY = /MCP server: (\d+) tools/g;
+const VERSION_JSON = /("version"\s*:\s*")([^"]+)(")/g;
+const VERSION_LOCKFILE_ROOT = /("name":\s*"tandem-browser",\s*\n\s*"version":\s*")([^"]+)(")/g;
+const VERSION_LOCKFILE_PACKAGE = /("":\s*{\s*\n\s*"name":\s*"tandem-browser",\s*\n\s*"version":\s*")([^"]+)(")/g;
+const VERSION_PROJECT = /(\*\*Current version:\*\*\s*`)([^`]+)(`)/g;
+const VERSION_README = /(- Current version:\s*`)([^`]+)(`)/g;
+const VERSION_HERO = /(developer preview &middot; v)([^<]+)(<\/div>)/g;
 
 // ── Files to check ──────────────────────────────────────────────────
 // [path, { version?, toolPatterns?: RegExp[] }]
 
 const targets = [
-  ['package.json',          { toolPatterns: [TOOL_PROSE] }],
-  ['README.md',             { toolPatterns: [TOOL_PROSE] }],
-  ['PROJECT.md',            { version: true, toolPatterns: [TOOL_PROSE] }],
+  ['package.json',          { toolPatterns: [TOOL_PROSE], versionPatterns: [VERSION_JSON] }],
+  ['package-lock.json',     { versionPatterns: [VERSION_LOCKFILE_ROOT, VERSION_LOCKFILE_PACKAGE] }],
+  ['README.md',             { toolPatterns: [TOOL_PROSE], versionPatterns: [VERSION_README] }],
+  ['PROJECT.md',            { version: true, toolPatterns: [TOOL_PROSE], versionPatterns: [VERSION_PROJECT] }],
   ['AGENTS.md',             { toolPatterns: [TOOL_PROSE] }],
   ['skill/SKILL.md',        { toolPatterns: [TOOL_PROSE] }],
-  ['docs/index.html',       { version: true, toolPatterns: [TOOL_PROSE, TOOL_HTML_STAT] }],
+  ['docs/index.html',       { version: true, toolPatterns: [TOOL_PROSE, TOOL_HTML_STAT], versionPatterns: [VERSION_HERO] }],
   ['docs/api.html',         { toolPatterns: [TOOL_HTML_STAT] }],
   ['docs/public-launch.md', { toolPatterns: [TOOL_PROSE] }],
   ['TODO.md',               { toolPatterns: [TOOL_TODO_SUMMARY] }],
@@ -104,6 +111,31 @@ function findMatches(content, pattern) {
   return matches;
 }
 
+function findVersionMatches(content, pattern) {
+  const re = new RegExp(pattern.source, pattern.flags);
+  const matches = [];
+  let m;
+  while ((m = re.exec(content)) !== null) {
+    matches.push(String(m[2]));
+  }
+  return matches;
+}
+
+function replaceVersions(content, pattern, expectedVersion) {
+  const issues = [];
+  const re = new RegExp(pattern.source, pattern.flags);
+  const newContent = content.replace(re, (...args) => {
+    const full = args[0];
+    const current = String(args[2]);
+    if (current !== expectedVersion) {
+      issues.push({ old: current });
+      return String(args[1]) + expectedVersion + String(args[3] ?? '');
+    }
+    return full;
+  });
+  return { content: newContent, issues };
+}
+
 // ── Run checks ──────────────────────────────────────────────────────
 
 const errors = [];
@@ -148,6 +180,29 @@ for (const [rel, checks] of targets) {
     const re = new RegExp(`(?<![\\d.])${escaped}(?![\\d.])`, 'g');
     if (!re.test(content)) {
       errors.push({ file: rel, issue: `version ${version} not found` });
+    }
+  }
+
+  if (checks.versionPatterns) {
+    let totalMatches = 0;
+    for (const pattern of checks.versionPatterns) {
+      const matches = findVersionMatches(content, pattern);
+      totalMatches += matches.length;
+
+      const wrong = matches.filter(v => v !== version);
+      if (wrong.length > 0) {
+        for (const current of wrong) {
+          errors.push({ file: rel, issue: `version ${current} → ${version}` });
+        }
+        if (fix) {
+          const result = replaceVersions(content, pattern, version);
+          content = result.content;
+          modified = true;
+        }
+      }
+    }
+    if (totalMatches === 0) {
+      errors.push({ file: rel, issue: 'no version reference found' });
     }
   }
 

--- a/shell/css/browser-shell.css
+++ b/shell/css/browser-shell.css
@@ -622,6 +622,10 @@
     }
 
     .wingman-badge {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
       font-size: 11px;
       padding: 3px 8px;
       background: rgba(233, 69, 96, 0.2);
@@ -629,6 +633,7 @@
       border-radius: 12px;
       color: var(--accent);
       cursor: default;
+      transition: background 0.18s, border-color 0.18s, box-shadow 0.18s, color 0.18s, transform 0.18s;
     }
 
     /* ═══ Extension toolbar ═══ */

--- a/shell/css/wingman.css
+++ b/shell/css/wingman.css
@@ -109,6 +109,98 @@
       color: var(--text);
     }
 
+    .wingman-badge.has-open-handoffs,
+    .wingman-panel-toggle.has-open-handoffs {
+      position: relative;
+      overflow: visible;
+    }
+
+    .wingman-badge.has-open-handoffs::after,
+    .wingman-panel-toggle.has-open-handoffs::after {
+      content: attr(data-handoff-count);
+      position: absolute;
+      min-width: 16px;
+      height: 16px;
+      padding: 0 5px;
+      border-radius: 999px;
+      background: rgba(15, 23, 42, 0.96);
+      border: 1px solid rgba(255, 255, 255, 0.18);
+      color: #fff;
+      font-size: 9px;
+      font-weight: 700;
+      line-height: 14px;
+      text-align: center;
+      box-shadow: 0 6px 18px rgba(0, 0, 0, 0.28);
+    }
+
+    .wingman-badge.has-open-handoffs::after {
+      top: -7px;
+      right: -9px;
+    }
+
+    .wingman-panel-toggle.has-open-handoffs::after {
+      top: -6px;
+      right: -8px;
+    }
+
+    .wingman-badge.attention-pending,
+    .wingman-panel-toggle.attention-pending {
+      border-color: rgba(251, 191, 36, 0.42);
+      box-shadow: 0 0 0 1px rgba(251, 191, 36, 0.18);
+    }
+
+    .wingman-badge.attention-active,
+    .wingman-panel-toggle.attention-active {
+      color: var(--text);
+      border-color: rgba(233, 69, 96, 0.62);
+      background: rgba(233, 69, 96, 0.18);
+      box-shadow: 0 0 0 1px rgba(233, 69, 96, 0.2), 0 0 22px rgba(233, 69, 96, 0.14);
+      animation: wingmanAttentionPulse 2.6s ease-in-out infinite;
+    }
+
+    .wingman-badge.attention-escalated,
+    .wingman-panel-toggle.attention-escalated {
+      color: var(--text);
+      border-color: rgba(251, 191, 36, 0.78);
+      background: rgba(251, 191, 36, 0.2);
+      box-shadow: 0 0 0 1px rgba(251, 191, 36, 0.24), 0 0 26px rgba(251, 191, 36, 0.18);
+      animation: wingmanAttentionPulseUrgent 1.8s ease-in-out infinite;
+    }
+
+    .wingman-badge.attention-level-review::after,
+    .wingman-panel-toggle.attention-level-review::after {
+      background: rgba(16, 185, 129, 0.92);
+    }
+
+    .wingman-badge.attention-level-action::after,
+    .wingman-panel-toggle.attention-level-action::after {
+      background: rgba(233, 69, 96, 0.94);
+    }
+
+    .wingman-badge.attention-level-urgent::after,
+    .wingman-panel-toggle.attention-level-urgent::after {
+      background: rgba(251, 191, 36, 0.96);
+      color: #1f2937;
+    }
+
+    @keyframes wingmanAttentionPulse {
+      0%, 100% {
+        box-shadow: 0 0 0 1px rgba(233, 69, 96, 0.2), 0 0 18px rgba(233, 69, 96, 0.12);
+      }
+      50% {
+        box-shadow: 0 0 0 1px rgba(233, 69, 96, 0.28), 0 0 30px rgba(233, 69, 96, 0.22);
+      }
+    }
+
+    @keyframes wingmanAttentionPulseUrgent {
+      0%, 100% {
+        box-shadow: 0 0 0 1px rgba(251, 191, 36, 0.26), 0 0 22px rgba(251, 191, 36, 0.18);
+      }
+      50% {
+        box-shadow: 0 0 0 1px rgba(251, 191, 36, 0.4), 0 0 34px rgba(251, 191, 36, 0.26);
+      }
+    }
+
     .panel-resize-handle {
       position: absolute;
       top: 0;
@@ -260,7 +352,7 @@
       display: flex;
       flex-direction: column;
       gap: 8px;
-      max-height: 310px;
+      max-height: 460px;
       overflow-y: auto;
       padding-right: 2px;
     }

--- a/shell/js/shortcut-router.js
+++ b/shell/js/shortcut-router.js
@@ -54,7 +54,9 @@
         document.getElementById('panel-screenshots').style.display = 'none';
         document.getElementById('panel-claronote').style.display = 'flex';
 
-        if (!document.getElementById('wingman-panel').classList.contains('open')) {
+        if (typeof window.openWingmanPanel === 'function') {
+          window.openWingmanPanel();
+        } else if (!document.getElementById('wingman-panel').classList.contains('open')) {
           document.getElementById('wingman-panel').classList.add('open');
           if (typeof window.updatePanelLayout === 'function') {
             window.updatePanelLayout();

--- a/shell/js/wingman.js
+++ b/shell/js/wingman.js
@@ -148,19 +148,221 @@
 
     const wingmanPanel = document.getElementById('wingman-panel');
     const panelBody = document.getElementById('panel-body');
+    const panelToggleBtn = document.getElementById('wingman-panel-toggle');
+    const activityEl = document.getElementById('activity-feed');
+    const handoffListEl = document.getElementById('handoff-list');
+    const handoffEmptyEl = document.getElementById('handoff-empty');
+    const handoffCountEl = document.getElementById('handoff-count');
+    const activityTabButton = document.querySelector('[data-panel-tab="activity"]');
+    const openHandoffs = new Map();
+    const unacknowledgedHandoffs = new Set();
+    const HANDOFF_ATTENTION_ESCALATION_MS = 12_000;
+    let handoffAttentionEscalationTimer = null;
+    let handoffAttentionEscalated = false;
+
+    function formatHandoffStatus(status) {
+      const labels = {
+        needs_human: 'Needs Human',
+        blocked: 'Blocked',
+        waiting_approval: 'Waiting Approval',
+        ready_to_resume: 'Ready To Resume',
+        completed_review: 'Completed Review',
+        resolved: 'Resolved',
+      };
+      return labels[status] || status;
+    }
+
+    function formatHandoffTime(timestamp) {
+      if (!timestamp) return '';
+      return new Date(timestamp).toLocaleTimeString('nl-BE', {
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+    }
+
+    function escapeHtml(s) {
+      return String(s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/\n/g, '<br>');
+    }
+
+    function isWingmanPanelOpen() {
+      return wingmanPanel.classList.contains('open');
+    }
+
+    function getHandoffAttentionLevel(handoff) {
+      if (!handoff || !handoff.open || handoff.status === 'resolved') return 'none';
+      if (typeof handoff.attentionLevel === 'string') return handoff.attentionLevel;
+      if (handoff.status === 'blocked' || handoff.status === 'waiting_approval') return 'urgent';
+      if (handoff.status === 'needs_human') return 'action';
+      if (handoff.status === 'ready_to_resume' || handoff.status === 'completed_review') return 'review';
+      return 'action';
+    }
+
+    function getHandoffAttentionRank(handoff) {
+      const level = getHandoffAttentionLevel(handoff);
+      return level === 'urgent' ? 3 : level === 'action' ? 2 : level === 'review' ? 1 : 0;
+    }
+
+    function getSortedOpenHandoffs() {
+      return Array.from(openHandoffs.values())
+        .sort((a, b) => {
+          const rankDelta = getHandoffAttentionRank(b) - getHandoffAttentionRank(a);
+          if (rankDelta !== 0) return rankDelta;
+          return (b.updatedAt || 0) - (a.updatedAt || 0);
+        });
+    }
+
+    function clearHandoffAttentionTimer() {
+      if (handoffAttentionEscalationTimer) {
+        clearTimeout(handoffAttentionEscalationTimer);
+        handoffAttentionEscalationTimer = null;
+      }
+    }
+
+    function updateActivityTabBadge() {
+      const count = openHandoffs.size;
+      if (handoffCountEl) {
+        handoffCountEl.textContent = String(count);
+      }
+      if (activityTabButton) {
+        activityTabButton.textContent = count > 0 ? `Activity (${count})` : 'Activity';
+      }
+    }
+
+    function updateWingmanAttentionUI() {
+      const count = openHandoffs.size;
+      const isOpen = isWingmanPanelOpen();
+      const topHandoff = getSortedOpenHandoffs()[0] || null;
+      const topLevel = topHandoff ? getHandoffAttentionLevel(topHandoff) : 'none';
+      const closedState = count === 0
+        ? 'idle'
+        : unacknowledgedHandoffs.size > 0
+          ? (handoffAttentionEscalated ? 'escalated' : 'active')
+          : 'pending';
+
+      const baseTitle = count === 0
+        ? null
+        : count === 1
+          ? `1 open handoff${topHandoff?.title ? `: ${topHandoff.title}` : ''}`
+          : `${count} open handoffs${topHandoff?.title ? ` — ${topHandoff.title}` : ''}`;
+
+      for (const element of [wingmanBadge, panelToggleBtn]) {
+        if (!element) continue;
+        element.classList.remove(
+          'has-open-handoffs',
+          'attention-pending',
+          'attention-active',
+          'attention-escalated',
+          'attention-level-review',
+          'attention-level-action',
+          'attention-level-urgent',
+        );
+        if (count > 0 && !isOpen) {
+          element.classList.add('has-open-handoffs', `attention-${closedState}`, `attention-level-${topLevel}`);
+          element.dataset.handoffCount = String(count);
+        } else {
+          delete element.dataset.handoffCount;
+        }
+      }
+
+      const badgeTitle = count === 0
+        ? 'Right-click for settings'
+        : isOpen
+          ? `${baseTitle}. Wingman panel is open.`
+          : closedState === 'escalated'
+            ? `${baseTitle}. Wingman is still waiting for you.`
+            : closedState === 'active'
+              ? `${baseTitle}. Wingman needs you.`
+              : `${baseTitle}. Open when you are ready.`;
+      wingmanBadge.title = badgeTitle;
+      if (panelToggleBtn) {
+        panelToggleBtn.title = count === 0 ? 'Toggle Wingman panel' : badgeTitle;
+      }
+    }
+
+    function scheduleHandoffAttentionEscalation() {
+      clearHandoffAttentionTimer();
+
+      if (isWingmanPanelOpen() || unacknowledgedHandoffs.size === 0) {
+        handoffAttentionEscalated = false;
+        updateWingmanAttentionUI();
+        return;
+      }
+
+      const tracked = Array.from(unacknowledgedHandoffs)
+        .map(id => openHandoffs.get(id))
+        .filter(Boolean);
+
+      if (tracked.length === 0) {
+        handoffAttentionEscalated = false;
+        updateWingmanAttentionUI();
+        return;
+      }
+
+      const now = Date.now();
+      const oldestAge = tracked.reduce((maxAge, handoff) => {
+        const age = Math.max(0, now - (handoff.updatedAt || handoff.createdAt || now));
+        return Math.max(maxAge, age);
+      }, 0);
+      const remaining = HANDOFF_ATTENTION_ESCALATION_MS - oldestAge;
+
+      if (remaining <= 0) {
+        handoffAttentionEscalated = true;
+        updateWingmanAttentionUI();
+        return;
+      }
+
+      handoffAttentionEscalated = false;
+      updateWingmanAttentionUI();
+      handoffAttentionEscalationTimer = setTimeout(() => {
+        handoffAttentionEscalated = true;
+        updateWingmanAttentionUI();
+        scheduleHandoffAttentionEscalation();
+      }, remaining);
+    }
+
+    function acknowledgeVisibleHandoffs() {
+      for (const handoffId of openHandoffs.keys()) {
+        unacknowledgedHandoffs.delete(handoffId);
+      }
+      handoffAttentionEscalated = false;
+      scheduleHandoffAttentionEscalation();
+    }
+
+    function setActivePanelTab(tab) {
+      document.querySelectorAll('.panel-tab').forEach(b => b.classList.remove('active'));
+      const targetButton = document.querySelector(`[data-panel-tab="${tab}"]`);
+      if (targetButton) {
+        targetButton.classList.add('active');
+      }
+      document.getElementById('panel-activity').style.display = tab === 'activity' ? 'flex' : 'none';
+      document.getElementById('panel-chat').style.display = tab === 'chat' ? 'flex' : 'none';
+      if (tab === 'chat') {
+        window.chatRouter?.ensureConnected();
+      }
+      document.getElementById('panel-screenshots').style.display = tab === 'screenshots' ? 'flex' : 'none';
+    }
+
+    function getPreferredPanelTabOnOpen() {
+      return openHandoffs.size > 0 ? 'activity' : 'chat';
+    }
+
+    function openWingmanPanel(preferredTab) {
+      if (!wingmanPanel.classList.contains('open')) {
+        wingmanPanel.classList.add('open');
+      }
+      setActivePanelTab(preferredTab || getPreferredPanelTabOnOpen());
+      updatePanelLayout();
+      acknowledgeVisibleHandoffs();
+    }
 
     // Panel tab switching
     document.querySelectorAll('.panel-tab').forEach(btn => {
       btn.addEventListener('click', () => {
-        document.querySelectorAll('.panel-tab').forEach(b => b.classList.remove('active'));
-        btn.classList.add('active');
-        const tab = btn.dataset.panelTab;
-        document.getElementById('panel-activity').style.display = tab === 'activity' ? 'flex' : 'none';
-        document.getElementById('panel-chat').style.display = tab === 'chat' ? 'flex' : 'none';
-        if (tab === 'chat') {
-          window.chatRouter?.ensureConnected();
-        }
-        document.getElementById('panel-screenshots').style.display = tab === 'screenshots' ? 'flex' : 'none';
+        setActivePanelTab(btn.dataset.panelTab);
         // ClaroNote disabled — decoupled, coming in a later update
         // document.getElementById('panel-claronote').style.display = tab === 'claronote' ? 'flex' : 'none';
         // if (tab === 'claronote') { window.initClaroNote?.(); }
@@ -171,58 +373,13 @@
     if (window.tandem) {
       window.tandem.onPanelToggle((data) => {
         if (data.open) {
-          wingmanPanel.classList.add('open');
+          openWingmanPanel();
         } else {
           wingmanPanel.classList.remove('open');
+          updatePanelLayout();
+          scheduleHandoffAttentionEscalation();
         }
-        updatePanelLayout();
       });
-
-      // Activity events
-      const activityEl = document.getElementById('activity-feed');
-      const handoffListEl = document.getElementById('handoff-list');
-      const handoffEmptyEl = document.getElementById('handoff-empty');
-      const handoffCountEl = document.getElementById('handoff-count');
-      const activityTabButton = document.querySelector('[data-panel-tab="activity"]');
-      const openHandoffs = new Map();
-
-      function formatHandoffStatus(status) {
-        const labels = {
-          needs_human: 'Needs Human',
-          blocked: 'Blocked',
-          waiting_approval: 'Waiting Approval',
-          ready_to_resume: 'Ready To Resume',
-          completed_review: 'Completed Review',
-          resolved: 'Resolved',
-        };
-        return labels[status] || status;
-      }
-
-      function formatHandoffTime(timestamp) {
-        if (!timestamp) return '';
-        return new Date(timestamp).toLocaleTimeString('nl-BE', {
-          hour: '2-digit',
-          minute: '2-digit',
-        });
-      }
-
-      function escapeHtml(s) {
-        return String(s)
-          .replace(/&/g, '&amp;')
-          .replace(/</g, '&lt;')
-          .replace(/>/g, '&gt;')
-          .replace(/\n/g, '<br>');
-      }
-
-      function updateActivityTabBadge() {
-        const count = openHandoffs.size;
-        if (handoffCountEl) {
-          handoffCountEl.textContent = String(count);
-        }
-        if (activityTabButton) {
-          activityTabButton.textContent = count > 0 ? `Activity (${count})` : 'Activity';
-        }
-      }
 
       async function activateHandoff(handoffId) {
         await fetch(`http://localhost:8765/handoffs/${handoffId}/activate`, { method: 'POST' });
@@ -272,8 +429,7 @@
         if (!handoffListEl || !handoffEmptyEl) return;
         handoffListEl.innerHTML = '';
 
-        const handoffs = Array.from(openHandoffs.values())
-          .sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
+        const handoffs = getSortedOpenHandoffs();
 
         handoffEmptyEl.style.display = handoffs.length === 0 ? 'block' : 'none';
 
@@ -375,6 +531,7 @@
         }
 
         updateActivityTabBadge();
+        updateWingmanAttentionUI();
       }
 
       async function applyHandoffUpdate(handoff) {
@@ -382,10 +539,17 @@
         const hydrated = await hydrateHandoff(handoff);
         if (hydrated.open) {
           openHandoffs.set(hydrated.id, hydrated);
+          if (isWingmanPanelOpen()) {
+            unacknowledgedHandoffs.delete(hydrated.id);
+          } else {
+            unacknowledgedHandoffs.add(hydrated.id);
+          }
         } else {
           openHandoffs.delete(hydrated.id);
+          unacknowledgedHandoffs.delete(hydrated.id);
         }
         renderHandoffs();
+        scheduleHandoffAttentionEscalation();
       }
 
       async function loadOpenHandoffs() {
@@ -393,12 +557,14 @@
           const response = await fetch('http://localhost:8765/handoffs?openOnly=true');
           const data = await response.json();
           openHandoffs.clear();
+          unacknowledgedHandoffs.clear();
           for (const handoff of data.handoffs || []) {
             if (handoff.open) {
               openHandoffs.set(handoff.id, handoff);
             }
           }
           renderHandoffs();
+          scheduleHandoffAttentionEscalation();
         } catch (e) {
           console.error('loadOpenHandoffs failed:', e);
         }
@@ -1412,7 +1578,6 @@
 
     // Panel resize
     const resizeHandle = document.getElementById('panel-resize');
-    const panelToggleBtn = document.getElementById('wingman-panel-toggle');
     const webviewContainer = document.getElementById('webview-container');
     let resizing = false;
 
@@ -1446,8 +1611,13 @@
 
     // Toggle panel function
     function toggleWingmanPanel() {
-      wingmanPanel.classList.toggle('open');
-      updatePanelLayout();
+      if (wingmanPanel.classList.contains('open')) {
+        wingmanPanel.classList.remove('open');
+        updatePanelLayout();
+        scheduleHandoffAttentionEscalation();
+      } else {
+        openWingmanPanel();
+      }
     }
 
     // Listen for transition end to update layout smoothly
@@ -1492,6 +1662,7 @@
 
     window.chatRouter = chatRouter;
     window.dismissAlert = dismissAlert;
+    window.openWingmanPanel = openWingmanPanel;
     window.toggleWingmanPanel = toggleWingmanPanel;
     window.updatePanelLayout = updatePanelLayout;
 })();

--- a/src/agents/task-handoff-coordinator.ts
+++ b/src/agents/task-handoff-coordinator.ts
@@ -163,20 +163,32 @@ export class TaskHandoffCoordinator {
   }
 
   approve(handoffId: string): Handoff | null {
-    const handoff = this.requireTaskLinkedHandoff(handoffId, 'approve');
+    const handoff = this.requireHandoff(handoffId);
     if (!handoff) {
       return null;
     }
+
+    if (!handoff.taskId || !handoff.stepId) {
+      return this.resolveStandaloneApproval(handoff, true);
+    }
+
+    this.requireTaskLinkedHandoff(handoffId, 'approve');
 
     this.taskManager.respondToApproval(handoff.taskId as string, handoff.stepId as string, true);
     return this.handoffManager.get(handoffId);
   }
 
   reject(handoffId: string): Handoff | null {
-    const handoff = this.requireTaskLinkedHandoff(handoffId, 'reject');
+    const handoff = this.requireHandoff(handoffId);
     if (!handoff) {
       return null;
     }
+
+    if (!handoff.taskId || !handoff.stepId) {
+      return this.resolveStandaloneApproval(handoff, false);
+    }
+
+    this.requireTaskLinkedHandoff(handoffId, 'reject');
 
     this.taskManager.respondToApproval(handoff.taskId as string, handoff.stepId as string, false);
     return this.handoffManager.get(handoffId);
@@ -196,6 +208,23 @@ export class TaskHandoffCoordinator {
 
   private requireHandoff(handoffId: string): Handoff | null {
     return this.handoffManager.get(handoffId);
+  }
+
+  private resolveStandaloneApproval(handoff: Handoff, approved: boolean): Handoff | null {
+    const updated = this.handoffManager.update(handoff.id, {
+      status: 'resolved',
+      open: false,
+      actionLabel: approved ? 'Approved' : 'Rejected',
+      body: appendHandoffNote(
+        handoff.body,
+        approved ? 'Human approved this handoff.' : 'Human rejected this handoff.',
+      ),
+    });
+    if (!updated) {
+      return null;
+    }
+    this.syncHandoffState(updated);
+    return updated;
   }
 
   private requireTaskLinkedHandoff(handoffId: string, verb: string): Handoff | null {

--- a/src/agents/tests/task-handoff-coordinator.test.ts
+++ b/src/agents/tests/task-handoff-coordinator.test.ts
@@ -201,17 +201,57 @@ describe('TaskHandoffCoordinator', () => {
     expect(taskManager.respondToApproval).toHaveBeenNthCalledWith(2, 'task-1', 'step-1', false);
   });
 
+  it('approves and rejects standalone waiting handoffs by resolving them directly', () => {
+    const standalone = createHandoff({
+      status: 'waiting_approval',
+      reason: 'approval_required',
+      taskId: null,
+      stepId: null,
+      body: 'Please decide',
+    });
+    handoffManager.get.mockReturnValue(standalone);
+    handoffManager.update
+      .mockReturnValueOnce(createHandoff({
+        status: 'resolved',
+        open: false,
+        taskId: null,
+        stepId: null,
+        actionLabel: 'Approved',
+        body: 'Please decide\n\nHuman approved this handoff.',
+        resolvedAt: 3,
+      }))
+      .mockReturnValueOnce(createHandoff({
+        status: 'resolved',
+        open: false,
+        taskId: null,
+        stepId: null,
+        actionLabel: 'Rejected',
+        body: 'Please decide\n\nHuman rejected this handoff.',
+        resolvedAt: 4,
+      }));
+
+    const approved = coordinator.approve('handoff-1');
+    const rejected = coordinator.reject('handoff-1');
+
+    expect(taskManager.respondToApproval).not.toHaveBeenCalled();
+    expect(handoffManager.update).toHaveBeenNthCalledWith(1, 'handoff-1', expect.objectContaining({
+      status: 'resolved',
+      open: false,
+      actionLabel: 'Approved',
+    }));
+    expect(handoffManager.update).toHaveBeenNthCalledWith(2, 'handoff-1', expect.objectContaining({
+      status: 'resolved',
+      open: false,
+      actionLabel: 'Rejected',
+    }));
+    expect(approved?.status).toBe('resolved');
+    expect(rejected?.status).toBe('resolved');
+  });
+
   it('returns null when approve cannot find a handoff', () => {
     handoffManager.get.mockReturnValue(null);
 
     expect(coordinator.approve('handoff-missing')).toBeNull();
-  });
-
-  it('throws when approve/reject target is not linked to a task step', () => {
-    handoffManager.get.mockReturnValue(createHandoff({ taskId: null, stepId: null }));
-
-    expect(() => coordinator.approve('handoff-1')).toThrow('Cannot approve a handoff that is not linked to a task step');
-    expect(() => coordinator.reject('handoff-1')).toThrow('Cannot reject a handoff that is not linked to a task step');
   });
 
   it('throws when approve/reject target task step is missing', () => {

--- a/src/api/routes/browser.ts
+++ b/src/api/routes/browser.ts
@@ -631,7 +631,7 @@ export function registerBrowserRoutes(router: Router, ctx: RouteContext): void {
   // ═══════════════════════════════════════════════
 
   router.post('/wingman-alert', (req: Request, res: Response) => {
-    const { title = 'Need help', body = '', workspaceId, tabId, agentId, source, actionLabel, reason } = req.body;
+    const { title = 'Need help', body = '', workspaceId, tabId, agentId, source, actionLabel, reason, activateContext = false } = req.body;
     if (workspaceId !== undefined && typeof workspaceId !== 'string') {
       res.status(400).json({ error: 'workspaceId must be a workspace ID string' });
       return;
@@ -640,8 +640,12 @@ export function registerBrowserRoutes(router: Router, ctx: RouteContext): void {
       res.status(400).json({ error: 'tabId must be a tab ID string' });
       return;
     }
+    if (activateContext !== undefined && typeof activateContext !== 'boolean') {
+      res.status(400).json({ error: 'activateContext must be a boolean' });
+      return;
+    }
     try {
-      if (workspaceId) {
+      if (activateContext && workspaceId) {
         ctx.workspaceManager.switch(workspaceId);
       }
       ctx.handoffManager.create({

--- a/src/api/routes/handoffs.ts
+++ b/src/api/routes/handoffs.ts
@@ -2,11 +2,14 @@ import type { Request, Response, Router } from 'express';
 import type { RouteContext } from '../context';
 import type { Handoff, HandoffStatus, UpdateHandoffInput } from '../../handoffs/manager';
 import { HANDOFF_STATUSES } from '../../handoffs/manager';
+import type { HandoffAttentionLevel } from '../../handoffs/attention';
+import { getHandoffAttentionLevel } from '../../handoffs/attention';
 import { wingmanAlert } from '../../notifications/alert';
 import { handleRouteError } from '../../utils/errors';
 
 interface SerializedHandoff extends Handoff {
   actionable: boolean;
+  attentionLevel: HandoffAttentionLevel;
   workspaceName: string | null;
   tabTitle: string | null;
   tabUrl: string | null;
@@ -43,6 +46,7 @@ function serializeHandoff(ctx: RouteContext, handoff: Handoff): SerializedHandof
   return {
     ...handoff,
     actionable: handoff.open,
+    attentionLevel: getHandoffAttentionLevel(handoff),
     workspaceName: workspace?.name ?? null,
     tabTitle: tab?.title ?? null,
     tabUrl: tab?.url ?? null,

--- a/src/api/tests/routes/browser.test.ts
+++ b/src/api/tests/routes/browser.test.ts
@@ -1241,17 +1241,29 @@ describe('Browser Routes', () => {
       expect(wingmanAlert).toHaveBeenCalledWith('Need help', '');
     });
 
-    it('activates the requested workspace before sending the alert', async () => {
+    it('keeps the user in the current workspace by default', async () => {
       const res = await request(app)
         .post('/wingman-alert')
         .send({ title: 'Captcha', body: 'Please take over', workspaceId: 'ws-ai' });
+
+      expect(res.status).toBe(200);
+      expect(ctx.workspaceManager.switch).not.toHaveBeenCalled();
+      expect(ctx.handoffManager.create).toHaveBeenCalledWith(expect.objectContaining({
+        workspaceId: 'ws-ai',
+      }));
+      expect(wingmanAlert).toHaveBeenCalledWith('Captcha', 'Please take over');
+    });
+
+    it('activates the requested workspace only when explicitly asked', async () => {
+      const res = await request(app)
+        .post('/wingman-alert')
+        .send({ title: 'Captcha', body: 'Please take over', workspaceId: 'ws-ai', activateContext: true });
 
       expect(res.status).toBe(200);
       expect(ctx.workspaceManager.switch).toHaveBeenCalledWith('ws-ai');
       expect(ctx.handoffManager.create).toHaveBeenCalledWith(expect.objectContaining({
         workspaceId: 'ws-ai',
       }));
-      expect(wingmanAlert).toHaveBeenCalledWith('Captcha', 'Please take over');
     });
 
     it('returns 400 when workspaceId is not a string', async () => {
@@ -1272,6 +1284,17 @@ describe('Browser Routes', () => {
 
       expect(res.status).toBe(400);
       expect(res.body.error).toBe('tabId must be a tab ID string');
+      expect(ctx.handoffManager.create).not.toHaveBeenCalled();
+      expect(wingmanAlert).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when activateContext is not a boolean', async () => {
+      const res = await request(app)
+        .post('/wingman-alert')
+        .send({ activateContext: 'yes' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('activateContext must be a boolean');
       expect(ctx.handoffManager.create).not.toHaveBeenCalled();
       expect(wingmanAlert).not.toHaveBeenCalled();
     });

--- a/src/api/tests/routes/handoffs.test.ts
+++ b/src/api/tests/routes/handoffs.test.ts
@@ -65,6 +65,7 @@ describe('Handoff Routes', () => {
       expect(res.body.handoffs[0]).toEqual(expect.objectContaining({
         id: 'handoff-1',
         actionable: true,
+        attentionLevel: 'action',
         workspaceName: 'AI Workspace',
         tabTitle: 'Example',
         tabUrl: 'https://example.com',
@@ -134,6 +135,7 @@ describe('Handoff Routes', () => {
         workspaceId: 'ws-1',
         tabId: 'tab-1',
       }));
+      expect(res.body.attentionLevel).toBe('urgent');
       expect(ctx.taskHandoffCoordinator.syncHandoffState).toHaveBeenCalledWith(expect.objectContaining({
         id: 'handoff-2',
       }));

--- a/src/bootstrap/runtime.ts
+++ b/src/bootstrap/runtime.ts
@@ -18,6 +18,7 @@ import { DevToolsManager } from '../devtools/manager';
 import { DeviceEmulator } from '../device/emulator';
 import { DownloadManager } from '../downloads/manager';
 import { EventStreamManager } from '../events/stream';
+import { getHandoffAttentionLevel } from '../handoffs/attention';
 import { HandoffManager, type Handoff } from '../handoffs/manager';
 import { ChromeImporter } from '../import/chrome-importer';
 import type { Logger } from '../utils/logger';
@@ -116,7 +117,13 @@ function wireHandoffManagerEvents(
     });
 
     if (canUseWindow(win)) {
-      win.webContents.send(IpcChannels.HANDOFF_UPDATED, { kind, handoff });
+      win.webContents.send(IpcChannels.HANDOFF_UPDATED, {
+        kind,
+        handoff: {
+          ...handoff,
+          attentionLevel: getHandoffAttentionLevel(handoff),
+        },
+      });
     }
   };
 

--- a/src/handoffs/attention.ts
+++ b/src/handoffs/attention.ts
@@ -1,0 +1,21 @@
+import type { Handoff } from './manager';
+
+export const HANDOFF_ATTENTION_LEVELS = ['none', 'review', 'action', 'urgent'] as const;
+
+export type HandoffAttentionLevel = (typeof HANDOFF_ATTENTION_LEVELS)[number];
+
+const STATUS_TO_ATTENTION_LEVEL: Record<Handoff['status'], HandoffAttentionLevel> = {
+  needs_human: 'action',
+  blocked: 'urgent',
+  waiting_approval: 'urgent',
+  ready_to_resume: 'review',
+  completed_review: 'review',
+  resolved: 'none',
+};
+
+export function getHandoffAttentionLevel(handoff: Pick<Handoff, 'status' | 'open'>): HandoffAttentionLevel {
+  if (!handoff.open || handoff.status === 'resolved') {
+    return 'none';
+  }
+  return STATUS_TO_ATTENTION_LEVEL[handoff.status];
+}

--- a/src/handoffs/tests/attention.test.ts
+++ b/src/handoffs/tests/attention.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { getHandoffAttentionLevel } from '../attention';
+
+describe('getHandoffAttentionLevel', () => {
+  it('maps actionable statuses to durable attention levels', () => {
+    expect(getHandoffAttentionLevel({ status: 'needs_human', open: true } as any)).toBe('action');
+    expect(getHandoffAttentionLevel({ status: 'blocked', open: true } as any)).toBe('urgent');
+    expect(getHandoffAttentionLevel({ status: 'waiting_approval', open: true } as any)).toBe('urgent');
+    expect(getHandoffAttentionLevel({ status: 'ready_to_resume', open: true } as any)).toBe('review');
+    expect(getHandoffAttentionLevel({ status: 'completed_review', open: true } as any)).toBe('review');
+  });
+
+  it('returns none for resolved or closed handoffs', () => {
+    expect(getHandoffAttentionLevel({ status: 'resolved', open: false } as any)).toBe('none');
+    expect(getHandoffAttentionLevel({ status: 'needs_human', open: false } as any)).toBe('none');
+  });
+});

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,5 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import fs from 'node:fs';
+import path from 'node:path';
 import { apiCall, truncateToWords } from './api-client.js';
 import { API_PORT } from '../utils/constants';
 // MCP uses stdio for protocol messages — ALL logging must go to stderr.
@@ -48,9 +50,23 @@ import { registerClipboardTools } from './tools/clipboard.js';
 
 // log is defined above — stderr-only for MCP stdio safety
 
+function readPackageVersion(): string {
+  const packagePath = path.resolve(__dirname, '..', '..', 'package.json');
+  try {
+    const raw = fs.readFileSync(packagePath, 'utf-8');
+    const pkg = JSON.parse(raw) as { version?: string };
+    if (typeof pkg.version === 'string' && pkg.version.trim().length > 0) {
+      return pkg.version.trim();
+    }
+  } catch (error) {
+    log.warn('Falling back to MCP version placeholder; failed to read package.json', error);
+  }
+  return '0.72.2';
+}
+
 const server = new McpServer({
   name: 'tandem-browser',
-  version: '0.70.0',  // 236 tools — full API parity + awareness + clipboard
+  version: readPackageVersion(),
 });
 
 // ═══════════════════════════════════════════════


### PR DESCRIPTION
…(wingman)

What was built/changed:
- New files: src/handoffs/attention.ts, src/handoffs/tests/attention.test.ts
- Modified files: Wingman renderer/CSS, handoff routes/runtime, task handoff coordinator, version metadata/docs files, scripts/check-consistency.js
- New behavior: persistent closed-panel attention state, no default workspace steal on /wingman-alert, Activity-first Wingman opening for handoffs, standalone approval handoffs resolving on Approve/Reject, synchronized app/docs/MCP version metadata
- Deleted files: none

Why this approach:
- Keeps the handoff model durable and non-spammy while fixing the concrete live-test regressions around workspace focus, inbox targeting, approval handling, and visibility
- Moves version reporting back to a single package-driven source of truth and adds automated consistency checks so startup/docs do not drift from the changelog again

Tested:
- node scripts/check-consistency.js: all files consistent
- npx tsc: zero errors
- npx vitest run: all tests pass
- Manual: live Tandem handoff flow retested with popup/audio, closed-panel attention, Activity auto-open, context navigation, mark-ready/resume, and approve/reject behavior

## What does this PR do?

<!-- A clear description of the change and why it is needed. -->

## How was it tested?

<!-- What did you do to verify this works? -->
<!-- For UI changes: manual app check. For API changes: curl or test coverage. -->

- [x] `npm run verify` passes
- [x] Manual app check done (if Electron lifecycle or visible UI changed)

## Notes

<!-- Anything risky, deferred, or worth calling out for the reviewer. -->
<!-- Security-sensitive changes (stealth, sessions, extensions, API auth): flag them explicitly. -->
