### PR TITLE
[codex] Add configurable watch diff modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to Tandem Browser will be documented in this file.
 ### Added
 
 - `ws://127.0.0.1:8765/watch/live` now streams an immediate watch snapshot plus incremental watch add/remove/check events to authenticated local clients, giving agents a real-time watch surface instead of polling `/watch/list`
+- Watches now support configurable diff modes for change detection: `content`, `title`, `title-or-content`, and `text-length`, exposed through both the HTTP API and MCP watch-add flow
 
 ## [v0.72.1] - 2026-04-14
 

--- a/TODO.md
+++ b/TODO.md
@@ -33,7 +33,7 @@ Last updated: April 14, 2026
 - [x] Google Photos upload support for screenshots; local OAuth client ID setup, connect/disconnect flow, and automatic upload path now exist
 - [x] Screenshot capture modes for `Web Page`, `Application`, and in-app `Region` selection from the main toolbar screenshot button
 - [x] Configurable quick links on the new tab page; links are no longer hardcoded
-- [ ] Configurable diff modes for watches beyond SHA-256 hash comparison
+- [x] Configurable diff modes for watches beyond SHA-256 hash comparison
 - [x] HAR export for the network inspector
 - [ ] Design and build the `Personal News` experience; the sidebar currently has a placeholder slot, but the actual panel and feed model are not implemented yet
 - [x] Built-in video recorder with Application and Region capture modes, tab audio + mic toggle, MP4 output via ffmpeg; replaces AudioCaptureManager

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tandem-browser",
   "version": "0.72.2",
-  "description": "Local-first Electron browser for shared human-AI browser context, with MCP/HTTP control surfaces and built-in security controls",
+  "description": "Local-first Electron browser with a 248-tool MCP server, MCP/HTTP control surfaces, and built-in security controls",
   "main": "dist/main.js",
   "author": "Tandem Browser contributors",
   "license": "MIT",

--- a/src/api/routes/misc.ts
+++ b/src/api/routes/misc.ts
@@ -446,9 +446,9 @@ export function registerMiscRoutes(router: Router, ctx: RouteContext): void {
 
   router.post('/watch/add', (req: Request, res: Response) => {
     try {
-      const { url, intervalMinutes = 30 } = req.body;
+      const { url, intervalMinutes = 30, diffMode } = req.body;
       if (!url) { res.status(400).json({ error: 'url required' }); return; }
-      const result = ctx.watchManager.addWatch(url, intervalMinutes);
+      const result = ctx.watchManager.addWatch(url, intervalMinutes, diffMode);
       if ('error' in result) { res.status(400).json(result); return; }
       res.json({ ok: true, watch: result });
     } catch (e) {

--- a/src/api/tests/helpers.ts
+++ b/src/api/tests/helpers.ts
@@ -193,7 +193,7 @@ export function createMockContext(): RouteContext {
 
     // ── watchManager ────────────────────────────
     watchManager: {
-      addWatch: vi.fn().mockReturnValue({ id: 'w1', url: '', intervalMinutes: 30 }),
+      addWatch: vi.fn().mockReturnValue({ id: 'w1', url: '', intervalMinutes: 30, diffMode: 'content' }),
       listWatches: vi.fn().mockReturnValue([]),
       removeWatch: vi.fn().mockReturnValue(true),
       forceCheck: vi.fn().mockResolvedValue({ changed: false }),

--- a/src/api/tests/routes/misc.test.ts
+++ b/src/api/tests/routes/misc.test.ts
@@ -806,7 +806,7 @@ describe('misc routes', () => {
 
   describe('POST /watch/add', () => {
     it('adds a watch with default interval', async () => {
-      const mockWatch = { id: 'w1', url: 'https://example.com', intervalMinutes: 30 };
+      const mockWatch = { id: 'w1', url: 'https://example.com', intervalMinutes: 30, diffMode: 'content' };
       vi.mocked(ctx.watchManager.addWatch).mockReturnValue(mockWatch as any);
 
       const res = await request(app)
@@ -815,11 +815,11 @@ describe('misc routes', () => {
 
       expect(res.status).toBe(200);
       expect(res.body).toEqual({ ok: true, watch: mockWatch });
-      expect(ctx.watchManager.addWatch).toHaveBeenCalledWith('https://example.com', 30);
+      expect(ctx.watchManager.addWatch).toHaveBeenCalledWith('https://example.com', 30, undefined);
     });
 
     it('adds a watch with custom interval', async () => {
-      const mockWatch = { id: 'w2', url: 'https://test.com', intervalMinutes: 60 };
+      const mockWatch = { id: 'w2', url: 'https://test.com', intervalMinutes: 60, diffMode: 'content' };
       vi.mocked(ctx.watchManager.addWatch).mockReturnValue(mockWatch as any);
 
       const res = await request(app)
@@ -827,7 +827,19 @@ describe('misc routes', () => {
         .send({ url: 'https://test.com', intervalMinutes: 60 });
 
       expect(res.status).toBe(200);
-      expect(ctx.watchManager.addWatch).toHaveBeenCalledWith('https://test.com', 60);
+      expect(ctx.watchManager.addWatch).toHaveBeenCalledWith('https://test.com', 60, undefined);
+    });
+
+    it('adds a watch with explicit diff mode', async () => {
+      const mockWatch = { id: 'w3', url: 'https://title-only.com', intervalMinutes: 30, diffMode: 'title' };
+      vi.mocked(ctx.watchManager.addWatch).mockReturnValue(mockWatch as any);
+
+      const res = await request(app)
+        .post('/watch/add')
+        .send({ url: 'https://title-only.com', diffMode: 'title' });
+
+      expect(res.status).toBe(200);
+      expect(ctx.watchManager.addWatch).toHaveBeenCalledWith('https://title-only.com', 30, 'title');
     });
 
     it('returns 400 when url is missing', async () => {

--- a/src/mcp/tests/watches.test.ts
+++ b/src/mcp/tests/watches.test.ts
@@ -32,7 +32,14 @@ describe('MCP watch tools', () => {
     mockApiCall.mockResolvedValueOnce({ id: 'w1' });
     mockLogActivity.mockResolvedValueOnce(undefined);
     await getHandler(tools, 'tandem_watch_add')({ url: 'https://news.com', intervalMinutes: 60 });
-    expect(mockApiCall).toHaveBeenCalledWith('POST', '/watch/add', { url: 'https://news.com', intervalMinutes: 60 });
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/watch/add', { url: 'https://news.com', intervalMinutes: 60, diffMode: undefined });
+  });
+
+  it('tandem_watch_add forwards diff mode', async () => {
+    mockApiCall.mockResolvedValueOnce({ id: 'w2' });
+    mockLogActivity.mockResolvedValueOnce(undefined);
+    await getHandler(tools, 'tandem_watch_add')({ url: 'https://news.com', intervalMinutes: 60, diffMode: 'title' });
+    expect(mockApiCall).toHaveBeenCalledWith('POST', '/watch/add', { url: 'https://news.com', intervalMinutes: 60, diffMode: 'title' });
   });
 
   it('tandem_watch_remove removes a watch', async () => {

--- a/src/mcp/tools/watches.ts
+++ b/src/mcp/tools/watches.ts
@@ -3,6 +3,8 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { apiCall, logActivity } from '../api-client.js';
 import { coerceShape } from '../coerce.js';
 
+const watchDiffModeSchema = z.enum(['content', 'title', 'title-or-content', 'text-length']);
+
 export function registerWatchTools(server: McpServer): void {
   server.tool(
     'tandem_watch_list',
@@ -20,9 +22,10 @@ export function registerWatchTools(server: McpServer): void {
     coerceShape({
       url: z.string().describe('URL to monitor'),
       intervalMinutes: z.number().optional().describe('Check interval in minutes (default: 30)'),
+      diffMode: watchDiffModeSchema.optional().describe('Change detection mode: content, title, title-or-content, or text-length'),
     }),
-    async ({ url, intervalMinutes }) => {
-      const data = await apiCall('POST', '/watch/add', { url, intervalMinutes });
+    async ({ url, intervalMinutes, diffMode }) => {
+      const data = await apiCall('POST', '/watch/add', { url, intervalMinutes, diffMode });
       await logActivity('watch_add', url);
       return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
     }

--- a/src/watch/tests/live-ws.test.ts
+++ b/src/watch/tests/live-ws.test.ts
@@ -22,8 +22,10 @@ class MockWatchManager {
       watches: [{
         id: 'watch-1',
         url: 'https://example.com',
+        diffMode: 'content',
         intervalMs: 60_000,
         lastCheck: null,
+        lastFingerprint: null,
         lastHash: null,
         lastTitle: null,
         lastError: null,
@@ -105,8 +107,10 @@ describe('WatchLiveWebSocket', () => {
       watch: {
         id: 'watch-1',
         url: 'https://example.com',
+        diffMode: 'content',
         intervalMs: 60_000,
         lastCheck: 999,
+        lastFingerprint: 'abc',
         lastHash: 'abc',
         lastTitle: 'Example',
         lastError: null,
@@ -123,8 +127,10 @@ describe('WatchLiveWebSocket', () => {
       watch: {
         id: 'watch-1',
         url: 'https://example.com',
+        diffMode: 'content',
         intervalMs: 60_000,
         lastCheck: 999,
+        lastFingerprint: 'abc',
         lastHash: 'abc',
         lastTitle: 'Example',
         lastError: null,

--- a/src/watch/tests/watcher.test.ts
+++ b/src/watch/tests/watcher.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { BrowserWindow } from 'electron';
 
 // Mock electron
 vi.mock('electron', () => ({
@@ -138,6 +139,28 @@ describe('WatchManager', () => {
       ]);
       wm2.destroy();
     });
+
+    it('filters invalid persisted watch entries', () => {
+      const savedState = {
+        watches: [
+          null,
+          { id: '', url: 'https://missing-id.com' },
+          { id: 'missing-url', url: '   ' },
+          { id: 'watch-valid', url: 'https://valid.com', intervalMs: 300000, createdAt: 1000 },
+        ],
+      };
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(savedState));
+
+      const wm2 = new WatchManager();
+      expect(wm2.listWatches()).toEqual([
+        expect.objectContaining({
+          id: 'watch-valid',
+          url: 'https://valid.com',
+        }),
+      ]);
+      wm2.destroy();
+    });
   });
 
   describe('addWatch()', () => {
@@ -251,6 +274,18 @@ describe('WatchManager', () => {
       wm.addWatch('https://cleanup.com', 5);
       expect(() => wm.destroy()).not.toThrow();
     });
+
+    it('closes the hidden window when present', () => {
+      const close = vi.fn();
+      (wm as never).hiddenWindow = {
+        isDestroyed: vi.fn().mockReturnValue(false),
+        close,
+      };
+
+      wm.destroy();
+
+      expect(close).toHaveBeenCalled();
+    });
   });
 
   describe('hashContent (via checkUrl)', () => {
@@ -259,6 +294,52 @@ describe('WatchManager', () => {
       const result = await wm.checkUrl('nonexistent');
       expect(result.changed).toBe(false);
       expect(result.error).toBe('Watch not found');
+    });
+
+    it('checkUrl returns load failure errors', async () => {
+      vi.spyOn(wm as never, 'getHiddenWindow').mockResolvedValue({
+        webContents: {
+          once: vi.fn().mockImplementation((event: string, cb: (...args: unknown[]) => void) => {
+            if (event === 'did-fail-load') {
+              setTimeout(() => cb(undefined, -105, 'Name not resolved'), 0);
+            }
+          }),
+          loadURL: vi.fn().mockResolvedValue(undefined),
+          executeJavaScript: vi.fn(),
+        },
+      } as never);
+
+      const initialSpy = vi.spyOn(wm, 'checkUrl').mockResolvedValue({ changed: false });
+      const watch = wm.addWatch('https://load-fail.com', 5) as { id: string };
+      initialSpy.mockRestore();
+
+      const pending = wm.checkUrl(watch.id);
+      await vi.advanceTimersByTimeAsync(0);
+      const result = await pending;
+
+      expect(result.changed).toBe(false);
+      expect(result.error).toContain('Load failed: Name not resolved (-105)');
+    });
+
+    it('checkUrl returns timeout errors', async () => {
+      vi.spyOn(wm as never, 'getHiddenWindow').mockResolvedValue({
+        webContents: {
+          once: vi.fn(),
+          loadURL: vi.fn().mockResolvedValue(undefined),
+          executeJavaScript: vi.fn(),
+        },
+      } as never);
+
+      const initialSpy = vi.spyOn(wm, 'checkUrl').mockResolvedValue({ changed: false });
+      const watch = wm.addWatch('https://timeout.com', 5) as { id: string };
+      initialSpy.mockRestore();
+
+      const pending = wm.checkUrl(watch.id);
+      await vi.advanceTimersByTimeAsync(30_000);
+      const result = await pending;
+
+      expect(result.changed).toBe(false);
+      expect(result.error).toBe('Page load timeout');
     });
   });
 
@@ -334,6 +415,67 @@ describe('WatchManager', () => {
       const result = await runCheckWithPage(watch.id, 'xyz', 'Length Title');
 
       expect(result).toEqual({ changed: false });
+    });
+
+    it('falls back to content hash for unknown fingerprint mode input', () => {
+      const fingerprint = (wm as never).buildDiffFingerprint('bogus', 'body', 'Title', 'hash123');
+      expect(fingerprint).toBe('hash123');
+    });
+  });
+
+  describe('timers', () => {
+    it('swallows timer check errors', async () => {
+      const spy = vi.spyOn(wm, 'checkUrl')
+        .mockResolvedValueOnce({ changed: false })
+        .mockRejectedValueOnce(new Error('timer failed'));
+
+      wm.addWatch('https://timer-error.com', 1);
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(spy).toHaveBeenNthCalledWith(1, expect.any(String), 'initial');
+      expect(spy).toHaveBeenNthCalledWith(2, expect.any(String), 'timer');
+    });
+  });
+
+  describe('getHiddenWindow()', () => {
+    it('reuses an existing hidden window', async () => {
+      const existingWindow = {
+        isDestroyed: vi.fn().mockReturnValue(false),
+        close: vi.fn(),
+      };
+      (wm as never).hiddenWindow = existingWindow;
+
+      const result = await (wm as never).getHiddenWindow();
+
+      expect(result).toBe(existingWindow);
+    });
+
+    it('logs stealth injection failures without throwing', async () => {
+      let finishLoadHandler: (() => void) | null = null;
+      vi.mocked(BrowserWindow).mockImplementationOnce(function () {
+        return {
+          webContents: {
+            on: vi.fn().mockImplementation((event: string, cb: () => void) => {
+              if (event === 'did-finish-load') {
+                finishLoadHandler = cb;
+              }
+            }),
+            once: vi.fn(),
+            loadURL: vi.fn().mockResolvedValue(undefined),
+            executeJavaScript: vi.fn().mockRejectedValue(new Error('stealth failed')),
+          },
+          isDestroyed: vi.fn().mockReturnValue(false),
+          close: vi.fn(),
+        } as never;
+      });
+
+      await (wm as never).getHiddenWindow();
+      expect(finishLoadHandler).not.toBeNull();
+
+      finishLoadHandler?.();
+      await Promise.resolve();
+      await Promise.resolve();
     });
   });
 

--- a/src/watch/tests/watcher.test.ts
+++ b/src/watch/tests/watcher.test.ts
@@ -12,7 +12,12 @@ vi.mock('electron', () => ({
         }
       }),
       loadURL: vi.fn().mockResolvedValue(undefined),
-      executeJavaScript: vi.fn().mockResolvedValue('page text content'),
+      executeJavaScript: vi.fn().mockImplementation((code: string) => {
+        if (code === 'document.title') {
+          return Promise.resolve('Example Title');
+        }
+        return Promise.resolve('page text content');
+      }),
     },
     isDestroyed: vi.fn().mockReturnValue(false),
     close: vi.fn(),
@@ -107,6 +112,30 @@ describe('WatchManager', () => {
 
       const wm2 = new WatchManager();
       expect(wm2.listWatches()).toHaveLength(1);
+      expect(wm2.listWatches()[0].diffMode).toBe('content');
+      wm2.destroy();
+    });
+
+    it('migrates legacy watches to a default diff mode', () => {
+      const savedState = {
+        watches: [{
+          id: 'watch-legacy', url: 'https://legacy.com', intervalMs: 300000,
+          lastCheck: 123, lastHash: 'abc123', lastTitle: 'Legacy', lastError: null,
+          changeCount: 2, createdAt: 1000,
+        }],
+      };
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(savedState));
+
+      const wm2 = new WatchManager();
+      expect(wm2.listWatches()).toEqual([
+        expect.objectContaining({
+          id: 'watch-legacy',
+          diffMode: 'content',
+          lastHash: 'abc123',
+          lastFingerprint: 'abc123',
+        }),
+      ]);
       wm2.destroy();
     });
   });
@@ -115,9 +144,11 @@ describe('WatchManager', () => {
     it('adds a new watch and returns entry', () => {
       const result = wm.addWatch('https://example.com', 5);
       expect('id' in result).toBe(true);
-      const entry = result as { id: string; url: string; intervalMs: number };
+      const entry = result as { id: string; url: string; intervalMs: number; diffMode: string; lastFingerprint: string | null };
       expect(entry.url).toBe('https://example.com');
       expect(entry.intervalMs).toBe(5 * 60 * 1000);
+      expect(entry.diffMode).toBe('content');
+      expect(entry.lastFingerprint).toBeNull();
       expect(fs.writeFileSync).toHaveBeenCalled();
     });
 
@@ -141,6 +172,17 @@ describe('WatchManager', () => {
       const result = wm.addWatch('https://fast.com', 0);
       const entry = result as { id: string; intervalMs: number };
       expect(entry.intervalMs).toBe(60000); // 1 minute minimum
+    });
+
+    it('stores explicit diff mode', () => {
+      const result = wm.addWatch('https://title-only.com', 5, 'title');
+      expect((result as { diffMode: string }).diffMode).toBe('title');
+    });
+
+    it('rejects unsupported diff modes', () => {
+      const result = wm.addWatch('https://bad-mode.com', 5, 'bogus' as never);
+      expect('error' in result).toBe(true);
+      expect((result as { error: string }).error).toContain('Unsupported diff mode');
     });
 
     it('emits a watch-added event', () => {
@@ -234,6 +276,64 @@ describe('WatchManager', () => {
       const { results } = await wm.forceCheck(entry.id);
       expect(results).toHaveLength(1);
       expect(results[0].id).toBe(entry.id);
+    });
+  });
+
+  describe('diff modes', () => {
+    async function runCheckWithPage(id: string, text: string, title: string) {
+      vi.spyOn(wm as never, 'getHiddenWindow').mockResolvedValue({
+        webContents: {
+          once: vi.fn().mockImplementation((event: string, cb: () => void) => {
+            if (event === 'did-finish-load') {
+              setTimeout(cb, 0);
+            }
+          }),
+          loadURL: vi.fn().mockResolvedValue(undefined),
+          executeJavaScript: vi.fn().mockImplementation((code: string) => {
+            if (code === 'document.title') {
+              return Promise.resolve(title);
+            }
+            return Promise.resolve(text);
+          }),
+        },
+      } as never);
+
+      const pending = wm.checkUrl(id);
+      await vi.advanceTimersByTimeAsync(2000);
+      return pending;
+    }
+
+    it('title mode ignores body-only changes', async () => {
+      const initialSpy = vi.spyOn(wm, 'checkUrl').mockResolvedValue({ changed: false });
+      const watch = wm.addWatch('https://title-mode.com', 5, 'title') as { id: string };
+      initialSpy.mockRestore();
+
+      await runCheckWithPage(watch.id, 'first body', 'Same Title');
+      const result = await runCheckWithPage(watch.id, 'second body', 'Same Title');
+
+      expect(result).toEqual({ changed: false });
+    });
+
+    it('title-or-content mode detects title changes', async () => {
+      const initialSpy = vi.spyOn(wm, 'checkUrl').mockResolvedValue({ changed: false });
+      const watch = wm.addWatch('https://title-or-content.com', 5, 'title-or-content') as { id: string };
+      initialSpy.mockRestore();
+
+      await runCheckWithPage(watch.id, 'same body', 'Title A');
+      const result = await runCheckWithPage(watch.id, 'same body', 'Title B');
+
+      expect(result).toEqual({ changed: true });
+    });
+
+    it('text-length mode ignores equal-length content churn', async () => {
+      const initialSpy = vi.spyOn(wm, 'checkUrl').mockResolvedValue({ changed: false });
+      const watch = wm.addWatch('https://length-mode.com', 5, 'text-length') as { id: string };
+      initialSpy.mockRestore();
+
+      await runCheckWithPage(watch.id, 'abc', 'Length Title');
+      const result = await runCheckWithPage(watch.id, 'xyz', 'Length Title');
+
+      expect(result).toEqual({ changed: false });
     });
   });
 

--- a/src/watch/watcher.ts
+++ b/src/watch/watcher.ts
@@ -16,8 +16,10 @@ const log = createLogger('Watcher');
 export interface WatchEntry {
   id: string;
   url: string;
+  diffMode: WatchDiffMode;
   intervalMs: number;
   lastCheck: number | null;
+  lastFingerprint: string | null;
   lastHash: string | null;
   lastTitle: string | null;
   lastError: string | null;
@@ -29,6 +31,14 @@ interface WatchState {
   watches: WatchEntry[];
 }
 
+export const WATCH_DIFF_MODES = [
+  'content',
+  'title',
+  'title-or-content',
+  'text-length',
+] as const;
+
+export type WatchDiffMode = (typeof WATCH_DIFF_MODES)[number];
 export type WatchCheckReason = 'initial' | 'manual' | 'timer';
 
 export interface WatchSnapshotEvent {
@@ -78,7 +88,7 @@ export type WatchLiveEvent =
  * WatchManager — Scheduled background page watching.
  *
  * Uses a hidden BrowserWindow to periodically check pages for changes.
- * Hashes page text content and compares with previous check.
+ * Supports multiple diff strategies per watch instead of only one hash mode.
  * Alerts the human/wingman when something changes.
  */
 export class WatchManager extends EventEmitter {
@@ -108,7 +118,7 @@ export class WatchManager extends EventEmitter {
   // === 4. Public methods ===
 
   /** Add a new watch */
-  addWatch(url: string, intervalMinutes: number): WatchEntry | { error: string } {
+  addWatch(url: string, intervalMinutes: number, diffMode: WatchDiffMode = 'content'): WatchEntry | { error: string } {
     if (this.state.watches.length >= this.MAX_WATCHES) {
       return { error: `Maximum ${this.MAX_WATCHES} watches bereikt` };
     }
@@ -118,11 +128,17 @@ export class WatchManager extends EventEmitter {
       return { error: 'URL is already being watched' };
     }
 
+    if (!this.isWatchDiffMode(diffMode)) {
+      return { error: `Unsupported diff mode: ${diffMode}` };
+    }
+
     const watch: WatchEntry = {
       id: this.nextId(),
       url,
+      diffMode,
       intervalMs: Math.max(1, intervalMinutes) * 60 * 1000,
       lastCheck: null,
+      lastFingerprint: null,
       lastHash: null,
       lastTitle: null,
       lastError: null,
@@ -225,7 +241,8 @@ export class WatchManager extends EventEmitter {
 
       const title: string = await win.webContents.executeJavaScript('document.title');
       const newHash = this.hashContent(textContent);
-      const changed = watch.lastHash !== null && watch.lastHash !== newHash;
+      const newFingerprint = this.buildDiffFingerprint(watch.diffMode, textContent, title, newHash);
+      const changed = watch.lastFingerprint !== null && watch.lastFingerprint !== newFingerprint;
 
       watch.lastCheck = Date.now();
       watch.lastTitle = title;
@@ -239,6 +256,7 @@ export class WatchManager extends EventEmitter {
         );
       }
 
+      watch.lastFingerprint = newFingerprint;
       watch.lastHash = newHash;
       this.save();
       this.emitWatchEvent({
@@ -303,7 +321,13 @@ export class WatchManager extends EventEmitter {
   private load(): WatchState {
     try {
       if (fs.existsSync(this.watchFile)) {
-        return JSON.parse(fs.readFileSync(this.watchFile, 'utf-8'));
+        const parsed = JSON.parse(fs.readFileSync(this.watchFile, 'utf-8')) as Partial<WatchState> | null;
+        const rawWatches = Array.isArray(parsed?.watches) ? parsed.watches : [];
+        return {
+          watches: rawWatches
+            .map((watch) => this.sanitizeWatchEntry(watch))
+            .filter((watch): watch is WatchEntry => watch !== null),
+        };
       }
     } catch (e) { log.warn('Watch state load failed, starting fresh:', e instanceof Error ? e.message : String(e)); }
     return { watches: [] };
@@ -348,6 +372,66 @@ export class WatchManager extends EventEmitter {
   /** Hash text content of a page */
   private hashContent(text: string): string {
     return crypto.createHash('sha256').update(text).digest('hex').substring(0, 16);
+  }
+
+  private isWatchDiffMode(value: unknown): value is WatchDiffMode {
+    return typeof value === 'string' && WATCH_DIFF_MODES.includes(value as WatchDiffMode);
+  }
+
+  private sanitizeWatchEntry(raw: unknown): WatchEntry | null {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+      return null;
+    }
+
+    const value = raw as Partial<Record<keyof WatchEntry, unknown>>;
+    const id = typeof value.id === 'string' ? value.id.trim() : '';
+    const url = typeof value.url === 'string' ? value.url.trim() : '';
+    if (!id || !url) {
+      return null;
+    }
+
+    const intervalMs = typeof value.intervalMs === 'number' && Number.isFinite(value.intervalMs)
+      ? Math.max(60_000, value.intervalMs)
+      : 30 * 60 * 1000;
+    const diffMode = this.isWatchDiffMode(value.diffMode) ? value.diffMode : 'content';
+    const lastHash = typeof value.lastHash === 'string' ? value.lastHash : null;
+    const lastFingerprint = typeof value.lastFingerprint === 'string'
+      ? value.lastFingerprint
+      : lastHash;
+
+    return {
+      id,
+      url,
+      diffMode,
+      intervalMs,
+      lastCheck: typeof value.lastCheck === 'number' ? value.lastCheck : null,
+      lastFingerprint,
+      lastHash,
+      lastTitle: typeof value.lastTitle === 'string' ? value.lastTitle : null,
+      lastError: typeof value.lastError === 'string' ? value.lastError : null,
+      changeCount: typeof value.changeCount === 'number' && Number.isFinite(value.changeCount) ? value.changeCount : 0,
+      createdAt: typeof value.createdAt === 'number' && Number.isFinite(value.createdAt) ? value.createdAt : Date.now(),
+    };
+  }
+
+  private buildDiffFingerprint(
+    diffMode: WatchDiffMode,
+    textContent: string,
+    title: string,
+    contentHash: string,
+  ): string {
+    const normalizedTitle = title.trim();
+    switch (diffMode) {
+      case 'title':
+        return normalizedTitle;
+      case 'title-or-content':
+        return this.hashContent(`${normalizedTitle}\n${textContent}`);
+      case 'text-length':
+        return String(textContent.length);
+      case 'content':
+      default:
+        return contentHash;
+    }
   }
 
   private cloneWatch(watch: WatchEntry): WatchEntry {


### PR DESCRIPTION
## What changed

This adds configurable diff modes for watches instead of relying only on a content hash.

The change includes:
- `WatchManager` support for per-watch `diffMode`
- persisted `lastFingerprint` state separate from the existing `lastHash`
- automatic migration of older watch entries to the default `content` mode
- `POST /watch/add` support for `diffMode`
- MCP `tandem_watch_add` support for `diffMode`
- focused manager, route, MCP, and live-watch test updates

Supported modes:
- `content`
- `title`
- `title-or-content`
- `text-length`

## Why

Some watch use cases care about page title changes, some care about broad page churn, and some only need a lightweight signal. With only a SHA-256 body hash, every watch behaved the same way and agents could not tune noise vs. sensitivity.

## Impact

- Existing watches keep working and load as `content` mode.
- New watches can choose the most useful detection strategy.
- HTTP and MCP clients stay aligned on the same watch contract.

## Validation

- `npx tsc`
- `npm test -- src/watch/tests/watcher.test.ts src/watch/tests/live-ws.test.ts src/api/tests/routes/misc.test.ts src/mcp/tests/watches.test.ts`
- `npm run verify`
- Manual: `npm start`, `POST /watch/add` with `diffMode=title`, `GET /watch/list`, `DELETE /watch/remove`

## Note

This PR also restores the global tool-count reference in `package.json` because `check-consistency` on current `main` was already failing without it.
