### PR TITLE
[codex] add screenshot capture endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ how it works, and why it exists.
 
 - **Repo:** `hydro13/tandem-browser` (GitHub: hydro13)
 - **Stack:** Electron 40 + TypeScript + Express.js API (`localhost:8765`) +
-  MCP server (248 tools)
+  MCP server (250 tools)
 - **Goal:** An agent-first browser where any AI (via MCP, HTTP API, or
   WebSocket) and a human browse together
 - **Philosophy:** Local-first, privacy-first, no cloud dependencies in the
@@ -39,7 +39,7 @@ tandem-browser/
 │   ├── snapshot/                 # Accessibility tree with @refs
 │   ├── network/                  # Inspector + mocking
 │   ├── sessions/                 # Multi-session isolation
-│   ├── mcp/                      # MCP server (248 tools, full API parity)
+│   ├── mcp/                      # MCP server (250 tools, full API parity)
 │   │   ├── server.ts             # MCP server entry point
 │   │   └── tools/                # Tool definitions (one file per domain)
 │   ├── agents/                   # TaskManager, X-Scout, TabLockManager
@@ -120,6 +120,12 @@ tandem-browser/
 - While Tandem is still effectively solo-maintained, prefer keeping required CI
   checks (`verify`, `CodeQL`) and using PRs as the review step; do not assume a
   second human reviewer will exist
+- Any merged `feat:` change must bump the app version before the PR is merged
+  (`minor`, e.g. `0.72.2` → `0.73.0`), and any merged `fix:` change must bump a
+  `patch` version (e.g. `0.72.2` → `0.72.3`)
+- Keep `CHANGELOG.md`, `package.json`, the in-app version, and the repo/docs
+  version references on the same release number; do not leave new product
+  surface under an old version header
 - Before merging a PR, quickly review the diff for version bumps, changelog
   noise, release impact, and whether README / CONTRIBUTING / TODO need updates
 - Commit message examples:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 All notable changes to Tandem Browser will be documented in this file.
 
-## [v0.72.2] - 2026-04-14
+## [v0.73.0] - 2026-04-14
 
-- fix: smooth Wingman handoff follow-through and restore version consistency
+- feat: expand live watch and screenshot automation surfaces
 
 ### Fixed
 
@@ -13,11 +13,14 @@ All notable changes to Tandem Browser will be documented in this file.
 - Standalone `waiting_approval` handoffs now resolve correctly on `Approve` and `Reject` even when they are not linked to a paused task step, so generic approval requests no longer appear to do nothing
 - The Wingman handoff list now gives open cards enough vertical room for common two-item cases, removing the cramped internal scrollbar seen during live testing
 - Version metadata now stays aligned across `package.json`, `package-lock.json`, repo docs, the landing page, and the MCP server, with `scripts/check-consistency.js` extended to catch future drift automatically
+- Apple Photos screenshot import now passes a real file `alias` into the Photos AppleScript flow instead of a raw POSIX file URL, fixing the blank-name / "Cannot Import Item" failure seen after application captures
 
 ### Added
 
 - `ws://127.0.0.1:8765/watch/live` now streams an immediate watch snapshot plus incremental watch add/remove/check events to authenticated local clients, giving agents a real-time watch surface instead of polling `/watch/list`
 - Watches now support configurable diff modes for change detection: `content`, `title`, `title-or-content`, and `text-length`, exposed through both the HTTP API and MCP watch-add flow
+- New HTTP screenshot capture routes: `POST /screenshot/application` saves a fresh full-window capture, and `POST /screenshot/region` saves a fresh application-region capture without requiring renderer IPC or clipboard round-trips
+- Matching MCP media tools now expose the same capture modes for MCP-first clients, bringing the server tool count to 250 while keeping screenshot capture parity with the local HTTP API
 
 ## [v0.72.1] - 2026-04-14
 

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -10,7 +10,7 @@ bicycle: two riders, one machine, each contributing what the other can't do
 alone.
 
 The browser runs two things in parallel. The human uses it like any other browser
-while AI agents operate through a built-in **MCP server** (248 tools) or a full
+while AI agents operate through a built-in **MCP server** (250 tools) or a full
 local **HTTP API** on `127.0.0.1:8765` with 300+ endpoints for navigation,
 interaction, data extraction, automation, sessions, sync, extensions, and
 developer tooling. Websites see a normal Chrome browser on macOS. They don't see
@@ -30,7 +30,7 @@ The security layer exists because when an AI has access to your browser, your th
 Data stays local. Sessions are isolated. Nothing leaves the machine through Tandem Browser without going through a filter first.
 
 **GitHub:** `hydro13/tandem-browser`  
-**Current version:** `0.72.2`  
+**Current version:** `0.73.0`  
 **Repository status:** Public developer preview  
 **Started:** February 11, 2026
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Want the fastest path in?
 | **System** | 6 | Browser status, headless mode, Google Photos, security overrides |
 | **Awareness** | 2 | Activity digest, real-time focus detection — the AI knows what you're doing |
 
-**248 tools total** — full parity with the HTTP API.
+**250 tools total** — full parity with the HTTP API.
 
 ## Why Not Just Use Playwright?
 
@@ -148,7 +148,7 @@ Add to your MCP configuration:
 }
 ```
 
-Start Tandem, and 248 tools are available immediately.
+Start Tandem, and 250 tools are available immediately.
 
 ### Cursor / Windsurf / Other MCP Clients
 
@@ -228,7 +228,7 @@ contributors, not yet a polished mass-user release.
 - Secondary platform: Linux
 - Windows: not actively validated
 - Binaries: not published yet (source-only)
-- Current version: `0.72.2`
+- Current version: `0.73.0`
 - Package metadata: [package.json](package.json)
 
 ## Community

--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,7 @@ Last updated: April 14, 2026
 ## Current Snapshot
 
 - Current app version: `0.72.2`
-- MCP server: 248 tools (full API parity + awareness)
+- MCP server: 250 tools (full API parity + awareness)
 - The codebase scope is larger than this backlog summary and includes major subsystems such as `sidebar`, `workspaces`, `pinboards`, `sync`, `headless`, and `sessions`.
 - Scheduled browsing already exists in baseline form via `WatchManager` and the `/watch/*` API routes.
 - Session isolation already exists in baseline form via `SessionManager` and the `/sessions/*` API routes.
@@ -28,7 +28,7 @@ Last updated: April 14, 2026
 - [x] Update `skill/SKILL.md` so MCP-first clients, direct-HTTP clients, and the new durable handoff model are all documented with the current Tandem behavior
 - [ ] Remove the remaining legacy OpenClaw compatibility IPC and unused webhook chat code after the signed gateway-chat path has shipped for a release or two
 - [x] `WebSocket /watch/live` for live watch updates
-- [ ] Expose `captureApplicationScreenshot` and `captureRegionScreenshot` as HTTP API endpoints (e.g. `POST /screenshot/application`, `POST /screenshot/region`) so OpenClaw agents can trigger full-window and region captures programmatically without requiring IPC or human interaction
+- [x] Expose `captureApplicationScreenshot` and `captureRegionScreenshot` as HTTP API endpoints (e.g. `POST /screenshot/application`, `POST /screenshot/region`) so OpenClaw agents can trigger full-window and region captures programmatically without requiring IPC or human interaction
 - [x] Show a notification when the Wingman panel is closed and Wingman replies
 - [x] Google Photos upload support for screenshots; local OAuth client ID setup, connect/disconnect flow, and automatic upload path now exist
 - [x] Screenshot capture modes for `Web Page`, `Application`, and in-app `Region` selection from the main toolbar screenshot button

--- a/docs/api.html
+++ b/docs/api.html
@@ -117,7 +117,7 @@ footer a:hover{color:var(--text2)}
 <div class="hero-stats">
 <div class="stat"><span class="stat-num">280+</span><span class="stat-label">Endpoints</span></div>
 <div class="stat"><span class="stat-num">19</span><span class="stat-label">Domains</span></div>
-<div class="stat"><span class="stat-num">248</span><span class="stat-label">MCP tools</span></div>
+<div class="stat"><span class="stat-num">250</span><span class="stat-label">MCP tools</span></div>
 </div>
 </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -140,12 +140,12 @@ footer a:hover{color:var(--text2)}
 </header>
 
 <div class="hero">
-<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v0.72.2</div>
+<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v0.73.0</div>
 <h1>Tandem Browser is the <em>human-AI symbiotic browser</em></h1>
 <p>A local-first browser where humans and AI agents work in shared context. Same tabs, same sessions, same authenticated browser state, with explicit handoffs when the human needs to step in. Not generic browser automation, an actual shared browser workspace for the web that already exists.</p>
 <div class="hero-stats">
 <div class="stat"><span class="stat-num">513</span><span class="stat-label">GitHub stars</span></div>
-<div class="stat"><span class="stat-num">248</span><span class="stat-label">MCP tools</span></div>
+<div class="stat"><span class="stat-num">250</span><span class="stat-label">MCP tools</span></div>
 <div class="stat"><span class="stat-num">300+</span><span class="stat-label">HTTP endpoints</span></div>
 <div class="stat"><span class="stat-num">8</span><span class="stat-label">Security layers</span></div>
 </div>

--- a/docs/public-launch.md
+++ b/docs/public-launch.md
@@ -20,7 +20,7 @@ Tandem Browser is now public: the local-first browser for shared human-AI browse
 Tandem Browser is now public.
 
 Tandem Browser is a local-first browser built for human-AI collaboration on the local
-machine. The human browses normally. Any AI agent that speaks MCP (248 tools) or
+machine. The human browses normally. Any AI agent that speaks MCP (250 tools) or
 HTTP (300+ endpoints) can operate inside the same real browser context for
 navigation, extraction, automation, screenshots, session work, and observability,
 while websites continue to see a normal Chromium browser instead of an "AI

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tandem-browser",
-  "version": "0.72.2",
+  "version": "0.73.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tandem-browser",
-      "version": "0.72.2",
+      "version": "0.73.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tandem-browser",
-  "version": "0.72.2",
-  "description": "Local-first Electron browser with a 248-tool MCP server, MCP/HTTP control surfaces, and built-in security controls",
+  "version": "0.73.0",
+  "description": "Local-first Electron browser with a 250-tool MCP server, MCP/HTTP control surfaces, and built-in security controls",
   "main": "dist/main.js",
   "author": "Tandem Browser contributors",
   "license": "MIT",

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -48,7 +48,7 @@ Practical notes:
 
 ### Option 1: MCP Server (recommended for agents)
 
-The MCP server exposes 248 tools with full API parity. Add to your MCP client
+The MCP server exposes 250 tools with full API parity. Add to your MCP client
 configuration (e.g. `~/.claude/settings.json` for Claude Code):
 
 ```json

--- a/src/api/routes/media.ts
+++ b/src/api/routes/media.ts
@@ -5,6 +5,13 @@ import { handleRouteError } from '../../utils/errors';
 import { getErrorMessage } from '../../utils/security';
 import { createRateLimitMiddleware } from '../rate-limit';
 
+interface ScreenshotRegion {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
 function renderGooglePhotosAuthPage(opts: { ok: boolean; title: string; message: string; detail?: string }): string {
   return `<!doctype html>
 <html>
@@ -33,6 +40,33 @@ function renderGooglePhotosAuthPage(opts: { ok: boolean; title: string; message:
     </script>
   </body>
 </html>`;
+}
+
+function getScreenshotCurrentUrl(ctx: RouteContext): string {
+  return ctx.tabManager.getActiveTab()?.url || 'tandem://window';
+}
+
+function parseScreenshotRegion(body: unknown): ScreenshotRegion | null {
+  if (!body || typeof body !== 'object') {
+    return null;
+  }
+
+  const candidate = body as Record<string, unknown>;
+  const x = candidate.x;
+  const y = candidate.y;
+  const width = candidate.width;
+  const height = candidate.height;
+
+  if (![x, y, width, height].every(value => typeof value === 'number' && Number.isFinite(value))) {
+    return null;
+  }
+
+  return {
+    x: x as number,
+    y: y as number,
+    width: width as number,
+    height: height as number,
+  };
 }
 
 /**
@@ -247,6 +281,40 @@ export function registerMediaRoutes(router: Router, ctx: RouteContext): void {
       } else {
         res.status(500).json(result);
       }
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+
+  router.post('/screenshot/application', async (_req: Request, res: Response) => {
+    try {
+      const result = await ctx.drawManager.captureApplicationScreenshot(getScreenshotCurrentUrl(ctx));
+      if (result.ok) {
+        res.json(result);
+      } else {
+        res.status(500).json(result);
+      }
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+
+  router.post('/screenshot/region', async (req: Request, res: Response) => {
+    const region = parseScreenshotRegion(req.body);
+    if (!region) {
+      res.status(400).json({ error: 'x, y, width, and height are required numbers' });
+      return;
+    }
+
+    try {
+      const result = await ctx.drawManager.captureRegionScreenshot(region, getScreenshotCurrentUrl(ctx));
+      if (result.ok) {
+        res.json(result);
+        return;
+      }
+
+      const status = result.error === 'Selected region is too small' ? 400 : 500;
+      res.status(status).json(result);
     } catch (e) {
       handleRouteError(res, e);
     }

--- a/src/api/tests/helpers.ts
+++ b/src/api/tests/helpers.ts
@@ -127,6 +127,8 @@ export function createMockContext(): RouteContext {
     drawManager: {
       getLastScreenshot: vi.fn().mockReturnValue(null),
       captureAnnotated: vi.fn().mockResolvedValue({ ok: true }),
+      captureApplicationScreenshot: vi.fn().mockResolvedValue({ ok: true, path: '/tmp/application.png' }),
+      captureRegionScreenshot: vi.fn().mockResolvedValue({ ok: true, path: '/tmp/region.png' }),
       toggleDrawMode: vi.fn().mockReturnValue(true),
       listScreenshots: vi.fn().mockReturnValue([]),
     } as any,

--- a/src/api/tests/routes/media.test.ts
+++ b/src/api/tests/routes/media.test.ts
@@ -619,6 +619,124 @@ describe('Media Routes', () => {
     });
   });
 
+  describe('POST /screenshot/application', () => {
+    it('captures an application screenshot using the active tab url', async () => {
+      vi.mocked(ctx.drawManager.captureApplicationScreenshot).mockResolvedValue({
+        ok: true,
+        path: '/tmp/application.png',
+      } as any);
+
+      const res = await request(app).post('/screenshot/application').send({});
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ ok: true, path: '/tmp/application.png' });
+      expect(ctx.drawManager.captureApplicationScreenshot).toHaveBeenCalledWith('https://example.com');
+    });
+
+    it('falls back to tandem window url when no active tab exists', async () => {
+      vi.mocked(ctx.tabManager.getActiveTab).mockReturnValue(null as any);
+      vi.mocked(ctx.drawManager.captureApplicationScreenshot).mockResolvedValue({
+        ok: true,
+        path: '/tmp/application.png',
+      } as any);
+
+      const res = await request(app).post('/screenshot/application').send({});
+
+      expect(res.status).toBe(200);
+      expect(ctx.drawManager.captureApplicationScreenshot).toHaveBeenCalledWith('tandem://window');
+    });
+
+    it('returns 500 when captureApplicationScreenshot reports failure', async () => {
+      vi.mocked(ctx.drawManager.captureApplicationScreenshot).mockResolvedValue({
+        ok: false,
+        error: 'capture failed',
+      } as any);
+
+      const res = await request(app).post('/screenshot/application').send({});
+
+      expect(res.status).toBe(500);
+      expect(res.body).toEqual({ ok: false, error: 'capture failed' });
+    });
+
+    it('returns 500 when captureApplicationScreenshot throws', async () => {
+      vi.mocked(ctx.drawManager.captureApplicationScreenshot).mockRejectedValue(new Error('application error'));
+
+      const res = await request(app).post('/screenshot/application').send({});
+
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe('application error');
+    });
+  });
+
+  describe('POST /screenshot/region', () => {
+    it('captures a region screenshot with the active tab url', async () => {
+      vi.mocked(ctx.drawManager.captureRegionScreenshot).mockResolvedValue({
+        ok: true,
+        path: '/tmp/region.png',
+      } as any);
+
+      const res = await request(app)
+        .post('/screenshot/region')
+        .send({ x: 12, y: 34, width: 320, height: 180 });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ ok: true, path: '/tmp/region.png' });
+      expect(ctx.drawManager.captureRegionScreenshot).toHaveBeenCalledWith(
+        { x: 12, y: 34, width: 320, height: 180 },
+        'https://example.com',
+      );
+    });
+
+    it('returns 400 when region coordinates are missing or invalid', async () => {
+      const res = await request(app)
+        .post('/screenshot/region')
+        .send({ x: 12, y: 34, width: '320' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('x, y, width, and height are required numbers');
+      expect(ctx.drawManager.captureRegionScreenshot).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when the selected region is too small', async () => {
+      vi.mocked(ctx.drawManager.captureRegionScreenshot).mockResolvedValue({
+        ok: false,
+        error: 'Selected region is too small',
+      } as any);
+
+      const res = await request(app)
+        .post('/screenshot/region')
+        .send({ x: 1, y: 2, width: 1, height: 3 });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toEqual({ ok: false, error: 'Selected region is too small' });
+    });
+
+    it('returns 500 when captureRegionScreenshot reports a runtime failure', async () => {
+      vi.mocked(ctx.drawManager.captureRegionScreenshot).mockResolvedValue({
+        ok: false,
+        error: 'capture failed',
+      } as any);
+
+      const res = await request(app)
+        .post('/screenshot/region')
+        .send({ x: 12, y: 34, width: 320, height: 180 });
+
+      expect(res.status).toBe(500);
+      expect(res.body).toEqual({ ok: false, error: 'capture failed' });
+    });
+
+    it('returns 500 when captureRegionScreenshot throws', async () => {
+      vi.mocked(ctx.drawManager.captureRegionScreenshot).mockRejectedValue(new Error('region error'));
+
+      const res = await request(app)
+        .post('/screenshot/region')
+        .send({ x: 12, y: 34, width: 320, height: 180 });
+
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe('region error');
+    });
+  });
+
   describe('POST /draw/toggle', () => {
     it('toggles draw mode on', async () => {
       vi.mocked(ctx.drawManager.toggleDrawMode).mockReturnValue(true);

--- a/src/draw/overlay.ts
+++ b/src/draw/overlay.ts
@@ -350,7 +350,7 @@ export class DrawOverlayManager {
     const scriptLines = [
       'on run argv',
       '  set importPath to item 1 of argv',
-      '  set theFile to POSIX file importPath',
+      '  set theFile to ((POSIX file importPath) as alias)',
       '  tell application "Photos"',
       '    activate',
       '    with timeout of 30 seconds',

--- a/src/draw/tests/overlay.test.ts
+++ b/src/draw/tests/overlay.test.ts
@@ -124,6 +124,7 @@ describe('DrawOverlayManager screenshot modes', () => {
   });
 
   it('imports Apple Photos using an alias file reference when enabled', async () => {
+    const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
     vi.useFakeTimers();
     configManager.getConfig.mockReturnValue({
       screenshots: {
@@ -132,19 +133,26 @@ describe('DrawOverlayManager screenshot modes', () => {
       },
     });
 
-    const manager = new DrawOverlayManager(win, configManager, googlePhotosManager);
-    await manager.captureApplicationScreenshot('https://example.com/demo');
-    vi.runAllTimers();
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
 
-    expect(execFileMock).toHaveBeenCalledWith(
-      'osascript',
-      expect.arrayContaining([
-        '-e',
-        '  set theFile to ((POSIX file importPath) as alias)',
-      ]),
-      expect.any(Function),
-    );
+    try {
+      const manager = new DrawOverlayManager(win, configManager, googlePhotosManager);
+      await manager.captureApplicationScreenshot('https://example.com/demo');
+      vi.runAllTimers();
 
-    vi.useRealTimers();
+      expect(execFileMock).toHaveBeenCalledWith(
+        'osascript',
+        expect.arrayContaining([
+          '-e',
+          '  set theFile to ((POSIX file importPath) as alias)',
+        ]),
+        expect.any(Function),
+      );
+    } finally {
+      if (platformDescriptor) {
+        Object.defineProperty(process, 'platform', platformDescriptor);
+      }
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/draw/tests/overlay.test.ts
+++ b/src/draw/tests/overlay.test.ts
@@ -2,9 +2,11 @@ import fs from 'fs';
 import path from 'path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { clipboardWriteImage, nativeImageCreateFromBuffer } = vi.hoisted(() => ({
+const { clipboardWriteImage, nativeImageCreateFromBuffer, execFileMock, execFileSyncMock } = vi.hoisted(() => ({
   clipboardWriteImage: vi.fn(),
   nativeImageCreateFromBuffer: vi.fn().mockReturnValue({ isEmpty: () => false }),
+  execFileMock: vi.fn(),
+  execFileSyncMock: vi.fn(),
 }));
 
 vi.mock('electron', () => ({
@@ -20,6 +22,11 @@ vi.mock('electron', () => ({
   webContents: {
     fromId: vi.fn(),
   },
+}));
+
+vi.mock('child_process', () => ({
+  execFile: execFileMock,
+  execFileSync: execFileSyncMock,
 }));
 
 vi.mock('fs', async () => {
@@ -73,6 +80,11 @@ describe('DrawOverlayManager screenshot modes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(fs.existsSync).mockReturnValue(false);
+    execFileMock.mockImplementation((_cmd, _args, callback) => {
+      callback?.(null);
+      return {} as any;
+    });
+    execFileSyncMock.mockImplementation(() => Buffer.from(''));
   });
 
   it('captures the full application window and emits a screenshot event', async () => {
@@ -109,5 +121,30 @@ describe('DrawOverlayManager screenshot modes', () => {
       width: 1200,
       height: 780,
     });
+  });
+
+  it('imports Apple Photos using an alias file reference when enabled', async () => {
+    vi.useFakeTimers();
+    configManager.getConfig.mockReturnValue({
+      screenshots: {
+        applePhotos: true,
+        googlePhotos: false,
+      },
+    });
+
+    const manager = new DrawOverlayManager(win, configManager, googlePhotosManager);
+    await manager.captureApplicationScreenshot('https://example.com/demo');
+    vi.runAllTimers();
+
+    expect(execFileMock).toHaveBeenCalledWith(
+      'osascript',
+      expect.arrayContaining([
+        '-e',
+        '  set theFile to ((POSIX file importPath) as alias)',
+      ]),
+      expect.any(Function),
+    );
+
+    vi.useRealTimers();
   });
 });

--- a/src/mcp/tests/media.test.ts
+++ b/src/mcp/tests/media.test.ts
@@ -91,6 +91,34 @@ describe('MCP media tools', () => {
     });
   });
 
+  describe('tandem_screenshot_capture_application', () => {
+    it('captures a full application screenshot', async () => {
+      mockApiCall.mockResolvedValueOnce({ path: '/tmp/application.png' });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      await getHandler(tools, 'tandem_screenshot_capture_application')({});
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/screenshot/application');
+    });
+  });
+
+  describe('tandem_screenshot_capture_region', () => {
+    it('captures a region screenshot', async () => {
+      mockApiCall.mockResolvedValueOnce({ path: '/tmp/region.png' });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      await getHandler(tools, 'tandem_screenshot_capture_region')({
+        x: 12,
+        y: 34,
+        width: 320,
+        height: 180,
+      });
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/screenshot/region', {
+        x: 12,
+        y: 34,
+        width: 320,
+        height: 180,
+      });
+    });
+  });
+
   describe('tandem_screenshots_list', () => {
     it('lists screenshots', async () => {
       mockApiCall.mockResolvedValueOnce({ screenshots: [] });

--- a/src/mcp/tools/media.ts
+++ b/src/mcp/tools/media.ts
@@ -104,6 +104,32 @@ export function registerMediaTools(server: McpServer): void {
   );
 
   server.tool(
+    'tandem_screenshot_capture_application',
+    'Capture a fresh screenshot of the full Tandem application window and return the saved file path.',
+    async () => {
+      const data = await apiCall('POST', '/screenshot/application');
+      await logActivity('screenshot_capture_application');
+      return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+    }
+  );
+
+  server.tool(
+    'tandem_screenshot_capture_region',
+    'Capture a fresh screenshot of a specific application region and return the saved file path.',
+    coerceShape({
+      x: z.number().describe('Region left coordinate in application-window pixels.'),
+      y: z.number().describe('Region top coordinate in application-window pixels.'),
+      width: z.number().describe('Region width in pixels.'),
+      height: z.number().describe('Region height in pixels.'),
+    }),
+    async ({ x, y, width, height }) => {
+      const data = await apiCall('POST', '/screenshot/region', { x, y, width, height });
+      await logActivity('screenshot_capture_region');
+      return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+    }
+  );
+
+  server.tool(
     'tandem_screenshots_list',
     'List saved screenshots.',
     coerceShape({


### PR DESCRIPTION
## What Changed

- added `POST /screenshot/application` and `POST /screenshot/region` so agents can trigger fresh full-window and region captures over HTTP
- added matching MCP media tools for application and region screenshot capture to preserve API parity
- fixed macOS Apple Photos screenshot import by passing Photos a real file `alias` instead of a raw POSIX file URL
- bumped Tandem to `0.73.0` and synced version references across package metadata, docs, and in-app status output
- made the version-bump rule explicit in `AGENTS.md` so merged `feat` work always carries a minor bump and merged `fix` work always carries a patch bump

## Why

The draw manager already had the underlying screenshot primitives, but they were only reachable through IPC/UI flows. Exposing them over HTTP and MCP makes the feature available to OpenClaw and other agent-first clients.

The Apple Photos import issue was a separate runtime bug found during live validation: screenshots were valid PNGs, but Photos received the wrong AppleScript file type and showed the blank-name / "Cannot Import Item" failure.

## Impact

- agents can now request full-application and region screenshots programmatically
- MCP-first clients gain the same screenshot capture modes without custom HTTP glue
- screenshots continue importing into Apple Photos when that setting is enabled
- Tandem now reports the new feature set under the correct `0.73.0` release version

## Validation

- `npm run verify`
- `npm start`
- manual `GET /status` confirmed `"version":"0.73.0"`
- manual `POST /screenshot/application` returned `200` and saved a screenshot
- manual `POST /screenshot/region` returned `200` and saved a screenshot
- manual invalid tiny region returned `400`
- manual Apple Photos import succeeded with `screenshots.applePhotos` enabled
