### PR TITLE
[codex] Add live watch websocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to Tandem Browser will be documented in this file.
 - The Wingman handoff list now gives open cards enough vertical room for common two-item cases, removing the cramped internal scrollbar seen during live testing
 - Version metadata now stays aligned across `package.json`, `package-lock.json`, repo docs, the landing page, and the MCP server, with `scripts/check-consistency.js` extended to catch future drift automatically
 
+### Added
+
+- `ws://127.0.0.1:8765/watch/live` now streams an immediate watch snapshot plus incremental watch add/remove/check events to authenticated local clients, giving agents a real-time watch surface instead of polling `/watch/list`
+
 ## [v0.72.1] - 2026-04-14
 
 - fix: keep handoff attention visible when the Wingman panel is closed

--- a/TODO.md
+++ b/TODO.md
@@ -27,7 +27,7 @@ Last updated: April 14, 2026
 
 - [x] Update `skill/SKILL.md` so MCP-first clients, direct-HTTP clients, and the new durable handoff model are all documented with the current Tandem behavior
 - [ ] Remove the remaining legacy OpenClaw compatibility IPC and unused webhook chat code after the signed gateway-chat path has shipped for a release or two
-- [ ] `WebSocket /watch/live` for live watch updates
+- [x] `WebSocket /watch/live` for live watch updates
 - [ ] Expose `captureApplicationScreenshot` and `captureRegionScreenshot` as HTTP API endpoints (e.g. `POST /screenshot/application`, `POST /screenshot/region`) so OpenClaw agents can trigger full-window and region captures programmatically without requiring IPC or human interaction
 - [x] Show a notification when the Wingman panel is closed and Wingman replies
 - [x] Google Photos upload support for screenshots; local OAuth client ID setup, connect/disconnect flow, and automatic upload path now exist

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -32,6 +32,7 @@ import { registerAwarenessRoutes } from './routes/awareness';
 import { registerClipboardRoutes } from './routes/clipboard';
 import { registerSecurityRoutes } from '../security/routes';
 import { nmProxy, TRUSTED_EXTENSION_PROXY_PATHS } from '../extensions/nm-proxy';
+import { WatchLiveWebSocket } from '../watch/live-ws';
 import type { ExtensionRouteAccessDecision } from '../extensions/manager';
 import { createLogger } from '../utils/logger';
 import { createRateLimitMiddleware } from './rate-limit';
@@ -95,6 +96,7 @@ export interface TandemAPIOptions {
 export class TandemAPI {
   private app: express.Application;
   private server: http.Server | null = null;
+  private watchLiveWebSocket: WatchLiveWebSocket | null = null;
   private win: BrowserWindow;
   private authToken: string;
   private port: number;
@@ -172,6 +174,34 @@ export class TandemAPI {
     } catch {
       return false;
     }
+  }
+
+  private getWebSocketToken(req: http.IncomingMessage): string | null {
+    const url = new URL(req.url ?? '', 'http://localhost');
+    const queryToken = url.searchParams.get('token')?.trim();
+    if (queryToken) {
+      return queryToken;
+    }
+
+    const authHeader = req.headers.authorization;
+    if (typeof authHeader === 'string') {
+      const match = authHeader.match(/^Bearer\s+(.+)$/i);
+      if (match?.[1]?.trim()) {
+        return match[1].trim();
+      }
+    }
+
+    const headerToken = req.headers['x-tandem-token'];
+    if (typeof headerToken === 'string' && headerToken.trim()) {
+      return headerToken.trim();
+    }
+
+    return null;
+  }
+
+  private authorizeWatchLiveRequest(req: http.IncomingMessage): boolean {
+    const token = this.getWebSocketToken(req);
+    return token ? this.isTokenValid(token) : false;
   }
 
   /** Shared validator for extension-authenticated HTTP and WebSocket bridges. */
@@ -442,6 +472,12 @@ export class TandemAPI {
   async start(): Promise<void> {
     return new Promise((resolve) => {
       this.server = this.app.listen(this.port, '127.0.0.1', () => {
+        if (this.server) {
+          this.watchLiveWebSocket?.close();
+          this.watchLiveWebSocket = new WatchLiveWebSocket(this.server, this.registry.watchManager, {
+            authorizeRequest: (req) => this.authorizeWatchLiveRequest(req),
+          });
+        }
         resolve();
       });
     });
@@ -452,6 +488,8 @@ export class TandemAPI {
   }
 
   stop(): void {
+    this.watchLiveWebSocket?.close();
+    this.watchLiveWebSocket = null;
     this.server?.close();
   }
 }

--- a/src/api/tests/helpers.ts
+++ b/src/api/tests/helpers.ts
@@ -197,6 +197,8 @@ export function createMockContext(): RouteContext {
       listWatches: vi.fn().mockReturnValue([]),
       removeWatch: vi.fn().mockReturnValue(true),
       forceCheck: vi.fn().mockResolvedValue({ changed: false }),
+      subscribe: vi.fn().mockReturnValue(() => undefined),
+      getSnapshot: vi.fn().mockReturnValue({ type: 'snapshot', watches: [], emittedAt: 0 }),
     } as any,
 
     // ── headlessManager ─────────────────────────

--- a/src/watch/live-ws.ts
+++ b/src/watch/live-ws.ts
@@ -1,0 +1,105 @@
+import type { Server as HttpServer, IncomingMessage } from 'http';
+import type { Socket } from 'net';
+import { WebSocketServer, WebSocket } from 'ws';
+import { createLogger } from '../utils/logger';
+import type { WatchLiveEvent, WatchManager } from './watcher';
+
+const log = createLogger('WatchLiveWS');
+const HEARTBEAT_INTERVAL_MS = 30_000;
+
+interface WatchSocket extends WebSocket {
+  isAlive?: boolean;
+}
+
+export interface WatchLiveWebSocketOptions {
+  authorizeRequest: (req: IncomingMessage) => boolean;
+}
+
+/**
+ * WatchLiveWebSocket — pushes watch snapshots and incremental updates to agents.
+ */
+export class WatchLiveWebSocket {
+  private readonly wss: WebSocketServer;
+  private readonly heartbeat: NodeJS.Timeout;
+  private readonly handleUpgradeBound: (req: IncomingMessage, socket: Socket, head: Buffer) => void;
+
+  constructor(
+    private readonly httpServer: HttpServer,
+    private readonly watchManager: WatchManager,
+    private readonly opts: WatchLiveWebSocketOptions,
+  ) {
+    this.wss = new WebSocketServer({ noServer: true });
+    this.handleUpgradeBound = this.handleUpgrade.bind(this);
+
+    this.httpServer.on('upgrade', this.handleUpgradeBound);
+    this.wss.on('connection', (ws) => {
+      this.handleConnection(ws as WatchSocket);
+    });
+
+    this.heartbeat = setInterval(() => {
+      for (const client of this.wss.clients) {
+        const socket = client as WatchSocket;
+        if (!socket.isAlive) {
+          socket.terminate();
+          continue;
+        }
+        socket.isAlive = false;
+        if (socket.readyState === WebSocket.OPEN) {
+          socket.ping();
+        }
+      }
+    }, HEARTBEAT_INTERVAL_MS);
+
+    log.info('Watch live WebSocket ready on /watch/live');
+  }
+
+  close(): void {
+    clearInterval(this.heartbeat);
+    this.httpServer.off('upgrade', this.handleUpgradeBound);
+    for (const client of this.wss.clients) {
+      client.close(1001, 'Server shutting down');
+    }
+    this.wss.close();
+  }
+
+  private handleUpgrade(req: IncomingMessage, socket: Socket, head: Buffer): void {
+    const url = new URL(req.url ?? '', 'http://localhost');
+    if (url.pathname !== '/watch/live') return;
+
+    if (!this.opts.authorizeRequest(req)) {
+      socket.write('HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n');
+      socket.destroy();
+      return;
+    }
+
+    this.wss.handleUpgrade(req, socket, head, (ws) => {
+      this.wss.emit('connection', ws, req);
+    });
+  }
+
+  private handleConnection(ws: WatchSocket): void {
+    ws.isAlive = true;
+    ws.on('pong', () => {
+      ws.isAlive = true;
+    });
+
+    this.sendEvent(ws, this.watchManager.getSnapshot());
+
+    const unsubscribe = this.watchManager.subscribe((event) => {
+      this.sendEvent(ws, event);
+    });
+
+    ws.on('close', () => {
+      unsubscribe();
+    });
+
+    ws.on('error', () => {
+      unsubscribe();
+    });
+  }
+
+  private sendEvent(ws: WebSocket, event: WatchLiveEvent): void {
+    if (ws.readyState !== WebSocket.OPEN) return;
+    ws.send(JSON.stringify(event));
+  }
+}

--- a/src/watch/tests/live-ws.test.ts
+++ b/src/watch/tests/live-ws.test.ts
@@ -1,0 +1,150 @@
+import http from 'http';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import WebSocket from 'ws';
+import { WatchLiveWebSocket } from '../live-ws';
+import type { WatchLiveEvent } from '../watcher';
+
+vi.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+class MockWatchManager {
+  private readonly listeners = new Set<(event: WatchLiveEvent) => void>();
+
+  getSnapshot(): WatchLiveEvent {
+    return {
+      type: 'snapshot',
+      watches: [{
+        id: 'watch-1',
+        url: 'https://example.com',
+        intervalMs: 60_000,
+        lastCheck: null,
+        lastHash: null,
+        lastTitle: null,
+        lastError: null,
+        changeCount: 0,
+        createdAt: 1,
+      }],
+      emittedAt: 123,
+    };
+  }
+
+  subscribe(cb: (event: WatchLiveEvent) => void): () => void {
+    this.listeners.add(cb);
+    return () => {
+      this.listeners.delete(cb);
+    };
+  }
+
+  emit(event: WatchLiveEvent): void {
+    for (const listener of this.listeners) {
+      listener(event);
+    }
+  }
+}
+
+describe('WatchLiveWebSocket', () => {
+  let server: http.Server;
+  let port: number;
+  let watchManager: MockWatchManager;
+  let watchLiveWs: WatchLiveWebSocket;
+
+  beforeEach(async () => {
+    watchManager = new MockWatchManager();
+    server = http.createServer();
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', () => resolve());
+    });
+    port = (server.address() as { port: number }).port;
+    watchLiveWs = new WatchLiveWebSocket(server, watchManager as never, {
+      authorizeRequest: (req) => new URL(req.url ?? '', 'http://localhost').searchParams.get('token') === 'secret',
+    });
+  });
+
+  afterEach(async () => {
+    watchLiveWs.close();
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+  });
+
+  it('sends a snapshot immediately after connection', async () => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/watch/live?token=secret`);
+    const message = await new Promise<WatchLiveEvent>((resolve, reject) => {
+      ws.once('message', (data) => resolve(JSON.parse(data.toString()) as WatchLiveEvent));
+      ws.once('error', reject);
+    });
+
+    expect(message).toEqual(watchManager.getSnapshot());
+    ws.close();
+  });
+
+  it('forwards watch events to connected clients', async () => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/watch/live?token=secret`);
+
+    await new Promise<void>((resolve, reject) => {
+      ws.once('message', () => resolve());
+      ws.once('error', reject);
+    });
+
+    const forwarded = new Promise<WatchLiveEvent>((resolve, reject) => {
+      ws.once('message', (data) => resolve(JSON.parse(data.toString()) as WatchLiveEvent));
+      ws.once('error', reject);
+    });
+
+    watchManager.emit({
+      type: 'watch-checked',
+      watch: {
+        id: 'watch-1',
+        url: 'https://example.com',
+        intervalMs: 60_000,
+        lastCheck: 999,
+        lastHash: 'abc',
+        lastTitle: 'Example',
+        lastError: null,
+        changeCount: 1,
+        createdAt: 1,
+      },
+      reason: 'timer',
+      changed: true,
+      emittedAt: 999,
+    });
+
+    expect(await forwarded).toEqual({
+      type: 'watch-checked',
+      watch: {
+        id: 'watch-1',
+        url: 'https://example.com',
+        intervalMs: 60_000,
+        lastCheck: 999,
+        lastHash: 'abc',
+        lastTitle: 'Example',
+        lastError: null,
+        changeCount: 1,
+        createdAt: 1,
+      },
+      reason: 'timer',
+      changed: true,
+      emittedAt: 999,
+    });
+
+    ws.close();
+  });
+
+  it('rejects unauthorized upgrade requests', async () => {
+    const error = await new Promise<Error>((resolve) => {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/watch/live`);
+      ws.once('error', (err) => resolve(err as Error));
+    });
+
+    expect(error.message).toContain('401');
+  });
+});

--- a/src/watch/tests/watcher.test.ts
+++ b/src/watch/tests/watcher.test.ts
@@ -6,7 +6,11 @@ vi.mock('electron', () => ({
     show: false,
     webContents: {
       on: vi.fn(),
-      once: vi.fn(),
+      once: vi.fn().mockImplementation((event: string, cb: () => void) => {
+        if (event === 'did-finish-load') {
+          setTimeout(cb, 0);
+        }
+      }),
       loadURL: vi.fn().mockResolvedValue(undefined),
       executeJavaScript: vi.fn().mockResolvedValue('page text content'),
     },
@@ -138,6 +142,18 @@ describe('WatchManager', () => {
       const entry = result as { id: string; intervalMs: number };
       expect(entry.intervalMs).toBe(60000); // 1 minute minimum
     });
+
+    it('emits a watch-added event', () => {
+      const events: string[] = [];
+      const unsubscribe = wm.subscribe((event) => {
+        events.push(event.type);
+      });
+
+      wm.addWatch('https://events.com', 5);
+
+      expect(events).toContain('watch-added');
+      unsubscribe();
+    });
   });
 
   describe('removeWatch()', () => {
@@ -164,6 +180,27 @@ describe('WatchManager', () => {
       wm.addWatch('https://b.com', 10);
       const watches = wm.listWatches();
       expect(watches).toHaveLength(2);
+    });
+
+    it('returns cloned entries', () => {
+      wm.addWatch('https://clone.com', 5);
+      const watches = wm.listWatches();
+      watches[0].url = 'https://mutated.example';
+
+      expect(wm.listWatches()[0].url).toBe('https://clone.com');
+    });
+  });
+
+  describe('getSnapshot()', () => {
+    it('returns a live snapshot event', () => {
+      wm.addWatch('https://snapshot.com', 5);
+
+      const snapshot = wm.getSnapshot();
+
+      expect(snapshot.type).toBe('snapshot');
+      expect(snapshot.watches).toHaveLength(1);
+      snapshot.watches[0].url = 'https://mutated.example';
+      expect(wm.getSnapshot().watches[0].url).toBe('https://snapshot.com');
     });
   });
 

--- a/src/watch/watcher.ts
+++ b/src/watch/watcher.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import crypto from 'crypto';
+import { EventEmitter } from 'events';
 import { tandemDir } from '../utils/paths';
 import { BrowserWindow, session } from 'electron';
 import { StealthManager } from '../stealth/manager';
@@ -28,6 +29,49 @@ interface WatchState {
   watches: WatchEntry[];
 }
 
+export type WatchCheckReason = 'initial' | 'manual' | 'timer';
+
+export interface WatchSnapshotEvent {
+  type: 'snapshot';
+  watches: WatchEntry[];
+  emittedAt: number;
+}
+
+export interface WatchAddedEvent {
+  type: 'watch-added';
+  watch: WatchEntry;
+  emittedAt: number;
+}
+
+export interface WatchRemovedEvent {
+  type: 'watch-removed';
+  watch: WatchEntry;
+  emittedAt: number;
+}
+
+export interface WatchCheckStartedEvent {
+  type: 'watch-check-started';
+  watch: WatchEntry;
+  reason: WatchCheckReason;
+  emittedAt: number;
+}
+
+export interface WatchCheckedEvent {
+  type: 'watch-checked';
+  watch: WatchEntry;
+  reason: WatchCheckReason;
+  changed: boolean;
+  error?: string;
+  emittedAt: number;
+}
+
+export type WatchLiveEvent =
+  | WatchSnapshotEvent
+  | WatchAddedEvent
+  | WatchRemovedEvent
+  | WatchCheckStartedEvent
+  | WatchCheckedEvent;
+
 // ─── Manager ────────────────────────────────────────────────────────
 
 /**
@@ -37,7 +81,7 @@ interface WatchState {
  * Hashes page text content and compares with previous check.
  * Alerts the human/wingman when something changes.
  */
-export class WatchManager {
+export class WatchManager extends EventEmitter {
 
   // === 1. Private state ===
 
@@ -52,6 +96,7 @@ export class WatchManager {
   // === 2. Constructor ===
 
   constructor() {
+    super();
     const baseDir = tandemDir();
     if (!fs.existsSync(baseDir)) fs.mkdirSync(baseDir, { recursive: true });
 
@@ -88,9 +133,14 @@ export class WatchManager {
     this.state.watches.push(watch);
     this.save();
     this.startTimer(watch);
+    this.emitWatchEvent({
+      type: 'watch-added',
+      watch: this.cloneWatch(watch),
+      emittedAt: Date.now(),
+    });
 
     // Do an initial check
-    this.checkUrl(watch.id).catch((e) => log.warn('Watch check failed for ' + watch.id + ':', e.message));
+    this.checkUrl(watch.id, 'initial').catch((e) => log.warn('Watch check failed for ' + watch.id + ':', e.message));
 
     return watch;
   }
@@ -104,12 +154,17 @@ export class WatchManager {
     this.stopTimer(watch.id);
     this.state.watches.splice(idx, 1);
     this.save();
+    this.emitWatchEvent({
+      type: 'watch-removed',
+      watch: this.cloneWatch(watch),
+      emittedAt: Date.now(),
+    });
     return true;
   }
 
   /** List all watches */
   listWatches(): WatchEntry[] {
-    return this.state.watches;
+    return this.state.watches.map(watch => this.cloneWatch(watch));
   }
 
   /** Force check a specific watch or all watches */
@@ -120,20 +175,26 @@ export class WatchManager {
 
     const results: { id: string; changed: boolean; error?: string }[] = [];
     for (const watch of targets) {
-      const result = await this.checkUrl(watch.id);
+      const result = await this.checkUrl(watch.id, 'manual');
       results.push({ id: watch.id, ...result });
     }
     return { results };
   }
 
   /** Check a single URL for changes */
-  async checkUrl(watchId: string): Promise<{ changed: boolean; error?: string }> {
+  async checkUrl(watchId: string, reason: WatchCheckReason = 'manual'): Promise<{ changed: boolean; error?: string }> {
     const watch = this.state.watches.find(w => w.id === watchId);
     if (!watch) return { changed: false, error: 'Watch not found' };
 
     // Prevent concurrent checks
     if (this.checking) return { changed: false, error: 'Already checking' };
     this.checking = true;
+    this.emitWatchEvent({
+      type: 'watch-check-started',
+      watch: this.cloneWatch(watch),
+      reason,
+      emittedAt: Date.now(),
+    });
 
     try {
       const win = await this.getHiddenWindow();
@@ -180,6 +241,13 @@ export class WatchManager {
 
       watch.lastHash = newHash;
       this.save();
+      this.emitWatchEvent({
+        type: 'watch-checked',
+        watch: this.cloneWatch(watch),
+        reason,
+        changed,
+        emittedAt: Date.now(),
+      });
 
       return { changed };
     } catch (e) {
@@ -187,10 +255,35 @@ export class WatchManager {
       watch.lastCheck = Date.now();
       watch.lastError = message;
       this.save();
+      this.emitWatchEvent({
+        type: 'watch-checked',
+        watch: this.cloneWatch(watch),
+        reason,
+        changed: false,
+        error: message,
+        emittedAt: Date.now(),
+      });
       return { changed: false, error: message };
     } finally {
       this.checking = false;
     }
+  }
+
+  /** Subscribe to live watch events. Returns an unsubscribe function. */
+  subscribe(cb: (event: WatchLiveEvent) => void): () => void {
+    this.on('watch-event', cb);
+    return () => {
+      this.off('watch-event', cb);
+    };
+  }
+
+  /** Build a current-state snapshot for newly connected live clients. */
+  getSnapshot(): WatchSnapshotEvent {
+    return {
+      type: 'snapshot',
+      watches: this.listWatches(),
+      emittedAt: Date.now(),
+    };
   }
 
   // === 6. Cleanup ===
@@ -257,11 +350,19 @@ export class WatchManager {
     return crypto.createHash('sha256').update(text).digest('hex').substring(0, 16);
   }
 
+  private cloneWatch(watch: WatchEntry): WatchEntry {
+    return { ...watch };
+  }
+
+  private emitWatchEvent(event: WatchLiveEvent): void {
+    this.emit('watch-event', event);
+  }
+
   /** Start timer for a single watch */
   private startTimer(watch: WatchEntry): void {
     this.stopTimer(watch.id);
     const timer = setInterval(() => {
-      this.checkUrl(watch.id).catch((e) => log.warn('Watch check failed for ' + watch.id + ':', e.message));
+      this.checkUrl(watch.id, 'timer').catch((e) => log.warn('Watch check failed for ' + watch.id + ':', e.message));
     }, watch.intervalMs);
     this.timers.set(watch.id, timer);
   }


### PR DESCRIPTION
## What changed

This adds a dedicated authenticated WebSocket endpoint at `ws://127.0.0.1:8765/watch/live` for real-time watch updates.

The change includes:
- a new `WatchLiveWebSocket` server attached to the existing Tandem API HTTP server
- typed watch lifecycle events emitted by `WatchManager`
- an initial snapshot on connect, followed by incremental `watch-added`, `watch-removed`, `watch-check-started`, and `watch-checked` events
- test coverage for both the watch manager event surface and the WebSocket handshake/stream behavior
- backlog/docs updates in `TODO.md` and `CHANGELOG.md`

## Why

The watch system already existed, but clients had to poll `/watch/list` and `/watch/check` to understand changes. This PR gives agents a proper live surface so watch monitoring can be reactive instead of polling-driven.

## Impact

- Agents can subscribe once and keep an up-to-date view of watches.
- The endpoint reuses the existing local API token model instead of introducing a separate secret.
- Existing watch routes remain unchanged.

## Validation

- `npx tsc`
- `npx vitest run`
- `npm run verify`
- Manual: `npm start`, connected to `/watch/live`, verified snapshot plus real `watch-added` and `watch-removed` events via API calls
