### PR TITLE
feat: add remote agent pairing and Tailscale HTTP onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ All notable changes to Tandem Browser will be documented in this file.
 
 ### Added
 
+- Remote agent pairing over Tailscale: agents on another machine can pair with Tandem via a one-time setup code (TDM-XXXX-XXXX), receive a durable binding token, and use the full HTTP API remotely — proven with Windows 11 + VS Code + Claude Code connecting to macOS over Tailscale
+- PairingManager with setup code generation (5-minute TTL), token exchange, binding lifecycle (paired/paused/revoked/removed), SHA-256 token hashing, and persistent storage at `~/.tandem/pairing/bindings.json`
+- Public bootstrap/discovery routes: `GET /agent` (human-readable), `GET /agent/manifest` (machine-readable with all endpoint families), `GET /agent/version` (capability summary), `GET /skill` (version-matched usage guide) — all request-aware so URLs are correct over Tailscale
+- Pairing HTTP routes: `POST /pairing/setup-code`, `POST /pairing/exchange` (public, rate-limited), `GET /pairing/whoami`, `GET /pairing/bindings`, pause/resume/revoke/remove per binding, and `GET /pairing/addresses` for Tailscale address auto-detection
+- Binding token auth (`tdm_ast_` prefix) accepted alongside existing local `api-token` for all HTTP routes and the `/watch/live` WebSocket
+- Onboarding-first "Connect your AI to Tandem" Settings UI with mode selector (same machine / another machine), address detection, instruction generation with `bindingKind`, and binding management cards
+- API listen host defaults to `0.0.0.0` (local + remote simultaneously) with auto-migration from `127.0.0.1` for existing installs
 - `ws://127.0.0.1:8765/watch/live` now streams an immediate watch snapshot plus incremental watch add/remove/check events to authenticated local clients, giving agents a real-time watch surface instead of polling `/watch/list`
 - Watches now support configurable diff modes for change detection: `content`, `title`, `title-or-content`, and `text-length`, exposed through both the HTTP API and MCP watch-add flow
 - New HTTP screenshot capture routes: `POST /screenshot/application` saves a fresh full-window capture, and `POST /screenshot/region` saves a fresh application-region capture without requiring renderer IPC or clipboard round-trips

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -10,11 +10,12 @@ bicycle: two riders, one machine, each contributing what the other can't do
 alone.
 
 The browser runs two things in parallel. The human uses it like any other browser
-while AI agents operate through a built-in **MCP server** (250 tools) or a full
-local **HTTP API** on `127.0.0.1:8765` with 300+ endpoints for navigation,
-interaction, data extraction, automation, sessions, sync, extensions, and
-developer tooling. Websites see a normal Chrome browser on macOS. They don't see
-the AI.
+while AI agents operate through a built-in **MCP server** (250 tools) or a
+**300+ endpoint HTTP API** for navigation, interaction, data extraction,
+automation, sessions, sync, extensions, and developer tooling. Local agents can
+use MCP or HTTP. Remote agents on the same Tailscale network connect via HTTP
+and authenticate through Tandem's pairing system. Websites see a normal Chrome
+browser on macOS. They don't see the AI.
 
 That distinction matters. Tandem Browser is not trying to be a generic automation shell,
 and it is not limited to sites that explicitly expose agent tools. It is the

--- a/README.md
+++ b/README.md
@@ -120,23 +120,14 @@ Depending on what you want to do:
 
 ## Connect Your AI Agent
 
-### Claude Code / Claude Desktop (MCP)
+Tandem supports AI agents running on the same machine or on a remote machine
+over a private Tailscale network. Both can be active at the same time.
 
-Add to your MCP configuration:
+### On the same machine (MCP or HTTP)
 
-**Claude Code** (`.mcp.json` in project root or `~/.claude/settings.json`):
-```json
-{
-  "mcpServers": {
-    "tandem": {
-      "command": "node",
-      "args": ["/path/to/tandem-browser/dist/mcp/server.js"]
-    }
-  }
-}
-```
+**MCP** — Add to your MCP client configuration (Claude Code, Claude Desktop,
+Cursor, Windsurf, or any MCP client):
 
-**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
 ```json
 {
   "mcpServers": {
@@ -150,12 +141,7 @@ Add to your MCP configuration:
 
 Start Tandem, and 250 tools are available immediately.
 
-### Cursor / Windsurf / Other MCP Clients
-
-Same config — point your MCP client at `dist/mcp/server.js`. Any client
-that implements the MCP protocol works.
-
-### HTTP API (for custom integrations)
+**HTTP API** — Use the local API token directly:
 
 ```bash
 TOKEN="$(cat ~/.tandem/api-token)"
@@ -166,6 +152,44 @@ curl -sS http://127.0.0.1:8765/tabs/list \
 ```
 
 300+ endpoints for everything the MCP tools can do, plus lower-level access.
+
+### On another machine (Tailscale + HTTP)
+
+Remote agents connect over a private Tailscale network. Both machines must be
+on the same tailnet. Tandem is never exposed to the public internet.
+
+1. Open Tandem Settings > Connected Agents
+2. Select "On another machine" and generate a setup code
+3. On the remote machine, exchange the code for a durable token:
+
+   ```bash
+   curl -X POST http://<tandem-tailscale-ip>:8765/pairing/exchange \
+     -H "Content-Type: application/json" \
+     -d '{"code":"TDM-XXXX-XXXX","machineId":"...","machineName":"...","agentLabel":"...","agentType":"..."}'
+   ```
+
+4. Use the returned token for all subsequent requests:
+
+   ```bash
+   curl -sS http://<tandem-tailscale-ip>:8765/status \
+     -H "Authorization: Bearer <token>"
+   ```
+
+The token is permanent until the user pauses, revokes, or removes it from
+Tandem's Connected Agents UI.
+
+Remote agents use the HTTP API. Remote MCP is not yet available.
+
+### Discovery
+
+A running Tandem instance publishes its own version-matched discovery surface:
+
+- `GET /agent` — human-readable bootstrap page
+- `GET /agent/manifest` — machine-readable endpoint manifest
+- `GET /skill` — version-matched usage guide
+
+These are public (no auth required) and use the request `Host` header, so they
+return correct URLs whether accessed locally or over Tailscale.
 
 ## Security Model
 
@@ -226,7 +250,7 @@ contributors, not yet a polished mass-user release.
 
 - Primary platform: macOS
 - Secondary platform: Linux
-- Windows: not actively validated
+- Windows: validated as a remote agent host (VS Code + Claude Code over Tailscale)
 - Binaries: not published yet (source-only)
 - Current version: `0.73.0`
 - Package metadata: [package.json](package.json)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -64,6 +64,7 @@ Each module is a self-contained subsystem with its own manager.
 | `network/` | `inspector.ts`, `mocker.ts` | Network logging, HAR export, request mocking |
 | `notifications/` | (multiple) | System notifications |
 | `openclaw/` | (multiple) | OpenClaw gateway integration, Wingman chat |
+| `pairing/` | `manager.ts` | Remote agent pairing (setup codes, token exchange, bindings) |
 | `panel/` | `manager.ts` | Wingman side panel management |
 | `passwords/` | (multiple) | Local password vault (AES-256-GCM) |
 | `pinboards/` | `manager.ts` | Sidebar pinboards for saved items |
@@ -88,12 +89,13 @@ Each module is a self-contained subsystem with its own manager.
 
 ### API Routes (src/api/routes/)
 
-19 route files, all following the `registerXRoutes(router, ctx)` pattern:
+21 route files, all following the `registerXRoutes(router, ctx)` pattern:
 
 | File | Endpoints | Domain |
 |------|-----------|--------|
 | `awareness.ts` | Activity digest, focus detection | AI awareness |
 | `agents.ts` | Tasks, tab locks, autonomy, emergency stop | Agent coordination |
+| `bootstrap.ts` | `/agent`, `/skill`, `/agent/manifest`, `/agent/version` | Agent discovery (public) |
 | `browser.ts` | Navigate, click, type, scroll, screenshot | Core browser actions |
 | `clipboard.ts` | Read/write clipboard | Clipboard access |
 | `content.ts` | Page content, extraction, markdown | Content extraction |
@@ -103,6 +105,7 @@ Each module is a self-contained subsystem with its own manager.
 | `media.ts` | Voice, audio, video, screenshots, draw | Media and capture |
 | `misc.ts` | Settings, passwords, watches, notifications | Utility endpoints |
 | `network.ts` | Network log, mocking, HAR export, APIs | Network inspection |
+| `pairing.ts` | Setup codes, token exchange, bindings, whoami | Remote agent pairing |
 | `pinboards.ts` | Pinboard CRUD, items, settings | Sidebar pinboards |
 | `previews.ts` | Create/update live HTML previews | Agent previews |
 | `sessions.ts` | Session CRUD, state save/load, fetch relay | Session isolation |

--- a/docs/plans/remote-agent-pairing-design.md
+++ b/docs/plans/remote-agent-pairing-design.md
@@ -1,0 +1,876 @@
+# Design: Remote Agent Pairing for Tandem Browser
+
+> **Date:** 2026-04-15
+> **Status:** Draft
+> **Effort:** Hard (1-2wk)
+> **Author:** Kees, based on Robin's Kanbu pairing model
+
+---
+
+## Problem / Motivation
+
+Tandem Browser already works well when the AI agent runs on the same machine. That is enough for early local workflows, but it breaks down as soon as the browser and the agent live on different nodes.
+
+That matters now because many real users run their agent somewhere else:
+
+- OpenClaw on a Mac mini
+- OpenClaw on a Linux box or VPS
+- Claude Code on a different workstation
+- Codex or another coding agent in a remote environment
+- mixed local + remote agents in the same personal tailnet
+
+Today, the cleanest Tandem story is still, more or less, "run the browser and the agent together". That is too narrow for where the product is heading.
+
+The goal of this design is to let **local and remote AI agents connect to Tandem Browser securely**, while keeping the human in control over **which agents may connect** and **whether those connections can be paused, revoked, or removed at any time**.
+
+This design intentionally borrows the **Kanbu pairing model**:
+
+- human-visible one-time setup code
+- short TTL
+- exchange for durable local credential
+- per-machine binding
+- explicit revoke
+- audit trail
+
+But Tandem is more sensitive than Kanbu. Kanbu exposes project data. Tandem can expose live browser context, authentication state, and real human web sessions. So the Tandem version must be stricter about **network boundary** and clearer about **ownership of trust**.
+
+**Tandem currently has:** strong local API and MCP surfaces, but no first-class pairing model for trusted remote agents.
+
+**Gap:** there is no elegant, user-controlled, secure way to connect a remote agent to a local Tandem Browser instance over a trusted network like Tailscale.
+
+---
+
+## Goals
+
+1. Let Tandem pair with agents that are:
+   - local on the same machine
+   - remote on another trusted machine
+   - MCP-capable or API-only
+2. Let a running Tandem instance expose its own **version-matched bootstrap/skill page** so binary installs do not depend on repo access.
+3. Keep setup simple for normal users.
+4. Avoid raw long-lived secret copy/paste as the primary UX.
+5. Preserve Tandem's philosophy of collaboration and trust, not enterprise IAM theater.
+6. Allow multiple connected agents over time, and eventually in parallel.
+7. Give the human a clear management surface for active bindings.
+8. Work cleanly on same-host and Tailscale paths, without any public internet exposure.
+
+---
+
+## Non-Goals
+
+- Public internet relay
+- Internet-facing control plane
+- OAuth provider work in phase 1
+- Fine-grained RBAC explosion
+- Scoped browser-enforced trust roles like Observe / Collaborate / Deep Access
+- Making Tandem dependent on MCP only
+- Replacing the existing local API or MCP model
+
+This is an **access and trust layer**, not a replacement for Tandem's protocol surfaces.
+
+---
+
+## Design Decisions
+
+### 1. Network boundary
+Remote agent access is allowed only through:
+- the same host
+- or a trusted private network path such as Tailscale
+
+LAN access is not a default remote path. If it is ever supported, it should be an explicit advanced opt-in, not the normal product path.
+
+There is **no internet-facing relay** in this design.
+
+Reason:
+- a public relay adds attack surface without adding meaningful value to Tandem's core use case
+- Tandem sits too close to sensitive browser context to justify relay complexity
+- same host + Tailscale is the right default boundary for this product
+- LAN is less explicit and less identity-rich than Tailscale, so it should never be the default remote trust boundary
+
+### 2. Binding identity
+Bindings are tied to:
+- `machineId`
+- `machineName`
+- `agentLabel`
+- `agentType`
+- `bindingKind` (`local` or `remote`)
+
+Reason:
+A single machine may run multiple distinct agents, for example:
+- OpenClaw on minimax
+- Claude Code on minimax
+- Codex on minimax
+
+These should not collapse into one trust record.
+
+Also, local and remote bindings should be represented as separate connection categories, not because they have different permissions, but because they differ operationally:
+- different transport assumptions
+- different diagnostics
+- different network metadata
+- clearer UI for the user
+
+### 3. No scoped trust modes
+Tandem should not enforce role slices like Observe, Collaborate, or Deep Access.
+
+Reason:
+- Tandem is a trust-based symbiotic browser
+- if the agent is not trusted enough for full Tandem capability, it should not be paired
+- if it is trusted enough to pair, Tandem should not second-guess the human-agent relationship with browser-level micromanagement
+- behavioral limits such as "just observe" belong between the human and their agent, not as browser-enforced product policy
+
+### 4. Binding controls are core, not later polish
+Every binding must support from day one:
+- pause
+- resume
+- revoke
+- remove
+
+Reason:
+The human must always be able to stop, disable, or clean up an existing connection immediately.
+
+### 5. No reduced remote API surface
+A paired agent should get the full Tandem capability surface.
+
+Reason:
+- pairing is admission into the shared workspace, not permission slicing
+- a client either belongs in Tandem or it does not
+- there is no product reason to create an artificially reduced remote API just because the client is remote
+
+Implementation detail: some routes may still need technical review to ensure they behave correctly outside localhost assumptions, but that is a robustness concern, not a product-level permission split.
+
+### 6. CLI helper is optional convenience, not phase-1 core
+A small helper such as `tandem pair --code TDM-XXXX-XXXX` could be useful for API-only clients, but it is not required for phase 1.
+
+Reason:
+- the architecture does not depend on it
+- phase 1 can work with direct HTTP exchange plus docs/examples
+- a CLI helper is primarily onboarding/UX sugar and can be added after the core pairing model is proven
+
+---
+
+## Core Product Idea
+
+Tandem should expose **two connected layers** for agent connectivity:
+
+1. a **bootstrap/discovery layer**
+2. a **pairing/admission layer**
+
+### 1. Bootstrap/discovery layer
+A running Tandem instance should host its own local, version-matched agent bootstrap page.
+
+This solves a real product problem:
+- today, many agents learn Tandem through `skill/SKILL.md` in the repo
+- that works only if the agent can read the repo
+- binary installs do not come with repo access
+- public hosted docs can drift from the exact installed Tandem version
+
+So Tandem itself should publish the "how to talk to me" surface.
+
+That means a running Tandem instance should expose something like:
+- `/agent`
+- `/skill`
+- `/agent/bootstrap`
+- `/agent/manifest`
+
+The exact route name is open, but the idea is fixed: **the running Tandem instance is the source of truth for its own agent instructions and capabilities**.
+
+### 2. Pairing/admission layer
+Above that bootstrap surface, Tandem should expose a pairing layer above both MCP and HTTP API access.
+
+That means:
+
+- the agent first discovers the running Tandem instance and reads its local bootstrap page
+- the user pairs an agent once
+- Tandem issues a durable binding credential
+- that binding can authenticate over either:
+  - MCP bootstrap flow
+  - HTTP API calls
+- the user can inspect, pause, revoke, and remove bindings from Tandem UI
+
+So the pairing system becomes the unified trust model for **all agent types**, not just MCP agents.
+
+This is intentionally **not** a scoped-access system. Pairing means admitting an agent into Tandem's shared human-AI browser context. If that trust is not appropriate, the agent should not be paired to Tandem in the first place.
+
+---
+
+## User Experience — How It Works
+
+### Primary story
+
+> Robin installs Tandem Browser and starts it.
+>
+> Tandem exposes a local agent bootstrap page on its running address, for example on localhost or the machine's Tailscale address.
+>
+> Robin tells his AI agent to connect to Tandem at that address.
+>
+> The agent opens Tandem's bootstrap page, reads the exact instructions and capabilities for that running Tandem version, and learns how to connect.
+>
+> The agent then asks to pair.
+>
+> Robin opens Tandem's new "Connected Agents" section in Settings and clicks "Pair new agent".
+>
+> Tandem shows a one-time setup code, valid for 5 minutes, plus a short explanation:
+>
+> "Give this code to the AI agent you want to connect."
+>
+> On another machine in the same tailnet, Robin's OpenClaw or Claude Code session says:
+>
+> "Connect to Tandem with code TDM-7KQ9-4XPM"
+>
+> The remote agent submits the code to Tandem's pairing endpoint.
+>
+> Tandem validates it, consumes it, creates a durable binding for that agent and machine, and returns a durable credential.
+>
+> From that point on, the remote agent can authenticate to Tandem until Robin pauses, revokes, or removes it.
+>
+> In Tandem's UI, Robin now sees:
+>
+> - OpenClaw on minimax
+> - status: Paired
+> - connected 2 minutes ago
+> - last used: just now
+> - pause / revoke / remove controls
+
+### The intended mental model
+
+The user flow is:
+- install Tandem
+- start Tandem
+- tell your AI agent where Tandem lives
+- the agent reads Tandem's own bootstrap page
+- open Tandem pairing settings
+- generate setup code
+- give the code to the agent
+- boom, connected
+
+### What the user should feel
+
+- pairing feels like connecting a trusted device, not provisioning infrastructure
+- connection is explicit and human-approved
+- remote access is possible without opening public ports
+- connected agents are visible and controllable
+- Tandem helps manage trust, but does not try to police the user's relationship with their own AI agents
+
+---
+
+## Pairing Model
+
+### Tandem states, not roles
+For phase 1, the meaningful states are:
+
+- **Paired**
+- **Paused**
+- **Revoked**
+- **Removed**
+
+Where:
+- **Paired** means the binding is active and usable
+- **Paused** means the binding still exists but cannot authenticate until resumed
+- **Revoked** means the credential is invalidated and the binding is permanently disabled unless re-paired or explicitly reissued
+- **Removed** means the binding record is removed from the active management list, with audit history retained separately
+
+### Why this better fits Tandem
+
+Tandem is not a sandbox for half-trusted agents.
+Tandem is a browser for human-AI symbiosis.
+
+If the trust is not there, the agent should not be paired.
+If the trust is there, Tandem should not second-guess the relationship with an internal permission taxonomy.
+
+---
+
+## Agent Types We Must Support
+
+### A. MCP-capable agents
+Examples:
+- OpenClaw MCP client
+- Claude Code with MCP
+- Cursor or other MCP-aware tools
+
+These agents can pair and then use Tandem through MCP-backed tools or local wrappers.
+
+### B. API-only agents
+Examples:
+- remote LLM runtime with plain HTTP client
+- custom assistants without MCP support
+- lightweight scripts or bridge services inside the same tailnet
+
+These agents should pair through the same setup-code flow, but receive a durable HTTP credential they can use against Tandem's API.
+
+### Design principle
+
+**Pairing is transport-agnostic.**
+
+Do not build one pairing flow for MCP and another for HTTP. Build one pairing system, then let the resulting binding authenticate against either protocol surface.
+
+---
+
+## Technical Approach
+
+### High-level architecture
+
+```text
+┌──────────────────────────────┐
+│ Tandem Browser               │
+│ local machine                │
+│                              │
+│  Settings > Connected Agents │
+│  Pairing service             │
+│  Binding registry            │
+│  Binding state manager       │
+│  API + MCP auth adapters     │
+└──────────────┬───────────────┘
+               │
+               │ same host or trusted Tailscale path
+               │
+    ┌──────────┴──────────┐
+    │                     │
+    ▼                     ▼
+┌───────────────┐   ┌────────────────┐
+│ MCP agent     │   │ API-only agent │
+│ OpenClaw etc. │   │ script/runtime │
+└───────────────┘   └────────────────┘
+        │                     │
+        │ submit setup code   │ submit setup code
+        └──────────┬──────────┘
+                   ▼
+        /pairing/exchange or equivalent
+                   │
+                   ▼
+      durable binding credential issued
+                   │
+                   ├─ used via MCP auth adapter
+                   └─ used via HTTP Authorization header
+```
+
+---
+
+## Connectivity Flow
+
+### Step 1: Tandem starts and exposes bootstrap surface
+A running Tandem instance exposes a local bootstrap page and optionally a machine-readable manifest.
+
+This surface should tell an agent:
+- Tandem version
+- available transport surfaces
+- base URL
+- pairing instructions
+- supported auth method
+- available capability families
+- versioned examples for this exact Tandem build
+
+### Step 2: agent discovers Tandem
+The human tells the agent where Tandem lives, for example:
+- `http://localhost:8765`
+- `http://100.x.y.z:8765` on Tailscale
+
+The agent opens Tandem's bootstrap page and learns how this specific running instance works.
+
+### Step 3: user generates setup code
+Tandem creates a one-time code.
+
+Properties:
+- format: `TDM-XXXX-XXXX`
+- short TTL, likely 5 minutes
+- one-time use only
+- only one active unused code per local Tandem profile by default
+- rate-limited generation
+
+### Step 4: user gives code to agent
+Examples:
+- "Connect to Tandem with code TDM-7KQ9-4XPM"
+- paste it into an agent settings screen
+- use a CLI pairing command
+
+### Step 5: agent exchanges code
+Remote agent sends:
+- setup code
+- machine ID
+- machine name
+- agent label
+- agent type (`openclaw`, `claude-code`, `codex`, `custom-api`, etc.)
+- client capabilities (`mcp`, `http`, or both)
+
+### Step 6: Tandem validates and consumes code
+Checks:
+- code exists
+- not expired
+- not consumed
+- local pairing mode enabled
+- request source allowed by local network policy
+
+### Step 7: Tandem creates binding
+Creates a persistent binding tied to:
+- local Tandem profile
+- machine identity
+- machine name
+- agent label
+- agent type
+- capability profile
+- issue time
+- last used time
+- binding state
+
+### Step 8: Tandem returns durable credential
+The credential should be:
+- long random secret
+- only shown to the remote client once
+- hashed in local storage on Tandem side
+- revocable
+- pausable by binding state
+- ideally prefixed, for example `tdm_ast_...`
+
+### Step 9: remote agent stores credential locally
+Examples:
+- MCP config file
+- local agent keychain
+- environment secret store
+- OpenClaw node config
+
+---
+
+## Credential Model
+
+### Setup code
+Human-facing bootstrap secret.
+
+Recommended properties:
+- prefix: `TDM`
+- 8 safe characters split in two groups
+- TTL: 5 minutes
+- one-time only
+- visible in Tandem UI only
+
+### Durable binding token
+Machine/agent credential.
+
+Recommended properties:
+- 256-bit random token minimum
+- stored hashed on Tandem side, SHA-256 + Argon2 or similar
+- opaque bearer token for phase 1
+- revocable
+- separate token per binding
+- token rotation supported later
+
+### Why bearer token first?
+Because it works for both:
+- API-only clients immediately
+- MCP clients through existing transport wrappers
+
+Mutual TLS or signed client assertions may come later, but bearer + same-host/Tailscale + pairing is the fastest elegant first version.
+
+---
+
+## Transport Model
+
+### Allowed network paths
+Phase 1 should support only:
+- same-host access
+- Tailscale private-network access
+
+LAN can exist only as a later advanced opt-in if there is a real need, but it should not be part of the default phase-1 remote story.
+
+### Explicit non-goal
+No:
+- public relay
+- internet-facing webhook bridge
+- cloud control plane
+- public auth gateway
+
+This matters because pairing should not accidentally become "public API but with nicer tokens".
+
+---
+
+## API Design
+
+These names are illustrative, not final.
+
+### Bootstrap endpoints
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| GET | `/agent` | Human-readable bootstrap page for agents |
+| GET | `/skill` | Version-matched skill/instructions page served by the running instance |
+| GET | `/agent/manifest` | Machine-readable manifest for API or agent clients |
+| GET | `/agent/version` | Minimal version/capability summary |
+
+### Pairing endpoints
+
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| POST | `/pairing/setup-code` | Generate one-time setup code from Tandem UI |
+| GET | `/pairing/setup-code/active` | Get current active setup code + TTL |
+| POST | `/pairing/exchange` | Exchange setup code for durable binding token |
+| GET | `/pairing/bindings` | List connected agents |
+| POST | `/pairing/bindings/:id/pause` | Pause a binding |
+| POST | `/pairing/bindings/:id/resume` | Resume a paused binding |
+| POST | `/pairing/bindings/:id/revoke` | Revoke a binding |
+| DELETE | `/pairing/bindings/:id` | Remove a binding from active management |
+| GET | `/pairing/whoami` | Validate binding token and return binding info |
+
+### Shared auth behavior
+Once paired, both MCP and HTTP clients authenticate using the binding token.
+
+Examples:
+- HTTP: `Authorization: Bearer tdm_ast_...`
+- MCP: wrapper passes same token into Tandem auth adapter
+
+### Capability negotiation
+During pairing, the client may declare:
+
+```json
+{
+  "agentType": "openclaw",
+  "agentLabel": "OpenClaw on minimax",
+  "transport": ["http", "mcp"],
+  "capabilities": {
+    "interactive": true,
+    "supportsMcp": true,
+    "supportsHttp": true
+  }
+}
+```
+
+Tandem uses this for display and compatibility, not as a scoped permission model.
+
+---
+
+## Internal Binding Model
+
+Internally, Tandem should manage **binding state**, not scoped role slices.
+
+Example internal representation:
+
+```ts
+type BindingState = 'paired' | 'paused' | 'revoked';
+
+interface AgentBindingRecord {
+  profileId: string;
+  machineId: string;
+  machineName?: string;
+  agentLabel: string;
+  agentType: string;
+  transportModes: Array<'http' | 'mcp'>;
+  tokenHash: string;
+  tokenPrefix: string;
+  state: BindingState;
+  createdAt: string;
+  lastUsedAt?: string;
+  revokedAt?: string;
+  pausedAt?: string;
+}
+```
+
+The backend still decides whether a binding may authenticate at all.
+But once authenticated, the binding is admitted to the full Tandem capability surface.
+
+---
+
+## UI Design in Tandem
+
+### New Settings section
+**Connected Agents**
+
+Shows:
+- remote access availability
+- current network policy
+- active setup code, if any
+- list of connected agents
+
+### Per binding card
+- agent label
+- machine name
+- agent type
+- status
+- connected since
+- last used
+- network origin when known
+- pause button
+- revoke button
+- remove button
+
+### Pair new agent dialog
+- explanation in plain language
+- setup code
+- countdown
+- short examples:
+  - "Connect to Tandem with code TDM-XXXX-XXXX"
+  - CLI example for API-only clients
+
+### Design principle
+The UI should feel like:
+- pairing and managing trusted copilot connections
+not like:
+- configuring an enterprise identity provider
+
+---
+
+## Binding Controls
+
+Every existing connection should support these controls from day one:
+
+### Pause
+- temporarily disable a binding without deleting it
+- useful when a machine is offline, being serviced, or should stop interacting for a while
+
+### Resume
+- re-enable a paused binding
+
+### Revoke
+- invalidate the credential immediately
+- the remote agent must re-pair or receive a fresh credential to connect again
+
+### Remove
+- remove the binding from the active management list after it is already paused or revoked
+- audit history should still remain available
+
+This is not optional future polish. It is core to the design.
+
+---
+
+## Local vs Remote Agents
+
+### Local agents
+Local agents can also use the pairing model if desired.
+That gives one consistent trust system.
+
+But phase 1 can keep localhost-dev workflows working as they do today.
+
+### Remote agents
+Remote agents benefit most:
+- same tailnet, different machine
+- no repo co-location required
+- no local shell on Tandem host required
+- human-controlled access without public exposure
+
+---
+
+## MCP and API-only coexistence
+
+This is critical.
+
+### MCP-capable agent path
+- pair once
+- receive binding token
+- MCP server or wrapper uses binding token to call Tandem
+- no second-class pairing path
+
+### API-only agent path
+- pair once
+- receive binding token
+- direct HTTP calls to Tandem API
+- same trust admission model
+
+### Why this is the right shape
+Because otherwise Tandem would accidentally split into:
+- a "real" integration path for MCP tools
+- a second-class path for everyone else
+
+That would be a mistake.
+
+Tandem should be **agent-native, not MCP-exclusive**.
+
+---
+
+## Audit and Visibility
+
+Every paired agent action should be attributable.
+
+Per binding, log:
+- binding created
+- setup code exchanged
+- binding paused
+- binding resumed
+- token revoked
+- binding removed
+- failed auth attempts
+- last successful use
+- network source if available
+
+This supports both security and product clarity.
+
+Tandem is about shared context, so the human must be able to answer:
+- who is connected?
+- what state is that connection in?
+- when were they last active?
+- can I stop them right now?
+
+---
+
+## Data Model Proposal
+
+### `agent_setup_codes`
+Fields:
+- `id`
+- `code`
+- `profile_id`
+- `created_at`
+- `expires_at`
+- `consumed_at`
+- `cancelled_at`
+- `created_by_user`
+
+### `agent_bindings`
+Fields:
+- `id`
+- `profile_id`
+- `machine_id`
+- `machine_name`
+- `agent_label`
+- `agent_type`
+- `transport_modes` (json)
+- `token_hash`
+- `token_prefix`
+- `state`
+- `created_at`
+- `last_used_at`
+- `paused_at`
+- `revoked_at`
+- `notes` optional
+
+### `agent_binding_events`
+Fields:
+- `id`
+- `binding_id`
+- `event_type`
+- `metadata`
+- `created_at`
+- `source_ip` optional
+- `tailnet_identity` optional
+
+---
+
+## Security Considerations
+
+### Strong points of this design
+- no public long-lived bootstrap secret sharing
+- one-time human-visible setup code
+- durable credential never needs to be shown in UI again
+- pause, revoke, and remove are built in
+- easy mental model for users
+- transport-agnostic
+- compatible with local-first and tailnet-first deployment
+
+### Key risks
+
+#### 1. Over-trusting remote agents
+Mitigation:
+- pairing is explicit
+- bindings are visible
+- pause, revoke, and remove are first-class controls
+- Local + Tailscale only network boundary
+
+#### 2. Public exposure by accident
+Mitigation:
+- same-host and Tailscale only in phase 1
+- no public relay path
+- no internet-facing control plane
+
+#### 3. Token theft on remote host
+Mitigation:
+- per-binding pause/revoke
+- last-used visibility
+- future token rotation
+- encourage local secret storage on agent host
+
+#### 4. Sensitive route leakage
+Mitigation:
+- only paired bindings may authenticate
+- sensitive routes are still guarded by Tandem's normal internal safety architecture
+- do not add internet-facing relay paths
+
+#### 5. Setup code brute force
+Mitigation:
+- short TTL
+- consume-on-use
+- rate limit generation and exchange
+- use safe characters and enough entropy
+
+---
+
+## Why this fits Tandem philosophically
+
+This design supports Tandem's actual idea:
+- human and AI share context
+- human keeps authorship and agency
+- trust is explicit
+- collaboration is first-class
+
+It does **not** force a master-servant model.
+It does **not** turn Tandem into a corporate access-control console.
+
+The browser is not deciding how much a trusted agent may participate.
+The browser is deciding whether that agent is admitted into the shared workspace at all.
+
+That is a much better fit for Tandem.
+
+---
+
+## Recommended Phasing
+
+### Phase 1: Core pairing
+Ship the Kanbu-shaped backbone.
+
+Scope:
+- setup code generation
+- exchange for durable token
+- binding storage
+- pause, resume, revoke, remove
+- HTTP auth using binding token
+- same-host/Tailscale reachability only
+- Connected Agents UI
+- binding state model in backend and UI
+
+### Phase 2: MCP adapter integration
+Scope:
+- first-class pairing flow for MCP-capable agents
+- local wrapper or MCP auth bridge
+- `whoami` and capability discovery
+- nicer agent-specific onboarding copy
+
+### Phase 3: Hardening and polish
+Scope:
+- token rotation
+- event log UI
+- richer device identity display
+- parallel multi-agent tuning
+
+### Phase 4: Optional federation, only if needed
+Scope:
+- signed clients or stronger client identity
+- richer remote fleet management inside private-network constraints
+
+This should be delayed until the simple pairing model proves itself.
+
+---
+
+## Resolved Decisions
+
+- **Local and remote bindings are separate categories** in the model and UI, but not separate trust levels.
+- **Remote pairing should default to Tailscale only**. LAN is not part of the default phase-1 remote path and should only be considered later as an advanced opt-in.
+- **A CLI helper for API-only clients is optional** and not required for phase 1.
+- **There is no intentionally reduced remote API surface**. A paired client is admitted to the full Tandem capability surface.
+
+---
+
+## Recommendation
+
+Build this.
+
+More specifically:
+
+- adopt the **Kanbu one-time pairing pattern**
+- make it **transport-agnostic**
+- keep the user-facing model to **paired / paused / revoked / removed**, not scopes or roles
+- default to **same host + Tailscale only**, never public relay
+- treat **local** and **remote** bindings as separate connection categories
+- bind identities to **machine + agent label**
+- treat MCP and API-only agents as equal citizens
+- do not artificially reduce the remote API surface
+- ship the simplest version that lets a remote OpenClaw node or API-only agent pair with a local Tandem Browser safely
+
+This is the right bridge between:
+- Tandem as a local-first human-AI browser
+- and Tandem as a real multi-agent browser substrate
+
+It is elegant, understandable, and aligned with the product.

--- a/docs/plans/remote-agent-pairing-review-notes.md
+++ b/docs/plans/remote-agent-pairing-review-notes.md
@@ -1,0 +1,111 @@
+# Review Notes: Remote Agent Pairing — Phase 1
+
+> **Branch:** feature/agent-bootstrap-and-pairing
+> **Date:** 2026-04-15
+> **Status:** Remote Tailscale connectivity proven in practice (Windows 11 + Claude Code → macOS)
+
+---
+
+## Key files
+
+### New files
+
+| File | Purpose | LOC |
+| --- | --- | --- |
+| `src/pairing/manager.ts` | Core pairing logic: setup codes, token exchange, binding CRUD, persistence | ~310 |
+| `src/api/routes/bootstrap.ts` | Public discovery surface with request-aware base URLs, correct route names, structured transport info | ~250 |
+| `src/api/routes/pairing.ts` | Pairing API: setup-code, exchange, bindings management, whoami, address detection | ~260 |
+| `src/pairing/tests/manager.test.ts` | 42 unit tests for PairingManager | ~350 |
+| `src/api/tests/routes/bootstrap.test.ts` | 10 route tests for bootstrap endpoints (incl. dynamic baseUrl, transport structure) | ~100 |
+| `src/api/tests/routes/pairing.test.ts` | 28 tests for pairing routes + detectAddresses | ~330 |
+
+### Modified files
+
+| File | Change |
+| --- | --- |
+| `src/api/server.ts` | Import bootstrap/pairing routes; public route paths; `isBindingTokenValid()` for dual-token auth; listen host from config (default `0.0.0.0`) |
+| `src/registry.ts` | Add `pairingManager: PairingManager` to ManagerRegistry |
+| `src/bootstrap/types.ts` | Add `pairingManager: PairingManager` to RuntimeManagers |
+| `src/bootstrap/runtime.ts` | Initialize PairingManager, wire into registry, add destroy call |
+| `src/config/manager.ts` | Add `apiListenHost` (default `0.0.0.0`); migration from old `127.0.0.1` saved value |
+| `src/api/tests/helpers.ts` | Add `pairingManager` mock to `createMockContext()` |
+| `shell/settings.html` | Onboarding-first "Connect your AI to Tandem" with mode selector, address detection, instruction generation with `bindingKind`, binding cards, controls, polling |
+
+---
+
+## Architectural choices
+
+### 1. Standalone manager + JSON storage
+Follows existing Tandem patterns (BookmarkManager, PinboardManager). JSON at `~/.tandem/pairing/bindings.json` with 0600 permissions. Setup codes are in-memory only (correct for 5-min TTL ephemeral secrets).
+
+### 2. Dual-token auth
+Binding tokens (`tdm_ast_`) are validated alongside the existing local `api-token` in `classifyCaller()`. Both result in `local-automation` caller class (full API access). The existing auth path is untouched — binding validation is an additive check. Short-circuits on prefix so non-binding tokens skip the lookup.
+
+### 3. SHA-256 token hashing (not argon2)
+Design doc suggested SHA-256 + argon2. Implementation uses SHA-256 only. Rationale: the token is 256-bit random (not a password), so SHA-256 with timing-safe comparison is sufficient. Argon2 would add a native dependency and slow down every API request for no security gain.
+
+### 4. Public bootstrap routes
+`/agent`, `/skill`, `/agent/manifest`, `/agent/version` are unauthenticated. They contain no sensitive data — only version info, capability lists, and pairing instructions. This is intentional: an agent must be able to discover Tandem before it has a token.
+
+### 5. Listen host defaults to 0.0.0.0
+Local and remote connections must work simultaneously (not either/or). The server listens on all interfaces by default. Existing installs that had `127.0.0.1` saved are auto-migrated to `0.0.0.0` during config load. This migration was validated after hitting the exact problem during live Tailscale testing.
+
+### 6. Structured transport info
+The manifest and version endpoints report transports as structured objects (`{ http: { local: true, remote: true }, mcp: { local: true, remote: false } }`) rather than a flat array. This prevents remote agents from assuming MCP is available remotely.
+
+---
+
+## Things to verify in the diff
+
+1. **`server.ts` auth changes** — `isBindingTokenValid()` is in the hot path for every API request. It short-circuits on the `tdm_ast_` prefix check, so non-binding tokens skip the lookup entirely.
+
+2. **Public route set** — `/agent`, `/agent/version`, `/agent/manifest`, `/skill`, `/pairing/exchange`, `/pairing/whoami` are public. The exchange endpoint has its own rate limiter (10/min). The whoami endpoint does its own auth internally.
+
+3. **Config migration** — `apiListenHost: "127.0.0.1"` is auto-migrated to `"0.0.0.0"` in `config/manager.ts load()`. This is a one-way migration — appropriate because `0.0.0.0` supports both local and remote.
+
+4. **Bootstrap route names** — all route names in `/agent` and `/skill` were corrected to match actual routes (e.g. `/tabs/list` not `/list-tabs`). Verify against actual route registrations if in doubt.
+
+5. **Instruction block `bindingKind`** — the generated instruction text now includes `"bindingKind": "local"` or `"bindingKind": "remote"` so bindings are classified correctly.
+
+---
+
+## Known limitations (acceptable for phase 1)
+
+- Remote MCP not available (agents use HTTP API; phase 2 scope)
+- No CORS support for browser-origin remote callers (curl/SDK works fine; phase 2)
+- Token not rotatable (phase 3)
+- No concurrent multi-agent stress testing done
+- UI polling for auto-refresh on pairing exists but not explicitly verified in live testing
+- `/dialog/pick-folder` is local-only (returns 422 for remote callers)
+- Extension native messaging proxy routes are local-only (require chrome-extension:// origin)
+- Security Gatekeeper WebSocket uses its own ephemeral secret (not binding tokens)
+
+## Remote HTTP API coverage audit (post phase-1 fixes)
+
+### Fixed in phase-1 coverage pass
+
+- Preview routes (`POST /preview`, `PUT /preview/:id`, `GET /preview/:id`) now use request-aware base URLs instead of hardcoded `127.0.0.1:8765`
+- WebSocket `/watch/live` now accepts binding tokens (`tdm_ast_`) alongside local api-tokens
+- `/agent/manifest` expanded from ~10 endpoints to full route family coverage (~150 endpoints across 25 families)
+- `/dialog/pick-folder` returns a clear 422 error for remote callers instead of crashing
+- `/GET /preview/:id` 404 page uses relative link instead of hardcoded localhost
+
+### Intentionally local-only (not bugs)
+
+- MCP (stdio transport)
+- `/dialog/pick-folder` (native OS dialog)
+- Extension native messaging proxy (`/extensions/native-message`, `/extensions/native-message/ws`)
+- Google Photos OAuth callback
+- Security Gatekeeper WebSocket (`/security/gatekeeper`)
+
+### Remote HTTP parity audit (final pass)
+
+All HTTP route files were audited line-by-line for remaining remote-breaking patterns. Result: **no remaining remote-breaking gaps found**. Every endpoint reachable by a local `api-token` is equally reachable by a `tdm_ast_` binding token. Auth is uniform via `classifyCaller()` — there is no per-route auth divergence.
+
+**Filesystem-path-in-response pattern (not a bug):** Several endpoints return a local filesystem path in the response body when they save files on the Tandem host (e.g. `GET /screenshot?save=...`, `POST /screenshot/application`, `POST /clipboard/save`, `POST /sessions/state/save`). These operations succeed remotely — the file is saved on the Tandem machine — but the `path` field is only meaningful locally. Remote agents should use the direct-data variants (e.g. `GET /screenshot` without `?save` returns PNG data directly). This is documented in the manifest `remoteNotes` section.
+
+### Remaining items (phase 2+)
+
+- CORS: browser-origin remote callers are blocked (CLI/SDK callers work fine without Origin header)
+- Native messaging proxy CSP patches hardcode `127.0.0.1:8765` (only affects local extensions, not remote agents)
+- Remote MCP transport

--- a/docs/plans/remote-agent-pairing-test-report.md
+++ b/docs/plans/remote-agent-pairing-test-report.md
@@ -1,0 +1,150 @@
+# Test Report: Remote Agent Pairing — Phase 1
+
+> **Date:** 2026-04-15
+> **Branch:** feature/agent-bootstrap-and-pairing
+> **Tandem version:** 0.73.0
+> **Tester:** Claude Code (Opus 4.6) + Robin Waslander (manual UI + live remote testing)
+
+---
+
+## What was built
+
+Phase 1 of remote agent connectivity for Tandem Browser:
+
+1. **PairingManager** — setup code generation, token exchange, binding lifecycle, JSON persistence
+2. **Bootstrap routes** — `/agent`, `/skill`, `/agent/manifest`, `/agent/version` with request-aware base URLs and correct route names
+3. **Pairing routes** — setup-code generation, exchange, bindings CRUD, whoami, address detection
+4. **Binding token auth** — paired agents authenticate with `tdm_ast_` tokens alongside existing `api-token`
+5. **Onboarding-first Settings UI** — "Connect your AI to Tandem" with two modes (on this machine / on another machine), address detection, generated instruction block with `bindingKind`, binding management
+6. **Address detection** — automatic local and Tailscale address detection via `GET /pairing/addresses`
+7. **Listen host default** — `apiListenHost` defaults to `0.0.0.0` (local + remote simultaneously), with config migration for existing installs
+
+---
+
+## Automated test results
+
+| Test file | Tests | Status |
+|---|---|---|
+| `src/pairing/tests/manager.test.ts` | 42 | All pass |
+| `src/api/tests/routes/bootstrap.test.ts` | 10 | All pass |
+| `src/api/tests/routes/pairing.test.ts` | 28 (routes + detectAddresses) | All pass |
+| **Full suite (115 files)** | **2382 pass, 39 skipped** | **Zero regressions** |
+
+TypeScript: clean compile (`tsc --noEmit`, zero errors).
+
+---
+
+## Live tests (manual, against running Tandem)
+
+### Setup code lifecycle
+
+| Test | Result |
+|---|---|
+| Generate setup code via UI | TDM-XXXX-XXXX displayed with countdown |
+| Generate setup code via API (`POST /pairing/setup-code`) | Code returned with TTL |
+| Code format matches `TDM-[A-Z0-9]{4}-[A-Z0-9]{4}` | Yes |
+| Previous unused code cancelled on new generation | Yes |
+
+### Token exchange
+
+| Test | Result |
+|---|---|
+| Exchange valid code via `POST /pairing/exchange` (local) | Token `tdm_ast_...` returned, binding created |
+| Exchange valid code via remote Tailscale host | Token returned, binding created, remote agent operational |
+| Exchange with missing fields | 400 with specific field error |
+| Exchange with invalid code format | 400 "Invalid setup code format" |
+| Exchange consumed code | 400 "already been used" |
+| Case-insensitive code matching | Yes (lowercase accepted) |
+
+### Binding token auth
+
+| Test | Result |
+|---|---|
+| `GET /pairing/whoami` with valid binding token | Returns full binding info |
+| Protected route with valid binding token (local) | Authorized (full API access) |
+| Protected route with valid binding token (remote via Tailscale) | Authorized (full API access) |
+| Protected route with invalid token | 401 Unauthorized |
+| Protected route with paused binding token | 401 Unauthorized |
+| Protected route with revoked binding token | 401 Unauthorized |
+
+### Binding state transitions
+
+| Test | Result |
+|---|---|
+| Pair (local) | Binding created, visible in UI, token works |
+| Pair (remote via Tailscale) | Binding created, visible in UI, remote agent can use all HTTP endpoints |
+| Pause (via UI) | Token rejected, binding shows paused state |
+| Resume (via UI) | Token works again, binding shows paired state |
+| Revoke (via UI) | Token permanently rejected |
+| Remove (via UI) | Binding removed from list, audit events preserved |
+
+### Remote Tailscale connectivity (proven)
+
+| Test | Environment | Result |
+|---|---|---|
+| Remote pairing over Tailscale | Windows 11 + VS Code + Claude Code → Apple laptop | Successful |
+| Remote HTTP API usage | Same setup | Agent inspected and controlled live browser |
+| Bootstrap route serving correct remote URLs | Tailscale IP in Host header | `baseUrl` correctly reflects Tailscale address |
+| Local + remote simultaneous access | Both local MCP and remote HTTP | Both work at the same time |
+
+### Bootstrap/discovery routes
+
+| Route | Result |
+|---|---|
+| `GET /agent` | Markdown bootstrap page with correct route names, version-matched, Tailscale guidance |
+| `GET /agent/version` | JSON with structured transport info (HTTP: local+remote, MCP: local only) |
+| `GET /agent/manifest` | Full manifest with correct endpoints, structured transports |
+| `GET /skill` | Version-matched quick-start with correct route names |
+
+All four routes are public (no auth required), serve correct route names, and use request-aware base URLs.
+
+### MCP connectivity
+
+| Test | Result |
+|---|---|
+| `tandem_browser_status` via MCP (local, stdio) | Works — returns ready state, active tab, version |
+| MCP unaffected by binding pause/revoke | Correct — MCP uses local api-token, not binding token |
+| Remote MCP | Not available — remote agents use HTTP API |
+
+---
+
+## What is proven
+
+- Full pairing lifecycle: generate code, exchange, authenticate, pause, resume, revoke, remove
+- **Remote Tailscale connectivity works end-to-end** (Windows 11 ↔ macOS, VS Code + Claude Code as remote client)
+- Local and remote connections work simultaneously (not either/or)
+- Binding token auth works alongside existing api-token without interference
+- UI reflects binding state correctly with live controls
+- Bootstrap surface provides version-matched discovery with correct route names
+- Address detection finds Tailscale interfaces automatically
+- Config migration handles existing `127.0.0.1` installs
+- Zero regressions in existing test suite (2382 tests)
+
+## What is not yet proven
+
+- **Remote MCP** — not in phase 1 scope; remote agents use HTTP API
+- **Token persistence across Tandem restart** — bindings save to disk but restart continuity not explicitly tested
+- **Multiple concurrent remote agents** — only single-remote-agent flows tested
+- **UI auto-refresh polling** — code exists but not explicitly verified in live testing
+
+---
+
+## Phase-1 remote HTTP coverage fixes
+
+The following issues were identified and fixed in a remote HTTP API coverage audit:
+
+1. **Preview URLs hardcoded to `127.0.0.1:8765`** — `POST /preview`, `PUT /preview/:id`, and `GET /preview/:id` (404 page) used hardcoded localhost URLs in responses. Fixed to use request-aware `Host` header so remote agents get correct URLs.
+2. **WebSocket `/watch/live` rejected binding tokens** — `authorizeWatchLiveRequest()` only validated local api-tokens. Fixed to also accept `tdm_ast_` binding tokens, so remote paired agents can use live watch notifications.
+3. **`/agent/manifest` listed only ~10 endpoints** — expanded to cover ~150 endpoints across 25 route families, giving remote agents a real discovery surface.
+4. **`/dialog/pick-folder` crashed for remote callers** — added guard that returns 422 with clear error when no BrowserWindow is available.
+
+---
+
+## Known follow-up items (phase 2+)
+
+1. **Remote MCP** — binding tokens need an MCP network transport (phase 2)
+2. **Token rotation** — not in phase 1 (design doc: phase 3)
+3. **Audit event log UI** — events are stored but no viewer yet (phase 3)
+4. **CORS for browser-origin remote requests** — curl/SDK works fine, browser-based remote UIs would need CORS expansion
+5. **Native messaging proxy CSP** — hardcodes `127.0.0.1:8765` in extension manifests (only affects local extensions, not remote agents)
+6. **Security Gatekeeper WebSocket** — uses its own ephemeral secret, not binding tokens (local-only by design)

--- a/shell/settings.html
+++ b/shell/settings.html
@@ -490,6 +490,7 @@
     <a href="#autonomy" data-section="autonomy">🤖 AI Autonomy</a>
     <a href="#data" data-section="data">💾 Data</a>
     <a href="#extensions" data-section="extensions">🧩 Extensions</a>
+    <a href="#agents" data-section="agents">🔗 Connected Agents</a>
   </nav>
 
   <div class="settings-body">
@@ -1026,6 +1027,55 @@
       <div class="ext-tab-content" id="ext-gallery">
         <div class="ext-category-filters" id="ext-gallery-filters"></div>
         <div id="ext-gallery-list"></div>
+      </div>
+    </div>
+
+    <!-- ═══ Connected Agents ═══ -->
+    <div class="section" id="agents">
+      <h2>🔗 Connect your AI to Tandem</h2>
+      <p class="section-desc">Let your AI agent work with you in Tandem Browser</p>
+
+      <!-- Onboarding: mode selector -->
+      <div class="field-group" id="agent-onboard">
+        <label class="field-label">Where is your AI running?</label>
+        <div style="display: flex; gap: 10px; margin-top: 8px;" id="agent-mode-btns">
+          <button class="btn btn-primary" id="agent-mode-local-btn" onclick="selectAgentMode('local')">On this machine</button>
+          <button class="btn btn-secondary" id="agent-mode-remote-btn" onclick="selectAgentMode('remote')">On another machine</button>
+        </div>
+      </div>
+
+      <!-- Mode detail + code generation area -->
+      <div class="field-group" id="agent-mode-detail" style="display:none; margin-top: 16px;">
+        <div id="agent-mode-info"></div>
+        <div style="margin-top: 12px;">
+          <button class="btn btn-primary" id="agent-connect-btn" onclick="generateAndShowInstructions()">Generate connection instructions</button>
+        </div>
+      </div>
+
+      <!-- Active code + instruction block -->
+      <div id="agent-instruction-area" style="display:none; margin-top: 16px;">
+        <div style="background: var(--input-bg); border-radius: 8px; padding: 16px; text-align: center;">
+          <div style="font-size: 24px; font-family: 'SF Mono', 'Menlo', 'Consolas', monospace; letter-spacing: 2px; margin-bottom: 8px;" id="agent-code-display"></div>
+          <div style="font-size: 12px; color: var(--text-dim);" id="agent-code-timer"></div>
+        </div>
+        <div style="margin-top: 12px;">
+          <label class="field-label">Give this to your AI</label>
+          <p class="field-desc">Copy the text below and paste it into your AI agent. It contains everything your AI needs to connect.</p>
+          <textarea id="agent-instruction-text" readonly rows="10"
+            style="width:100%;font-family:'SF Mono','Menlo','Consolas',monospace;font-size:12px;background:var(--surface2);color:var(--text);border:1px solid var(--border);border-radius:6px;padding:12px;resize:vertical;margin-top:8px;"></textarea>
+        </div>
+        <div style="display: flex; gap: 8px; margin-top: 10px;">
+          <button class="btn btn-sm btn-primary" onclick="copyInstructions()">Copy instructions</button>
+          <button class="btn btn-sm btn-secondary" onclick="cancelSetupCode()">Cancel</button>
+        </div>
+      </div>
+
+      <!-- Bindings list -->
+      <div class="field-group" style="margin-top: 28px;">
+        <label class="field-label">Connected agents</label>
+        <div id="agent-bindings-list">
+          <p class="field-desc" id="agent-no-bindings">No agents connected yet.</p>
+        </div>
       </div>
     </div>
 
@@ -2205,6 +2255,247 @@
       return d.innerHTML;
     }
 
+    // ═══ Connected Agents ═══
+    let activeSetupCode = null;
+    let codeTimerInterval = null;
+    let codePollInterval = null;
+    let selectedMode = null; // 'local' | 'remote'
+    let detectedAddresses = null;
+
+    async function loadAddresses() {
+      try {
+        const res = await fetch(`${API}/pairing/addresses`);
+        if (res.ok) detectedAddresses = await res.json();
+      } catch { /* API not ready */ }
+    }
+
+    function selectAgentMode(mode) {
+      selectedMode = mode;
+      // Update button styles
+      const localBtn = document.getElementById('agent-mode-local-btn');
+      const remoteBtn = document.getElementById('agent-mode-remote-btn');
+      localBtn.className = mode === 'local' ? 'btn btn-primary' : 'btn btn-secondary';
+      remoteBtn.className = mode === 'remote' ? 'btn btn-primary' : 'btn btn-secondary';
+
+      const detail = document.getElementById('agent-mode-detail');
+      const info = document.getElementById('agent-mode-info');
+      const connectBtn = document.getElementById('agent-connect-btn');
+      detail.style.display = '';
+
+      if (mode === 'local') {
+        const addr = detectedAddresses ? detectedAddresses.local.address : 'http://127.0.0.1:8765';
+        info.innerHTML = `
+          <p class="field-desc">Your AI and Tandem are on the same machine.</p>
+          <div style="font-size:13px;color:var(--text-dim);margin-top:6px;">
+            Tandem address: <strong style="color:var(--text)">${esc(addr)}</strong>
+          </div>`;
+        connectBtn.disabled = false;
+        connectBtn.textContent = 'Generate connection instructions';
+      } else {
+        if (detectedAddresses && detectedAddresses.tailscale.available) {
+          const addr = detectedAddresses.tailscale.address;
+          info.innerHTML = `
+            <p class="field-desc">Your AI runs on another machine in your Tailscale network.</p>
+            <div style="font-size:13px;color:var(--text-dim);margin-top:6px;">
+              Tandem address: <strong style="color:var(--text)">${esc(addr)}</strong>
+            </div>
+            <p class="field-desc" style="margin-top:6px;font-size:11px;">Both machines must be on the same Tailscale network. Tandem is never exposed to the public internet.</p>`;
+          connectBtn.disabled = false;
+          connectBtn.textContent = 'Generate connection instructions';
+        } else {
+          info.innerHTML = `
+            <p class="field-desc" style="color:var(--warning)">No Tailscale connection detected.</p>
+            <p class="field-desc" style="margin-top:4px;">Remote connections require Tailscale. Make sure Tailscale is running and this machine is connected to your tailnet.</p>
+            <p class="field-desc" style="margin-top:4px;font-size:11px;">Tandem only supports remote connections over private Tailscale networks, never over the public internet.</p>`;
+          connectBtn.disabled = true;
+          connectBtn.textContent = 'Tailscale not available';
+        }
+      }
+    }
+
+    function buildInstructionText(code, mode) {
+      const addr = mode === 'local'
+        ? (detectedAddresses ? detectedAddresses.local.address : 'http://127.0.0.1:8765')
+        : detectedAddresses.tailscale.address;
+
+      if (mode === 'local') {
+        return [
+          `Connect to Tandem Browser running on this machine.`,
+          ``,
+          `Tandem address: ${addr}`,
+          `Setup code: ${code}`,
+          ``,
+          `Steps:`,
+          `1. Read ${addr}/agent to learn how this Tandem instance works.`,
+          `2. Exchange the setup code for a connection token:`,
+          `   POST ${addr}/pairing/exchange`,
+          `   Body: { "code": "${code}", "machineId": "<your-machine-id>", "machineName": "<your-hostname>", "agentLabel": "<your-name>", "agentType": "<your-type>", "bindingKind": "local" }`,
+          `3. Use the returned token as: Authorization: Bearer <token>`,
+          `4. The token is permanent. Store it securely.`,
+        ].join('\n');
+      } else {
+        return [
+          `Connect to Tandem Browser on a remote machine via Tailscale.`,
+          `Both machines must be on the same Tailscale network.`,
+          ``,
+          `Tandem address: ${addr}`,
+          `Setup code: ${code}`,
+          ``,
+          `Steps:`,
+          `1. Read ${addr}/agent to learn how this Tandem instance works.`,
+          `2. Exchange the setup code for a connection token:`,
+          `   POST ${addr}/pairing/exchange`,
+          `   Body: { "code": "${code}", "machineId": "<your-machine-id>", "machineName": "<your-hostname>", "agentLabel": "<your-name>", "agentType": "<your-type>", "bindingKind": "remote" }`,
+          `3. Use the returned token as: Authorization: Bearer <token>`,
+          `4. The token is permanent. Store it securely.`,
+          ``,
+          `Note: This connection only works over Tailscale. Tandem is not exposed to the public internet.`,
+        ].join('\n');
+      }
+    }
+
+    async function generateAndShowInstructions() {
+      try {
+        const res = await fetch(`${API}/pairing/setup-code`, { method: 'POST' });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          showToast(err.error || 'Failed to generate code');
+          return;
+        }
+        const data = await res.json();
+        activeSetupCode = data;
+
+        // Hide onboarding controls, show instruction area
+        document.getElementById('agent-onboard').style.display = 'none';
+        document.getElementById('agent-mode-detail').style.display = 'none';
+        const area = document.getElementById('agent-instruction-area');
+        area.style.display = '';
+
+        document.getElementById('agent-code-display').textContent = data.code;
+        document.getElementById('agent-instruction-text').value = buildInstructionText(data.code, selectedMode);
+
+        // Countdown timer
+        if (codeTimerInterval) clearInterval(codeTimerInterval);
+        codeTimerInterval = setInterval(() => {
+          const remaining = Math.max(0, Math.floor((new Date(data.expiresAt).getTime() - Date.now()) / 1000));
+          const m = Math.floor(remaining / 60);
+          const s = remaining % 60;
+          document.getElementById('agent-code-timer').textContent = remaining > 0
+            ? `Expires in ${m}:${s.toString().padStart(2, '0')}`
+            : 'Expired';
+          if (remaining <= 0) {
+            clearInterval(codeTimerInterval);
+            cancelSetupCode();
+          }
+        }, 1000);
+
+        // Poll for new bindings
+        if (codePollInterval) clearInterval(codePollInterval);
+        let lastCount = -1;
+        codePollInterval = setInterval(async () => {
+          try {
+            const bRes = await fetch(`${API}/pairing/bindings`);
+            if (!bRes.ok) return;
+            const bindings = await bRes.json();
+            if (lastCount >= 0 && bindings.length > lastCount) {
+              renderAgentBindings(bindings);
+              cancelSetupCode();
+              showToast('Agent connected');
+            } else {
+              lastCount = bindings.length;
+            }
+          } catch { /* ignore */ }
+        }, 2000);
+      } catch {
+        showToast('Failed to generate setup code');
+      }
+    }
+
+    function cancelSetupCode() {
+      activeSetupCode = null;
+      if (codeTimerInterval) clearInterval(codeTimerInterval);
+      if (codePollInterval) clearInterval(codePollInterval);
+      document.getElementById('agent-instruction-area').style.display = 'none';
+      document.getElementById('agent-onboard').style.display = '';
+      if (selectedMode) {
+        document.getElementById('agent-mode-detail').style.display = '';
+      }
+    }
+
+    function copyInstructions() {
+      const text = document.getElementById('agent-instruction-text').value;
+      navigator.clipboard.writeText(text).then(() => showToast('Instructions copied'));
+    }
+
+    async function loadAgentBindings() {
+      try {
+        const res = await fetch(`${API}/pairing/bindings`);
+        if (!res.ok) return;
+        const bindings = await res.json();
+        renderAgentBindings(bindings);
+      } catch { /* API not ready */ }
+    }
+
+    function renderAgentBindings(bindings) {
+      const container = document.getElementById('agent-bindings-list');
+      const noBindings = document.getElementById('agent-no-bindings');
+
+      if (!bindings || bindings.length === 0) {
+        noBindings.style.display = '';
+        container.querySelectorAll('.agent-card').forEach(c => c.remove());
+        return;
+      }
+
+      noBindings.style.display = 'none';
+      container.querySelectorAll('.agent-card').forEach(c => c.remove());
+
+      for (const b of bindings) {
+        const card = document.createElement('div');
+        card.className = 'agent-card';
+        card.style.cssText = 'background: var(--surface2); border-radius: 8px; padding: 14px 16px; margin-bottom: 8px; display: flex; justify-content: space-between; align-items: center;';
+
+        const statusColor = b.state === 'paired' ? 'var(--success)' : b.state === 'paused' ? 'var(--warning)' : 'var(--danger)';
+        const statusDot = `<span style="display:inline-block;width:8px;height:8px;border-radius:50%;background:${statusColor};margin-right:6px"></span>`;
+        const lastUsed = b.lastUsedAt ? new Date(b.lastUsedAt).toLocaleString() : 'never';
+
+        card.innerHTML = `
+          <div>
+            <div style="font-weight:500;font-size:14px">${statusDot}${esc(b.agentLabel)}</div>
+            <div style="font-size:12px;color:var(--text-dim);margin-top:4px">
+              ${esc(b.machineName)} · ${esc(b.agentType)} · last used: ${lastUsed}
+            </div>
+          </div>
+          <div style="display:flex;gap:6px">
+            ${b.state === 'paired' ? `<button class="btn-sm btn-secondary" onclick="agentAction('${b.id}','pause')">Pause</button>` : ''}
+            ${b.state === 'paused' ? `<button class="btn-sm btn-secondary" onclick="agentAction('${b.id}','resume')">Resume</button>` : ''}
+            ${b.state !== 'revoked' ? `<button class="btn-sm btn-secondary" style="color:var(--warning)" onclick="agentAction('${b.id}','revoke')">Revoke</button>` : ''}
+            <button class="btn-sm btn-secondary" style="color:var(--danger)" onclick="agentAction('${b.id}','remove')">Remove</button>
+          </div>
+        `;
+        container.appendChild(card);
+      }
+    }
+
+    async function agentAction(id, action) {
+      try {
+        if (action === 'remove') {
+          const res = await fetch(`${API}/pairing/bindings/${id}`, { method: 'DELETE' });
+          if (res.ok) { showToast('Agent removed'); loadAgentBindings(); }
+        } else {
+          const res = await fetch(`${API}/pairing/bindings/${id}/${action}`, { method: 'POST' });
+          if (res.ok) {
+            showToast(`Agent ${action}d`);
+            loadAgentBindings();
+          } else {
+            const err = await res.json().catch(() => ({}));
+            showToast(err.error || `Failed to ${action}`);
+          }
+        }
+      } catch {
+        showToast(`Failed to ${action} agent`);
+      }
+    }
+
     // ═══ Init ═══
     loadConfig();
     loadAutonomy();
@@ -2212,6 +2503,8 @@
     loadChromeProfiles();
     updateSyncStatus();
     loadExtInstalled();
+    loadAddresses();
+    loadAgentBindings();
     // Refresh stats every 10s
     setInterval(loadBehaviorStats, 10000);
   </script>

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tandem-browser
-description: Use Tandem Browser's running MCP server or local API on 127.0.0.1:8765 to inspect, browse, and interact with the user's shared browser safely. Prefer targeted tabs and sessions, use snapshot refs before raw DOM or JS, verify action completion explicitly, and leave durable handoffs instead of retrying blindly.
+description: Use Tandem Browser's MCP server (local agents) or HTTP API (local and remote agents) to inspect, browse, and interact with the user's shared browser safely. Prefer targeted tabs and sessions, use snapshot refs before raw DOM or JS, verify action completion explicitly, and leave durable handoffs instead of retrying blindly.
 homepage: https://github.com/hydro13/tandem-browser
 user-invocable: false
 metadata: {"openclaw":{"emoji":"🚲","requires":{"bins":["curl","node"]}}}
@@ -28,14 +28,31 @@ instead of a sandbox browser, especially for:
 
 ## Connecting to Tandem
 
-## Practical Connection Reality
+Tandem supports agents on the same machine (MCP or HTTP) and on remote machines
+over a private Tailscale network (HTTP only). Both can be active at the same
+time.
+
+### Discovery
+
+A running Tandem instance publishes its own version-matched bootstrap surface.
+This works for both local and remote agents, and does not require repo access:
+
+- `GET /agent` — human-readable bootstrap page
+- `GET /agent/manifest` — machine-readable endpoint manifest with all route families
+- `GET /skill` — version-matched usage guide
+- `GET /agent/version` — version and capability summary
+
+These routes are public (no auth required) and use the request `Host` header,
+so they return correct URLs whether accessed at `localhost:8765` or over
+Tailscale.
+
+### Practical Connection Reality
 
 The conceptual model is simple:
 
 1. Tandem is already running
-2. the agent has repo access
-3. the agent reads this `skill/SKILL.md`
-4. the agent uses MCP or HTTP to talk to the running Tandem instance
+2. the agent discovers Tandem via its bootstrap surface or this skill file
+3. the agent uses MCP or HTTP to talk to the running Tandem instance
 
 Practical notes:
 
@@ -46,7 +63,7 @@ Practical notes:
 - MCP and HTTP are connection layers to Tandem, not substitutes for a running
   Tandem instance
 
-### Option 1: MCP Server (recommended for agents)
+### Option 1: MCP Server (same machine only)
 
 The MCP server exposes 250 tools with full API parity. Add to your MCP client
 configuration (e.g. `~/.claude/settings.json` for Claude Code):
@@ -66,15 +83,18 @@ Start Tandem (`npm start`), and the agent can connect to the running MCP server.
 All MCP tools mirror the HTTP API below, so the same capabilities are available
 through either connection method when the client supports them.
 
-### Option 2: HTTP API
+MCP uses stdio transport and requires the agent to run on the same machine as
+Tandem. Remote MCP is not yet available.
 
-Use direct HTTP when the client can call the local API itself, or when manual
-debugging and shell scripts are the fastest path. Normal Tandem routes require
-the bearer token from `~/.tandem/api-token`.
+### Option 2: HTTP API (local or remote)
+
+Use direct HTTP when the client can call the API itself, or when the agent is
+on a remote machine. Local agents use the token from `~/.tandem/api-token`.
+Remote agents use a binding token obtained through Tandem's pairing flow.
 
 ```bash
-API="http://127.0.0.1:8765"
-TOKEN="$(cat ~/.tandem/api-token)"
+API="http://127.0.0.1:8765"            # or http://<tailscale-ip>:8765 for remote
+TOKEN="$(cat ~/.tandem/api-token)"      # or binding token from pairing
 AUTH_HEADER="Authorization: Bearer $TOKEN"
 JSON_HEADER="Content-Type: application/json"
 

--- a/src/api/routes/bootstrap.ts
+++ b/src/api/routes/bootstrap.ts
@@ -1,0 +1,445 @@
+/**
+ * Bootstrap/discovery routes — agent-facing surface for a running Tandem instance.
+ *
+ * These routes let any agent discover what this Tandem instance supports,
+ * how to pair, and what version-matched capabilities are available.
+ * The bootstrap surface is public (no auth required) because it contains
+ * no sensitive data — only version info, pairing instructions, and capability families.
+ */
+
+import type { Router, Request, Response } from 'express';
+import { app } from 'electron';
+import type { RouteContext } from '../context';
+
+/** Capability families exposed by Tandem, grouped for agent discovery. */
+const CAPABILITY_FAMILIES = [
+  'browser',
+  'tabs',
+  'navigation',
+  'snapshots',
+  'devtools',
+  'network',
+  'sessions',
+  'agents',
+  'content',
+  'media',
+  'extensions',
+  'data',
+  'handoffs',
+  'sidebar',
+  'workspaces',
+  'sync',
+  'pinboards',
+  'previews',
+  'awareness',
+  'clipboard',
+  'security',
+];
+
+export function registerBootstrapRoutes(router: Router, _ctx: RouteContext): void {
+  const getVersion = (): string => {
+    try { return app.getVersion(); } catch { return 'unknown'; }
+  };
+
+  /** Derive base URL from the incoming request's Host header. */
+  const getBaseUrl = (req: Request): string => {
+    const host = req.headers.host ?? 'localhost:8765';
+    return `http://${host}`;
+  };
+
+  // ═══════════════════════════════════════════════
+  // GET /agent — human-readable bootstrap page
+  // ═══════════════════════════════════════════════
+
+  router.get('/agent', (req: Request, res: Response) => {
+    const version = getVersion();
+    const baseUrl = getBaseUrl(req);
+    res.type('text/markdown').send(`# Tandem Browser — Agent Bootstrap
+
+**Version:** ${version}
+**Base URL:** \`${baseUrl}\`
+**Auth:** Bearer token (via pairing or local api-token)
+
+## How to connect
+
+### On the same machine as Tandem
+Read the local API token from \`~/.tandem/api-token\` and use it as:
+\`\`\`
+Authorization: Bearer <token>
+\`\`\`
+
+### On a different machine (Tailscale only)
+Remote connections are supported only over a private Tailscale network.
+Both machines must be members of the same tailnet.
+
+1. The Tandem user generates a one-time setup code in Settings
+2. Exchange the code for a durable token:
+   \`POST ${baseUrl}/pairing/exchange\`
+   with body: \`{ "code": "TDM-XXXX-XXXX", "machineId": "...", "machineName": "...", "agentLabel": "...", "agentType": "..." }\`
+3. Use the returned token as: \`Authorization: Bearer <token>\`
+4. The token is permanent until the user revokes it
+
+Tandem is never exposed to the public internet.
+
+## Using Tandem after connecting
+
+Once you have a Bearer token (from local api-token or from pairing), use the HTTP API:
+\`\`\`
+Authorization: Bearer <your-token>
+\`\`\`
+
+All Tandem capabilities are available as HTTP endpoints. Key starting points:
+
+### Browser status and navigation
+- \`GET ${baseUrl}/status\` — browser ready state, active tab, viewport
+- \`POST ${baseUrl}/navigate\` — navigate to a URL (body: \`{ "url": "..." }\`)
+- \`GET ${baseUrl}/page-content\` — extract page text content
+- \`GET ${baseUrl}/page-html\` — get page HTML
+
+### Tabs
+- \`GET ${baseUrl}/tabs/list\` — list all open tabs
+- \`POST ${baseUrl}/tabs/open\` — open a new tab (body: \`{ "url": "..." }\`)
+- \`POST ${baseUrl}/tabs/close\` — close a tab (body: \`{ "tabId": "..." }\`)
+- \`POST ${baseUrl}/tabs/focus\` — switch to a tab (body: \`{ "tabId": "..." }\`)
+
+### Interaction (use snapshots for reliable element targeting)
+- \`GET ${baseUrl}/snapshot\` — accessibility tree with ref IDs
+- \`POST ${baseUrl}/snapshot/click\` — click element by ref (body: \`{ "ref": "@e1" }\`)
+- \`POST ${baseUrl}/snapshot/fill\` — fill input by ref (body: \`{ "ref": "@e2", "value": "..." }\`)
+- \`POST ${baseUrl}/execute-js\` — run JavaScript in the page
+
+### Screenshots and content
+- \`GET ${baseUrl}/screenshot\` — capture screenshot (returns base64 PNG)
+- \`POST ${baseUrl}/content/extract\` — structured content extraction
+
+### Background tab targeting
+Add \`X-Tab-Id: <tabId>\` header to target a specific tab instead of the active one.
+
+## MCP access
+Tandem also provides an MCP server with 250+ tools. MCP is available for agents running
+on the same machine as Tandem (via stdio transport):
+\`\`\`json
+{
+  "mcpServers": {
+    "tandem": {
+      "command": "node",
+      "args": ["<path-to-tandem>/dist/mcp/server.js"]
+    }
+  }
+}
+\`\`\`
+MCP over network transport is not yet available. Remote agents should use the HTTP API.
+
+## Discovery
+- \`GET ${baseUrl}/agent/manifest\` — full machine-readable manifest with all endpoints (JSON)
+- \`GET ${baseUrl}/agent/version\` — version and capability summary (JSON)
+- \`GET ${baseUrl}/skill\` — version-matched usage guide
+
+## Capability families
+${CAPABILITY_FAMILIES.map(f => `- ${f}`).join('\n')}
+
+## Complete endpoint reference
+See \`GET ${baseUrl}/agent/manifest\` for the full list of 300+ endpoints.
+`);
+  });
+
+  // ═══════════════════════════════════════════════
+  // GET /agent/version — minimal version + capability summary
+  // ═══════════════════════════════════════════════
+
+  router.get('/agent/version', (_req: Request, res: Response) => {
+    res.json({
+      name: 'tandem-browser',
+      version: getVersion(),
+      capabilityFamilies: CAPABILITY_FAMILIES,
+      transports: {
+        http: { available: true, local: true, remote: true },
+        mcp: { available: true, local: true, remote: false, note: 'MCP is available via stdio for agents on the same machine. Remote MCP is not yet supported.' },
+      },
+      authMethods: ['bearer-token'],
+      pairingSupported: true,
+    });
+  });
+
+  // ═══════════════════════════════════════════════
+  // GET /agent/manifest — full machine-readable manifest
+  // ═══════════════════════════════════════════════
+
+  router.get('/agent/manifest', (req: Request, res: Response) => {
+    const version = getVersion();
+    const baseUrl = getBaseUrl(req);
+    res.json({
+      name: 'tandem-browser',
+      version,
+      baseUrl,
+      transports: {
+        http: { available: true, local: true, remote: true },
+        mcp: { available: true, local: true, remote: false, note: 'MCP via stdio only. Remote MCP not yet supported.' },
+      },
+      authMethods: ['bearer-token'],
+      pairingSupported: true,
+      pairing: {
+        setupCodeFormat: 'TDM-XXXX-XXXX',
+        setupCodeTtlSeconds: 300,
+        exchangeEndpoint: '/pairing/exchange',
+        whoamiEndpoint: '/pairing/whoami',
+        tokenPrefix: 'tdm_ast_',
+      },
+      capabilityFamilies: CAPABILITY_FAMILIES,
+      endpoints: {
+        bootstrap: {
+          agent: { method: 'GET', path: '/agent', description: 'Human-readable bootstrap page' },
+          version: { method: 'GET', path: '/agent/version', description: 'Version and capability summary' },
+          manifest: { method: 'GET', path: '/agent/manifest', description: 'This manifest' },
+          skill: { method: 'GET', path: '/skill', description: 'Version-matched usage guide' },
+        },
+        pairing: {
+          generateCode: { method: 'POST', path: '/pairing/setup-code', description: 'Generate one-time setup code', auth: 'required' },
+          activeCode: { method: 'GET', path: '/pairing/setup-code/active', description: 'Get active setup code', auth: 'required' },
+          exchange: { method: 'POST', path: '/pairing/exchange', description: 'Exchange setup code for durable token', auth: 'none' },
+          whoami: { method: 'GET', path: '/pairing/whoami', description: 'Validate token and return binding info', auth: 'binding-token' },
+          listBindings: { method: 'GET', path: '/pairing/bindings', description: 'List connected agents', auth: 'required' },
+          pauseBinding: { method: 'POST', path: '/pairing/bindings/:id/pause', description: 'Pause a binding', auth: 'required' },
+          resumeBinding: { method: 'POST', path: '/pairing/bindings/:id/resume', description: 'Resume a paused binding', auth: 'required' },
+          revokeBinding: { method: 'POST', path: '/pairing/bindings/:id/revoke', description: 'Revoke a binding', auth: 'required' },
+          removeBinding: { method: 'DELETE', path: '/pairing/bindings/:id', description: 'Remove binding from active list', auth: 'required' },
+        },
+        browser: {
+          status: { method: 'GET', path: '/status', description: 'Browser ready state, active tab, viewport', auth: 'none' },
+          navigate: { method: 'POST', path: '/navigate', description: 'Navigate to URL' },
+          pageContent: { method: 'GET', path: '/page-content', description: 'Extract page text content' },
+          pageHtml: { method: 'GET', path: '/page-html', description: 'Get page HTML' },
+          screenshot: { method: 'GET', path: '/screenshot', description: 'Capture screenshot (base64 PNG)' },
+          executeJs: { method: 'POST', path: '/execute-js', description: 'Run JavaScript in the page' },
+          click: { method: 'POST', path: '/click', description: 'Click element' },
+          type: { method: 'POST', path: '/type', description: 'Type text' },
+          scroll: { method: 'POST', path: '/scroll', description: 'Scroll page' },
+          pressKey: { method: 'POST', path: '/press-key', description: 'Press key' },
+          pressKeyCombo: { method: 'POST', path: '/press-key-combo', description: 'Press key combination' },
+          wait: { method: 'POST', path: '/wait', description: 'Wait for page element' },
+          links: { method: 'GET', path: '/links', description: 'Get all page links' },
+          forms: { method: 'GET', path: '/forms', description: 'Get all page forms' },
+          cookies: { method: 'GET', path: '/cookies', description: 'Get page cookies' },
+          reload: { method: 'POST', path: '/reload', description: 'Reload page' },
+          goBack: { method: 'POST', path: '/go-back', description: 'Navigate back' },
+          goForward: { method: 'POST', path: '/go-forward', description: 'Navigate forward' },
+        },
+        tabs: {
+          list: { method: 'GET', path: '/tabs/list', description: 'List all open tabs' },
+          open: { method: 'POST', path: '/tabs/open', description: 'Open new tab' },
+          close: { method: 'POST', path: '/tabs/close', description: 'Close tab' },
+          focus: { method: 'POST', path: '/tabs/focus', description: 'Switch to tab' },
+          setEmoji: { method: 'POST', path: '/tabs/:id/emoji', description: 'Set tab emoji badge' },
+          clearEmoji: { method: 'DELETE', path: '/tabs/:id/emoji', description: 'Remove tab emoji badge' },
+        },
+        snapshots: {
+          get: { method: 'GET', path: '/snapshot', description: 'Accessibility tree with element refs' },
+          click: { method: 'POST', path: '/snapshot/click', description: 'Click element by @ref' },
+          fill: { method: 'POST', path: '/snapshot/fill', description: 'Fill input by @ref' },
+          text: { method: 'GET', path: '/snapshot/text', description: 'Get text of element by @ref' },
+        },
+        find: {
+          find: { method: 'POST', path: '/find', description: 'Find element by role/text/label' },
+          findAll: { method: 'POST', path: '/find/all', description: 'Find all matching elements' },
+          findClick: { method: 'POST', path: '/find/click', description: 'Find and click element' },
+          findFill: { method: 'POST', path: '/find/fill', description: 'Find and fill element' },
+        },
+        devtools: {
+          status: { method: 'GET', path: '/devtools/status', description: 'DevTools connection status' },
+          console: { method: 'GET', path: '/devtools/console', description: 'Console log entries' },
+          consoleErrors: { method: 'GET', path: '/devtools/console/errors', description: 'Console errors only' },
+          network: { method: 'GET', path: '/devtools/network', description: 'Network requests via CDP' },
+          domQuery: { method: 'POST', path: '/devtools/dom/query', description: 'Query DOM by CSS selector' },
+          domXpath: { method: 'POST', path: '/devtools/dom/xpath', description: 'Query DOM by XPath' },
+          evaluate: { method: 'POST', path: '/devtools/evaluate', description: 'Evaluate JS via CDP' },
+          cdp: { method: 'POST', path: '/devtools/cdp', description: 'Raw CDP command' },
+          storage: { method: 'GET', path: '/devtools/storage', description: 'Cookies, localStorage, sessionStorage' },
+          performance: { method: 'GET', path: '/devtools/performance', description: 'Performance metrics' },
+        },
+        network: {
+          log: { method: 'GET', path: '/network/log', description: 'Network request log' },
+          domains: { method: 'GET', path: '/network/domains', description: 'Request domains' },
+          apis: { method: 'GET', path: '/network/apis', description: 'Detected API endpoints' },
+          har: { method: 'GET', path: '/network/har', description: 'Export as HAR' },
+          mock: { method: 'POST', path: '/network/mock', description: 'Add mock rule' },
+          unmock: { method: 'POST', path: '/network/unmock', description: 'Remove mock rule' },
+          mocks: { method: 'GET', path: '/network/mocks', description: 'List active mocks' },
+        },
+        sessions: {
+          list: { method: 'GET', path: '/sessions/list', description: 'List sessions' },
+          create: { method: 'POST', path: '/sessions/create', description: 'Create session' },
+          switch: { method: 'POST', path: '/sessions/switch', description: 'Switch session' },
+          destroy: { method: 'POST', path: '/sessions/destroy', description: 'Destroy session' },
+          fetch: { method: 'POST', path: '/sessions/fetch', description: 'Fetch with session credentials' },
+        },
+        content: {
+          extract: { method: 'POST', path: '/content/extract', description: 'Structured content extraction' },
+          extractUrl: { method: 'POST', path: '/content/extract/url', description: 'Extract content from URL' },
+        },
+        media: {
+          screenshotAnnotated: { method: 'GET', path: '/screenshot/annotated', description: 'Get annotated screenshot' },
+          captureAnnotated: { method: 'POST', path: '/screenshot/annotated', description: 'Capture annotated screenshot' },
+          captureApplication: { method: 'POST', path: '/screenshot/application', description: 'Capture application window' },
+          captureRegion: { method: 'POST', path: '/screenshot/region', description: 'Capture region' },
+          screenshots: { method: 'GET', path: '/screenshots', description: 'List saved screenshots' },
+          audioStatus: { method: 'GET', path: '/audio/status', description: 'Audio recording status' },
+          audioStart: { method: 'POST', path: '/audio/start', description: 'Start audio recording' },
+          audioStop: { method: 'POST', path: '/audio/stop', description: 'Stop audio recording' },
+        },
+        agents: {
+          tasks: { method: 'GET', path: '/tasks', description: 'List tasks' },
+          createTask: { method: 'POST', path: '/tasks', description: 'Create task' },
+          getTask: { method: 'GET', path: '/tasks/:id', description: 'Get task details' },
+          emergencyStop: { method: 'POST', path: '/emergency-stop', description: 'Stop all running tasks' },
+          autonomy: { method: 'GET', path: '/autonomy', description: 'Agent autonomy settings' },
+          updateAutonomy: { method: 'PATCH', path: '/autonomy', description: 'Update autonomy' },
+          tabLocks: { method: 'GET', path: '/tab-locks', description: 'List tab locks' },
+        },
+        handoffs: {
+          list: { method: 'GET', path: '/handoffs', description: 'List handoffs' },
+          create: { method: 'POST', path: '/handoffs', description: 'Create handoff' },
+          get: { method: 'GET', path: '/handoffs/:id', description: 'Get handoff details' },
+          approve: { method: 'POST', path: '/handoffs/:id/approve', description: 'Approve handoff' },
+          reject: { method: 'POST', path: '/handoffs/:id/reject', description: 'Reject handoff' },
+          resolve: { method: 'POST', path: '/handoffs/:id/resolve', description: 'Resolve handoff' },
+        },
+        awareness: {
+          digest: { method: 'GET', path: '/awareness/digest', description: 'Smart activity summary' },
+          focus: { method: 'GET', path: '/awareness/focus', description: 'Current activity type' },
+          activityLog: { method: 'GET', path: '/activity-log', description: 'Raw activity log' },
+          activeTabContext: { method: 'GET', path: '/active-tab/context', description: 'Active tab context' },
+          eventsRecent: { method: 'GET', path: '/events/recent', description: 'Recent events' },
+        },
+        clipboard: {
+          read: { method: 'GET', path: '/clipboard', description: 'Read clipboard' },
+          writeText: { method: 'POST', path: '/clipboard/text', description: 'Set clipboard text' },
+          writeImage: { method: 'POST', path: '/clipboard/image', description: 'Set clipboard image' },
+        },
+        bookmarks: {
+          list: { method: 'GET', path: '/bookmarks', description: 'List bookmarks' },
+          add: { method: 'POST', path: '/bookmarks/add', description: 'Add bookmark' },
+          search: { method: 'GET', path: '/bookmarks/search', description: 'Search bookmarks' },
+        },
+        history: {
+          list: { method: 'GET', path: '/history', description: 'Browsing history' },
+          search: { method: 'GET', path: '/history/search', description: 'Search history' },
+        },
+        workspaces: {
+          list: { method: 'GET', path: '/workspaces', description: 'List workspaces' },
+          create: { method: 'POST', path: '/workspaces', description: 'Create workspace' },
+          activate: { method: 'POST', path: '/workspaces/:id/activate', description: 'Activate workspace' },
+        },
+        pinboards: {
+          list: { method: 'GET', path: '/pinboards', description: 'List pinboards' },
+          create: { method: 'POST', path: '/pinboards', description: 'Create pinboard' },
+          get: { method: 'GET', path: '/pinboards/:id', description: 'Get pinboard' },
+          items: { method: 'GET', path: '/pinboards/:id/items', description: 'Get pinboard items' },
+          addItem: { method: 'POST', path: '/pinboards/:id/items', description: 'Add item to pinboard' },
+        },
+        previews: {
+          list: { method: 'GET', path: '/previews', description: 'List previews' },
+          create: { method: 'POST', path: '/preview', description: 'Create live HTML preview' },
+          get: { method: 'GET', path: '/preview/:id', description: 'View preview' },
+          update: { method: 'PUT', path: '/preview/:id', description: 'Update preview (live refresh)' },
+          delete: { method: 'DELETE', path: '/preview/:id', description: 'Delete preview' },
+        },
+        config: {
+          get: { method: 'GET', path: '/config', description: 'Get full configuration' },
+          update: { method: 'PATCH', path: '/config', description: 'Update configuration' },
+        },
+        data: {
+          export: { method: 'GET', path: '/data/export', description: 'Export all user data' },
+          import: { method: 'POST', path: '/data/import', description: 'Import data' },
+        },
+        headless: {
+          open: { method: 'POST', path: '/headless/open', description: 'Open URL in headless' },
+          content: { method: 'GET', path: '/headless/content', description: 'Get headless page content' },
+          status: { method: 'GET', path: '/headless/status', description: 'Headless status' },
+          close: { method: 'POST', path: '/headless/close', description: 'Close headless' },
+        },
+        watch: {
+          add: { method: 'POST', path: '/watch/add', description: 'Watch a page for changes' },
+          list: { method: 'GET', path: '/watch/list', description: 'List watched pages' },
+          check: { method: 'POST', path: '/watch/check', description: 'Check watched page now' },
+          remove: { method: 'DELETE', path: '/watch/remove', description: 'Stop watching' },
+          liveWs: { method: 'WS', path: '/watch/live', description: 'WebSocket stream of watch events' },
+        },
+        workflows: {
+          list: { method: 'GET', path: '/workflows', description: 'List workflows' },
+          create: { method: 'POST', path: '/workflows', description: 'Create workflow' },
+          run: { method: 'POST', path: '/workflow/run', description: 'Run workflow' },
+          status: { method: 'GET', path: '/workflow/status/:executionId', description: 'Execution status' },
+          stop: { method: 'POST', path: '/workflow/stop', description: 'Stop workflow' },
+        },
+        siteMemory: {
+          sites: { method: 'GET', path: '/memory/sites', description: 'List sites with stored memory' },
+          site: { method: 'GET', path: '/memory/site/:domain', description: 'Get memory for domain' },
+          search: { method: 'POST', path: '/memory/search', description: 'Search across site memory' },
+        },
+        auth: {
+          states: { method: 'GET', path: '/auth/states', description: 'Detected auth states' },
+          state: { method: 'GET', path: '/auth/state/:domain', description: 'Auth state for domain' },
+          check: { method: 'POST', path: '/auth/check', description: 'Check for login form' },
+        },
+        localOnly: {
+          _note: 'These endpoints require local context (Electron window, extension origin, or local filesystem access) and are not available to remote agents.',
+          pickFolder: { method: 'POST', path: '/dialog/pick-folder', description: 'Open native folder picker (requires local window)' },
+          extensionNativeMessage: { method: 'POST', path: '/extensions/native-message', description: 'Extension native messaging (requires chrome-extension:// origin)' },
+          extensionNativeMessageWs: { method: 'WS', path: '/extensions/native-message/ws', description: 'Extension native messaging WebSocket (requires chrome-extension:// origin)' },
+        },
+        remoteNotes: {
+          _note: 'Some endpoints return local filesystem paths in response bodies (e.g. screenshot save path). These operations execute on the Tandem host and succeed remotely, but the returned path is only meaningful on the Tandem machine. Use GET /screenshot (without ?save) to receive screenshot data directly.',
+        },
+      },
+    });
+  });
+
+  // ═══════════════════════════════════════════════
+  // GET /skill — version-matched skill/instructions
+  // ═══════════════════════════════════════════════
+
+  router.get('/skill', (req: Request, res: Response) => {
+    const version = getVersion();
+    const baseUrl = getBaseUrl(req);
+    res.type('text/markdown').send(`# Tandem Browser Skill — v${version}
+
+Tandem Browser is a live human-AI browser. Use its API at \`${baseUrl}\`
+to inspect, browse, and interact with the user's real browser context.
+
+## Key principles
+- Prefer targeted tabs and sessions over global operations
+- Use snapshot refs (\`GET ${baseUrl}/snapshot\`) before raw DOM or JS — snapshots give you
+  stable element references like \`@e1\`, \`@e2\` that you can click or fill
+- Verify action completion explicitly
+- Leave durable handoffs instead of retrying blindly
+
+## Auth
+All requests require: \`Authorization: Bearer <your-token>\`
+
+## Quick start workflow
+1. \`GET ${baseUrl}/status\` — check Tandem is ready, see active tab
+2. \`GET ${baseUrl}/snapshot\` — get accessibility tree with clickable refs
+3. \`POST ${baseUrl}/snapshot/click\` with \`{ "ref": "@e1" }\` — click an element
+4. \`POST ${baseUrl}/snapshot/fill\` with \`{ "ref": "@e2", "value": "text" }\` — type into an input
+5. \`GET ${baseUrl}/page-content\` — read page text
+6. \`POST ${baseUrl}/navigate\` with \`{ "url": "https://..." }\` — go to a URL
+
+## Tab management
+- \`GET ${baseUrl}/tabs/list\` — see all tabs
+- \`POST ${baseUrl}/tabs/open\` with \`{ "url": "..." }\` — open new tab
+- \`POST ${baseUrl}/tabs/focus\` with \`{ "tabId": "..." }\` — switch tabs
+- Use \`X-Tab-Id: <id>\` header to target a background tab
+
+## Screenshots
+- \`GET ${baseUrl}/screenshot\` — capture the visible page (base64 PNG)
+
+## MCP
+MCP (250+ tools) is available for agents on the same machine via stdio transport.
+Remote agents should use the HTTP API — it provides the same capabilities.
+
+## Full reference
+\`GET ${baseUrl}/agent/manifest\` returns all 300+ endpoints as structured JSON.
+\`GET ${baseUrl}/agent\` has a more detailed getting-started guide.
+`);
+  });
+}

--- a/src/api/routes/misc.ts
+++ b/src/api/routes/misc.ts
@@ -92,6 +92,13 @@ export function registerMiscRoutes(router: Router, ctx: RouteContext): void {
     try {
       const { dialog, BrowserWindow } = require('electron');
       const win = BrowserWindow.getFocusedWindow() || BrowserWindow.getAllWindows()[0];
+      if (!win) {
+        res.status(422).json({
+          error: 'Folder picker requires a local Tandem window. This endpoint is not available for remote agents.',
+          localOnly: true,
+        });
+        return;
+      }
       const result = await dialog.showOpenDialog(win, {
         properties: ['openDirectory', 'createDirectory'],
         title: 'Choose screenshot folder',

--- a/src/api/routes/pairing.ts
+++ b/src/api/routes/pairing.ts
@@ -1,0 +1,252 @@
+/**
+ * Pairing routes — setup code generation, exchange, and binding management.
+ *
+ * Public routes (no auth): /pairing/exchange
+ * Binding-token routes: /pairing/whoami
+ * Protected routes (local api-token): everything else
+ */
+
+import type { Router, Request, Response } from 'express';
+import os from 'os';
+import type { RouteContext } from '../context';
+import { createRateLimitMiddleware } from '../rate-limit';
+import { handleRouteError } from '../../utils/errors';
+import { API_PORT } from '../../utils/constants';
+
+const exchangeRateLimit = createRateLimitMiddleware({
+  bucket: 'pairing-exchange',
+  windowMs: 60_000,
+  max: 10,
+  message: 'Too many pairing attempts. Retry shortly.',
+});
+
+/** Detect the best connection addresses for local and Tailscale modes. */
+export function detectAddresses(): {
+  local: { address: string; hostname: string };
+  tailscale: { available: boolean; address: string | null; hostname: string | null };
+} {
+  const hostname = os.hostname();
+  const local = { address: `http://127.0.0.1:${API_PORT}`, hostname };
+
+  // Scan network interfaces for Tailscale (100.x.y.z CGNAT range)
+  const interfaces = os.networkInterfaces();
+  let tailscaleIp: string | null = null;
+
+  for (const [_name, addrs] of Object.entries(interfaces)) {
+    if (!addrs) continue;
+    for (const addr of addrs) {
+      if (addr.family === 'IPv4' && !addr.internal && addr.address.startsWith('100.')) {
+        tailscaleIp = addr.address;
+        break;
+      }
+    }
+    if (tailscaleIp) break;
+  }
+
+  return {
+    local,
+    tailscale: {
+      available: tailscaleIp !== null,
+      address: tailscaleIp ? `http://${tailscaleIp}:${API_PORT}` : null,
+      hostname: tailscaleIp ? `${hostname} (${tailscaleIp})` : null,
+    },
+  };
+}
+
+export function registerPairingRoutes(router: Router, ctx: RouteContext): void {
+
+  // ═══════════════════════════════════════════════
+  // GET /pairing/addresses — detect local + Tailscale addresses
+  // ═══════════════════════════════════════════════
+
+  router.get('/pairing/addresses', (_req: Request, res: Response) => {
+    res.json(detectAddresses());
+  });
+
+  // ═══════════════════════════════════════════════
+  // POST /pairing/setup-code — generate one-time code
+  // ═══════════════════════════════════════════════
+
+  router.post('/pairing/setup-code', (_req: Request, res: Response) => {
+    try {
+      const setupCode = ctx.pairingManager.generateSetupCode();
+      res.json({
+        code: setupCode.code,
+        expiresAt: new Date(setupCode.expiresAt).toISOString(),
+        ttlSeconds: Math.max(0, Math.floor((setupCode.expiresAt - Date.now()) / 1000)),
+      });
+    } catch (e) {
+      if (e instanceof Error && e.message.includes('Too many')) {
+        res.status(429).json({ error: e.message });
+        return;
+      }
+      handleRouteError(res, e);
+    }
+  });
+
+  // ═══════════════════════════════════════════════
+  // GET /pairing/setup-code/active — get current active code
+  // ═══════════════════════════════════════════════
+
+  router.get('/pairing/setup-code/active', (_req: Request, res: Response) => {
+    const active = ctx.pairingManager.getActiveSetupCode();
+    if (!active) {
+      res.json(null);
+      return;
+    }
+    res.json({
+      code: active.code,
+      expiresAt: new Date(active.expiresAt).toISOString(),
+      ttlSeconds: Math.max(0, Math.floor((active.expiresAt - Date.now()) / 1000)),
+    });
+  });
+
+  // ═══════════════════════════════════════════════
+  // POST /pairing/exchange — exchange setup code for token (PUBLIC)
+  // ═══════════════════════════════════════════════
+
+  router.post('/pairing/exchange', exchangeRateLimit, (req: Request, res: Response) => {
+    try {
+      const { code, machineId, machineName, agentLabel, agentType, bindingKind, transport } = req.body;
+
+      if (!code || typeof code !== 'string') {
+        res.status(400).json({ error: 'code is required' });
+        return;
+      }
+      if (!machineId || typeof machineId !== 'string') {
+        res.status(400).json({ error: 'machineId is required' });
+        return;
+      }
+      if (!machineName || typeof machineName !== 'string') {
+        res.status(400).json({ error: 'machineName is required' });
+        return;
+      }
+      if (!agentLabel || typeof agentLabel !== 'string') {
+        res.status(400).json({ error: 'agentLabel is required' });
+        return;
+      }
+      if (!agentType || typeof agentType !== 'string') {
+        res.status(400).json({ error: 'agentType is required' });
+        return;
+      }
+
+      // Validate setup code format
+      const normalizedCode = code.toUpperCase().trim();
+      if (!/^TDM-[A-Z0-9]{4}-[A-Z0-9]{4}$/.test(normalizedCode)) {
+        res.status(400).json({ error: 'Invalid setup code format. Expected TDM-XXXX-XXXX' });
+        return;
+      }
+
+      const sourceIp = req.socket.remoteAddress ?? null;
+      const result = ctx.pairingManager.exchangeSetupCode({
+        code: normalizedCode,
+        machineId,
+        machineName,
+        agentLabel,
+        agentType,
+        bindingKind: bindingKind === 'remote' ? 'remote' : 'local',
+        transport: Array.isArray(transport) ? transport.filter((t: string) => t === 'http' || t === 'mcp') : ['http'],
+      }, sourceIp);
+
+      res.json({
+        token: result.token,
+        binding: {
+          id: result.binding.id,
+          agentLabel: result.binding.agentLabel,
+          agentType: result.binding.agentType,
+          bindingKind: result.binding.bindingKind,
+          state: result.binding.state,
+        },
+      });
+    } catch (e) {
+      if (e instanceof Error) {
+        if (e.message.includes('Invalid setup code') || e.message.includes('already been used') || e.message.includes('expired')) {
+          res.status(400).json({ error: e.message });
+          return;
+        }
+      }
+      handleRouteError(res, e);
+    }
+  });
+
+  // ═══════════════════════════════════════════════
+  // GET /pairing/whoami — validate token, return binding info
+  // ═══════════════════════════════════════════════
+
+  router.get('/pairing/whoami', (req: Request, res: Response) => {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      res.status(401).json({ error: 'Authorization: Bearer <token> required' });
+      return;
+    }
+
+    const token = authHeader.slice(7).trim();
+    const binding = ctx.pairingManager.whoami(token);
+    if (!binding) {
+      res.status(401).json({ error: 'Invalid or inactive binding token' });
+      return;
+    }
+
+    res.json(binding);
+  });
+
+  // ═══════════════════════════════════════════════
+  // GET /pairing/bindings — list all bindings
+  // ═══════════════════════════════════════════════
+
+  router.get('/pairing/bindings', (_req: Request, res: Response) => {
+    res.json(ctx.pairingManager.listBindings());
+  });
+
+  // ═══════════════════════════════════════════════
+  // POST /pairing/bindings/:id/pause
+  // ═══════════════════════════════════════════════
+
+  router.post('/pairing/bindings/:id/pause', (req: Request, res: Response) => {
+    const result = ctx.pairingManager.pauseBinding(req.params.id as string);
+    if (!result) {
+      res.status(404).json({ error: 'Binding not found or not in paired state' });
+      return;
+    }
+    res.json({ success: true, state: result.state });
+  });
+
+  // ═══════════════════════════════════════════════
+  // POST /pairing/bindings/:id/resume
+  // ═══════════════════════════════════════════════
+
+  router.post('/pairing/bindings/:id/resume', (req: Request, res: Response) => {
+    const result = ctx.pairingManager.resumeBinding(req.params.id as string);
+    if (!result) {
+      res.status(404).json({ error: 'Binding not found or not in paused state' });
+      return;
+    }
+    res.json({ success: true, state: result.state });
+  });
+
+  // ═══════════════════════════════════════════════
+  // POST /pairing/bindings/:id/revoke
+  // ═══════════════════════════════════════════════
+
+  router.post('/pairing/bindings/:id/revoke', (req: Request, res: Response) => {
+    const result = ctx.pairingManager.revokeBinding(req.params.id as string);
+    if (!result) {
+      res.status(404).json({ error: 'Binding not found or already revoked' });
+      return;
+    }
+    res.json({ success: true, state: result.state });
+  });
+
+  // ═══════════════════════════════════════════════
+  // DELETE /pairing/bindings/:id — remove from active list
+  // ═══════════════════════════════════════════════
+
+  router.delete('/pairing/bindings/:id', (req: Request, res: Response) => {
+    const result = ctx.pairingManager.removeBinding(req.params.id as string);
+    if (!result) {
+      res.status(404).json({ error: 'Binding not found' });
+      return;
+    }
+    res.json({ success: true });
+  });
+}

--- a/src/api/routes/previews.ts
+++ b/src/api/routes/previews.ts
@@ -131,6 +131,12 @@ function injectLiveReload(html: string, id: string, version: number): string {
  * @param router - Express router to attach routes to
  * @param ctx - shared manager registry and main BrowserWindow
  */
+/** Derive base URL from the incoming request's Host header. */
+function getBaseUrl(req: Request): string {
+  const host = req.headers.host ?? 'localhost:8765';
+  return `http://${host}`;
+}
+
 export function registerPreviewRoutes(router: Router, ctx: RouteContext): void {
 
   // List all previews
@@ -174,7 +180,7 @@ export function registerPreviewRoutes(router: Router, ctx: RouteContext): void {
       writePreview(preview);
       log.info(`Preview created: ${id}`);
 
-      const url = `http://127.0.0.1:8765/preview/${id}`;
+      const url = `${getBaseUrl(req)}/preview/${id}`;
 
       // Open in a new tab by default (openTab defaults to true)
       if (openTab !== false) {
@@ -220,7 +226,7 @@ export function registerPreviewRoutes(router: Router, ctx: RouteContext): void {
       writePreview(updated);
       log.info(`Preview updated: ${id} (v${updated.version})`);
 
-      res.json({ ok: true, id, version: updated.version, url: `http://127.0.0.1:8765/preview/${id}` });
+      res.json({ ok: true, id, version: updated.version, url: `${getBaseUrl(req)}/preview/${id}` });
     } catch (e) {
       handleRouteError(res, e);
     }
@@ -253,7 +259,7 @@ export function registerPreviewRoutes(router: Router, ctx: RouteContext): void {
         res.status(404).send(`<!DOCTYPE html><html><body>
           <h1>Preview not found</h1>
           <p>No preview with id <code>${escapeHtml(id)}</code> exists.</p>
-          <p><a href="http://127.0.0.1:8765/previews">View all previews</a></p>
+          <p><a href="/previews">View all previews</a></p>
         </body></html>`);
         return;
       }

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -30,6 +30,8 @@ import { registerPinboardRoutes } from './routes/pinboards';
 import { registerPreviewRoutes } from './routes/previews';
 import { registerAwarenessRoutes } from './routes/awareness';
 import { registerClipboardRoutes } from './routes/clipboard';
+import { registerBootstrapRoutes } from './routes/bootstrap';
+import { registerPairingRoutes } from './routes/pairing';
 import { registerSecurityRoutes } from '../security/routes';
 import { nmProxy, TRUSTED_EXTENSION_PROXY_PATHS } from '../extensions/nm-proxy';
 import { WatchLiveWebSocket } from '../watch/live-ws';
@@ -38,7 +40,16 @@ import { createLogger } from '../utils/logger';
 import { createRateLimitMiddleware } from './rate-limit';
 
 const log = createLogger('TandemAPI');
-const PUBLIC_ROUTE_PATHS = new Set<string>(['/status', '/google-photos/oauth/callback']);
+const PUBLIC_ROUTE_PATHS = new Set<string>([
+  '/status',
+  '/google-photos/oauth/callback',
+  '/agent',
+  '/agent/version',
+  '/agent/manifest',
+  '/skill',
+  '/pairing/exchange',
+  '/pairing/whoami',
+]);
 // Preview routes are public — they serve HTML pages that must be openable in a browser tab
 // without requiring a Bearer token in the request headers.
 const PUBLIC_ROUTE_PREFIXES = ['/preview/', '/previews'];
@@ -165,6 +176,12 @@ export class TandemAPI {
     }
   }
 
+  /** Check if a token is a valid binding token from a paired agent. */
+  private isBindingTokenValid(token: string): boolean {
+    if (!token.startsWith('tdm_ast_')) return false;
+    return this.registry.pairingManager.validateToken(token) !== null;
+  }
+
   /** Timing-safe comparison of a candidate token against the stored auth token */
   private isTokenValid(token: string): boolean {
     try {
@@ -201,7 +218,8 @@ export class TandemAPI {
 
   private authorizeWatchLiveRequest(req: http.IncomingMessage): boolean {
     const token = this.getWebSocketToken(req);
-    return token ? this.isTokenValid(token) : false;
+    if (!token) return false;
+    return this.isTokenValid(token) || this.isBindingTokenValid(token);
   }
 
   /** Shared validator for extension-authenticated HTTP and WebSocket bridges. */
@@ -341,6 +359,11 @@ export class TandemAPI {
       return { kind: 'local-automation', authMode: 'token', origin, remoteAddress, extensionId: null };
     }
 
+    // Check binding tokens from paired agents
+    if (bearerToken && this.isBindingTokenValid(bearerToken)) {
+      return { kind: 'local-automation', authMode: 'token', origin, remoteAddress, extensionId: null };
+    }
+
     if (
       authMode === 'trusted-extension'
       && extensionId
@@ -463,6 +486,8 @@ export class TandemAPI {
     registerPreviewRoutes(router, ctx);
     registerAwarenessRoutes(router, ctx);
     registerClipboardRoutes(router, ctx);
+    registerBootstrapRoutes(router, ctx);
+    registerPairingRoutes(router, ctx);
 
     // Native messaging proxy: route extension connectNative/sendNativeMessage
     // through Tandem's API since Electron 40 doesn't support them natively.
@@ -470,8 +495,11 @@ export class TandemAPI {
   }
 
   async start(): Promise<void> {
+    // Default: 0.0.0.0 (all interfaces — supports both local and Tailscale remote).
+    // Existing installs with 127.0.0.1 are auto-migrated to 0.0.0.0 on config load.
+    const listenHost = this.registry.configManager.getConfig().general?.apiListenHost ?? '0.0.0.0';
     return new Promise((resolve) => {
-      this.server = this.app.listen(this.port, '127.0.0.1', () => {
+      this.server = this.app.listen(this.port, listenHost, () => {
         if (this.server) {
           this.watchLiveWebSocket?.close();
           this.watchLiveWebSocket = new WatchLiveWebSocket(this.server, this.registry.watchManager, {

--- a/src/api/tests/helpers.ts
+++ b/src/api/tests/helpers.ts
@@ -667,6 +667,25 @@ export function createMockContext(): RouteContext {
       writeImage: vi.fn(),
       saveAs: vi.fn().mockReturnValue({ path: '/tmp/test.png', size: 1024 }),
     } as any,
+
+    // ── pairingManager ─────────────────────────
+    pairingManager: {
+      generateSetupCode: vi.fn().mockReturnValue({ code: 'TDM-TEST-CODE', createdAt: Date.now(), expiresAt: Date.now() + 300_000, consumed: false }),
+      getActiveSetupCode: vi.fn().mockReturnValue(null),
+      exchangeSetupCode: vi.fn().mockReturnValue({ token: 'tdm_ast_test', binding: { id: 'b1', state: 'paired' } }),
+      validateToken: vi.fn().mockReturnValue(null),
+      listBindings: vi.fn().mockReturnValue([]),
+      getBinding: vi.fn().mockReturnValue(null),
+      pauseBinding: vi.fn().mockReturnValue(null),
+      resumeBinding: vi.fn().mockReturnValue(null),
+      revokeBinding: vi.fn().mockReturnValue(null),
+      removeBinding: vi.fn().mockReturnValue(false),
+      whoami: vi.fn().mockReturnValue(null),
+      getBindingEvents: vi.fn().mockReturnValue([]),
+      destroy: vi.fn(),
+      on: vi.fn(),
+      emit: vi.fn(),
+    } as any,
   };
 
   return ctx;

--- a/src/api/tests/routes/bootstrap.test.ts
+++ b/src/api/tests/routes/bootstrap.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+
+vi.mock('electron', () => ({
+  BrowserWindow: vi.fn(),
+  app: { getVersion: () => '0.73.0' },
+  session: {},
+  webContents: {
+    fromId: vi.fn(),
+    getAllWebContents: vi.fn().mockReturnValue([]),
+  },
+}));
+
+import { registerBootstrapRoutes } from '../../routes/bootstrap';
+import { createMockContext, createTestApp } from '../helpers';
+import type { RouteContext } from '../../context';
+
+describe('Bootstrap Routes', () => {
+  let ctx: RouteContext;
+  let app: ReturnType<typeof createTestApp>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ctx = createMockContext();
+    app = createTestApp(registerBootstrapRoutes, ctx);
+  });
+
+  describe('GET /agent', () => {
+    it('returns markdown bootstrap page', async () => {
+      const res = await request(app).get('/agent');
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('text/markdown');
+      expect(res.text).toContain('Tandem Browser');
+      expect(res.text).toContain('TDM-XXXX-XXXX');
+    });
+
+    it('includes version in bootstrap page', async () => {
+      const res = await request(app).get('/agent');
+      expect(res.text).toContain('0.73.0');
+    });
+
+    it('uses Host header for base URL', async () => {
+      const res = await request(app).get('/agent').set('Host', '100.64.0.1:8765');
+      expect(res.text).toContain('http://100.64.0.1:8765');
+    });
+
+    it('mentions Tailscale-only for remote', async () => {
+      const res = await request(app).get('/agent');
+      expect(res.text).toContain('Tailscale');
+      expect(res.text).toContain('never exposed to the public internet');
+    });
+  });
+
+  describe('GET /agent/version', () => {
+    it('returns version and capability info', async () => {
+      const res = await request(app).get('/agent/version');
+      expect(res.status).toBe(200);
+      expect(res.body.name).toBe('tandem-browser');
+      expect(res.body.version).toBe('0.73.0');
+      expect(res.body.capabilityFamilies).toContain('browser');
+      expect(res.body.transports.http.available).toBe(true);
+      expect(res.body.transports.http.remote).toBe(true);
+      expect(res.body.transports.mcp.available).toBe(true);
+      expect(res.body.transports.mcp.remote).toBe(false);
+      expect(res.body.pairingSupported).toBe(true);
+    });
+  });
+
+  describe('GET /agent/manifest', () => {
+    it('returns full manifest', async () => {
+      const res = await request(app).get('/agent/manifest');
+      expect(res.status).toBe(200);
+      expect(res.body.name).toBe('tandem-browser');
+      expect(res.body.pairing.setupCodeFormat).toBe('TDM-XXXX-XXXX');
+      expect(res.body.pairing.exchangeEndpoint).toBe('/pairing/exchange');
+      expect(res.body.endpoints.bootstrap).toBeDefined();
+      expect(res.body.endpoints.pairing).toBeDefined();
+    });
+
+    it('uses Host header for baseUrl', async () => {
+      const res = await request(app).get('/agent/manifest').set('Host', '100.64.0.1:8765');
+      expect(res.body.baseUrl).toBe('http://100.64.0.1:8765');
+    });
+
+    it('includes major endpoint families for remote discovery', async () => {
+      const res = await request(app).get('/agent/manifest');
+      const families = Object.keys(res.body.endpoints);
+      expect(families).toContain('browser');
+      expect(families).toContain('tabs');
+      expect(families).toContain('snapshots');
+      expect(families).toContain('devtools');
+      expect(families).toContain('network');
+      expect(families).toContain('sessions');
+      expect(families).toContain('content');
+      expect(families).toContain('agents');
+      expect(families).toContain('handoffs');
+      expect(families).toContain('awareness');
+      expect(families).toContain('clipboard');
+      expect(families).toContain('previews');
+      expect(families).toContain('workspaces');
+      expect(families).toContain('pinboards');
+      expect(families).toContain('watch');
+      expect(families).toContain('config');
+      expect(families).toContain('localOnly');
+    });
+
+    it('includes skill endpoint in bootstrap section', async () => {
+      const res = await request(app).get('/agent/manifest');
+      expect(res.body.endpoints.bootstrap.skill).toBeDefined();
+      expect(res.body.endpoints.bootstrap.skill.path).toBe('/skill');
+    });
+
+    it('marks local-only endpoints explicitly', async () => {
+      const res = await request(app).get('/agent/manifest');
+      expect(res.body.endpoints.localOnly._note).toContain('not available to remote agents');
+      expect(res.body.endpoints.localOnly.pickFolder.path).toBe('/dialog/pick-folder');
+    });
+  });
+
+  describe('GET /skill', () => {
+    it('returns markdown skill page', async () => {
+      const res = await request(app).get('/skill');
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('text/markdown');
+      expect(res.text).toContain('Tandem Browser Skill');
+      expect(res.text).toContain('snapshot');
+    });
+
+    it('distinguishes local MCP from remote HTTP', async () => {
+      const res = await request(app).get('/skill');
+      expect(res.text).toContain('Remote agents should use the HTTP API');
+      expect(res.text).toContain('MCP');
+      expect(res.text).not.toContain('127.0.0.1');
+    });
+
+    it('uses Host header for URLs', async () => {
+      const res = await request(app).get('/skill').set('Host', '100.64.0.1:8765');
+      expect(res.text).toContain('http://100.64.0.1:8765');
+    });
+  });
+});

--- a/src/api/tests/routes/pairing.test.ts
+++ b/src/api/tests/routes/pairing.test.ts
@@ -1,0 +1,430 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+
+vi.mock('electron', () => ({
+  BrowserWindow: vi.fn(),
+  session: {},
+  webContents: {
+    fromId: vi.fn(),
+    getAllWebContents: vi.fn().mockReturnValue([]),
+  },
+}));
+
+import { registerPairingRoutes, detectAddresses } from '../../routes/pairing';
+import { createMockContext, createTestApp } from '../helpers';
+import type { RouteContext } from '../../context';
+
+describe('Pairing Routes', () => {
+  let ctx: RouteContext;
+  let app: ReturnType<typeof createTestApp>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ctx = createMockContext();
+    app = createTestApp(registerPairingRoutes, ctx);
+  });
+
+  // ─── POST /pairing/setup-code ─────────────────
+
+  describe('POST /pairing/setup-code', () => {
+    it('generates a setup code', async () => {
+      vi.mocked(ctx.pairingManager.generateSetupCode).mockReturnValue({
+        code: 'TDM-AAAA-BBBB',
+        createdAt: Date.now(),
+        expiresAt: Date.now() + 300_000,
+        consumed: false,
+      });
+
+      const res = await request(app).post('/pairing/setup-code');
+      expect(res.status).toBe(200);
+      expect(res.body.code).toBe('TDM-AAAA-BBBB');
+      expect(res.body.ttlSeconds).toBeGreaterThan(0);
+      expect(res.body.expiresAt).toBeDefined();
+    });
+
+    it('returns 429 when rate limited', async () => {
+      vi.mocked(ctx.pairingManager.generateSetupCode).mockImplementation(() => {
+        throw new Error('Too many setup codes generated');
+      });
+
+      const res = await request(app).post('/pairing/setup-code');
+      expect(res.status).toBe(429);
+    });
+  });
+
+  // ─── GET /pairing/setup-code/active ───────────
+
+  describe('GET /pairing/setup-code/active', () => {
+    it('returns null when no active code', async () => {
+      vi.mocked(ctx.pairingManager.getActiveSetupCode).mockReturnValue(null);
+
+      const res = await request(app).get('/pairing/setup-code/active');
+      expect(res.status).toBe(200);
+      expect(res.body).toBeNull();
+    });
+
+    it('returns active code', async () => {
+      vi.mocked(ctx.pairingManager.getActiveSetupCode).mockReturnValue({
+        code: 'TDM-CCCC-DDDD',
+        createdAt: Date.now(),
+        expiresAt: Date.now() + 200_000,
+        consumed: false,
+      });
+
+      const res = await request(app).get('/pairing/setup-code/active');
+      expect(res.status).toBe(200);
+      expect(res.body.code).toBe('TDM-CCCC-DDDD');
+    });
+  });
+
+  // ─── POST /pairing/exchange ───────────────────
+
+  describe('POST /pairing/exchange', () => {
+    it('exchanges valid code for token', async () => {
+      vi.mocked(ctx.pairingManager.exchangeSetupCode).mockReturnValue({
+        token: 'tdm_ast_testtoken',
+        binding: {
+          id: 'binding-1',
+          machineId: 'machine-1',
+          machineName: 'TestMachine',
+          agentLabel: 'Claude Code',
+          agentType: 'claude-code',
+          bindingKind: 'local',
+          transportModes: ['http'],
+          tokenHash: 'hash',
+          tokenPrefix: 'tdm_ast_12345678',
+          state: 'paired',
+          createdAt: new Date().toISOString(),
+          lastUsedAt: new Date().toISOString(),
+          pausedAt: null,
+          revokedAt: null,
+        },
+      });
+
+      const res = await request(app)
+        .post('/pairing/exchange')
+        .send({
+          code: 'TDM-AAAA-BBBB',
+          machineId: 'machine-1',
+          machineName: 'TestMachine',
+          agentLabel: 'Claude Code',
+          agentType: 'claude-code',
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.token).toBe('tdm_ast_testtoken');
+      expect(res.body.binding.id).toBe('binding-1');
+      expect(res.body.binding.state).toBe('paired');
+    });
+
+    it('rejects missing required fields', async () => {
+      const res = await request(app)
+        .post('/pairing/exchange')
+        .send({ code: 'TDM-AAAA-BBBB' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('machineId');
+    });
+
+    it('rejects invalid code format', async () => {
+      const res = await request(app)
+        .post('/pairing/exchange')
+        .send({
+          code: 'INVALID',
+          machineId: 'machine-1',
+          machineName: 'Test',
+          agentLabel: 'Agent',
+          agentType: 'test',
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('Invalid setup code format');
+    });
+
+    it('returns 400 for expired code', async () => {
+      vi.mocked(ctx.pairingManager.exchangeSetupCode).mockImplementation(() => {
+        throw new Error('This setup code has expired');
+      });
+
+      const res = await request(app)
+        .post('/pairing/exchange')
+        .send({
+          code: 'TDM-AAAA-BBBB',
+          machineId: 'machine-1',
+          machineName: 'Test',
+          agentLabel: 'Agent',
+          agentType: 'test',
+        });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('passes bindingKind and transport to manager', async () => {
+      vi.mocked(ctx.pairingManager.exchangeSetupCode).mockReturnValue({
+        token: 'tdm_ast_testtoken',
+        binding: {
+          id: 'binding-1',
+          machineId: 'machine-1',
+          machineName: 'RemoteMachine',
+          agentLabel: 'Claude Code',
+          agentType: 'claude-code',
+          bindingKind: 'remote',
+          transportModes: ['http'],
+          tokenHash: 'hash',
+          tokenPrefix: 'tdm_ast_12345678',
+          state: 'paired',
+          createdAt: new Date().toISOString(),
+          lastUsedAt: new Date().toISOString(),
+          pausedAt: null,
+          revokedAt: null,
+        },
+      });
+
+      await request(app)
+        .post('/pairing/exchange')
+        .send({
+          code: 'TDM-AAAA-BBBB',
+          machineId: 'machine-1',
+          machineName: 'RemoteMachine',
+          agentLabel: 'Claude Code',
+          agentType: 'claude-code',
+          bindingKind: 'remote',
+          transport: ['http'],
+        });
+
+      expect(ctx.pairingManager.exchangeSetupCode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bindingKind: 'remote',
+          transport: ['http'],
+        }),
+        expect.anything(),
+      );
+    });
+
+    it('defaults bindingKind to local when not specified', async () => {
+      vi.mocked(ctx.pairingManager.exchangeSetupCode).mockReturnValue({
+        token: 'tdm_ast_testtoken',
+        binding: { id: 'b1', state: 'paired' } as any,
+      });
+
+      await request(app)
+        .post('/pairing/exchange')
+        .send({
+          code: 'TDM-AAAA-BBBB',
+          machineId: 'machine-1',
+          machineName: 'Test',
+          agentLabel: 'Agent',
+          agentType: 'test',
+        });
+
+      expect(ctx.pairingManager.exchangeSetupCode).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bindingKind: 'local',
+          transport: ['http'],
+        }),
+        expect.anything(),
+      );
+    });
+
+    it('returns 500 for unexpected errors', async () => {
+      vi.mocked(ctx.pairingManager.exchangeSetupCode).mockImplementation(() => {
+        throw new Error('Unexpected database failure');
+      });
+
+      const res = await request(app)
+        .post('/pairing/exchange')
+        .send({
+          code: 'TDM-AAAA-BBBB',
+          machineId: 'machine-1',
+          machineName: 'Test',
+          agentLabel: 'Agent',
+          agentType: 'test',
+        });
+
+      expect(res.status).toBe(500);
+    });
+  });
+
+  // ─── GET /pairing/whoami ──────────────────────
+
+  describe('GET /pairing/whoami', () => {
+    it('returns binding info for valid token', async () => {
+      vi.mocked(ctx.pairingManager.whoami).mockReturnValue({
+        id: 'binding-1',
+        machineId: 'machine-1',
+        machineName: 'TestMachine',
+        agentLabel: 'Claude Code',
+        agentType: 'claude-code',
+        bindingKind: 'local',
+        transportModes: ['http'],
+        state: 'paired',
+        createdAt: new Date().toISOString(),
+        lastUsedAt: new Date().toISOString(),
+        pausedAt: null,
+        revokedAt: null,
+        tokenPrefix: 'tdm_ast_12345678',
+      });
+
+      const res = await request(app)
+        .get('/pairing/whoami')
+        .set('Authorization', 'Bearer tdm_ast_testtoken');
+
+      expect(res.status).toBe(200);
+      expect(res.body.agentLabel).toBe('Claude Code');
+    });
+
+    it('returns 401 without auth header', async () => {
+      const res = await request(app).get('/pairing/whoami');
+      expect(res.status).toBe(401);
+    });
+
+    it('returns 401 for invalid token', async () => {
+      vi.mocked(ctx.pairingManager.whoami).mockReturnValue(null);
+
+      const res = await request(app)
+        .get('/pairing/whoami')
+        .set('Authorization', 'Bearer tdm_ast_invalid');
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  // ─── GET /pairing/bindings ────────────────────
+
+  describe('GET /pairing/bindings', () => {
+    it('returns bindings list', async () => {
+      vi.mocked(ctx.pairingManager.listBindings).mockReturnValue([
+        {
+          id: 'binding-1',
+          machineId: 'machine-1',
+          machineName: 'TestMachine',
+          agentLabel: 'Claude Code',
+          agentType: 'claude-code',
+          bindingKind: 'local',
+          transportModes: ['http'],
+          state: 'paired',
+          createdAt: new Date().toISOString(),
+          lastUsedAt: null,
+          pausedAt: null,
+          revokedAt: null,
+          tokenPrefix: 'tdm_ast_12345678',
+        },
+      ]);
+
+      const res = await request(app).get('/pairing/bindings');
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].agentLabel).toBe('Claude Code');
+    });
+  });
+
+  // ─── Binding state transitions ────────────────
+
+  describe('POST /pairing/bindings/:id/pause', () => {
+    it('pauses a binding', async () => {
+      vi.mocked(ctx.pairingManager.pauseBinding).mockReturnValue({ state: 'paused' } as any);
+
+      const res = await request(app).post('/pairing/bindings/binding-1/pause');
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.state).toBe('paused');
+    });
+
+    it('returns 404 for non-pausable binding', async () => {
+      vi.mocked(ctx.pairingManager.pauseBinding).mockReturnValue(null);
+
+      const res = await request(app).post('/pairing/bindings/non-existent/pause');
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('POST /pairing/bindings/:id/resume', () => {
+    it('resumes a paused binding', async () => {
+      vi.mocked(ctx.pairingManager.resumeBinding).mockReturnValue({ state: 'paired' } as any);
+
+      const res = await request(app).post('/pairing/bindings/binding-1/resume');
+      expect(res.status).toBe(200);
+      expect(res.body.state).toBe('paired');
+    });
+
+    it('returns 404 for non-resumable binding', async () => {
+      vi.mocked(ctx.pairingManager.resumeBinding).mockReturnValue(null);
+
+      const res = await request(app).post('/pairing/bindings/binding-1/resume');
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('POST /pairing/bindings/:id/revoke', () => {
+    it('revokes a binding', async () => {
+      vi.mocked(ctx.pairingManager.revokeBinding).mockReturnValue({ state: 'revoked' } as any);
+
+      const res = await request(app).post('/pairing/bindings/binding-1/revoke');
+      expect(res.status).toBe(200);
+      expect(res.body.state).toBe('revoked');
+    });
+  });
+
+  describe('DELETE /pairing/bindings/:id', () => {
+    it('removes a binding', async () => {
+      vi.mocked(ctx.pairingManager.removeBinding).mockReturnValue(true);
+
+      const res = await request(app).delete('/pairing/bindings/binding-1');
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+    });
+
+    it('returns 404 for non-existent binding', async () => {
+      vi.mocked(ctx.pairingManager.removeBinding).mockReturnValue(false);
+
+      const res = await request(app).delete('/pairing/bindings/non-existent');
+      expect(res.status).toBe(404);
+    });
+  });
+
+  // ─── GET /pairing/addresses ───────────────────
+
+  describe('GET /pairing/addresses', () => {
+    it('returns local and tailscale address info', async () => {
+      const res = await request(app).get('/pairing/addresses');
+      expect(res.status).toBe(200);
+      expect(res.body.local).toBeDefined();
+      expect(res.body.local.address).toContain('127.0.0.1');
+      expect(res.body.local.hostname).toBeDefined();
+      expect(res.body.tailscale).toBeDefined();
+      expect(typeof res.body.tailscale.available).toBe('boolean');
+    });
+  });
+});
+
+// ─── detectAddresses unit tests ─────────────────
+
+describe('detectAddresses', () => {
+  it('always returns local address', () => {
+    const result = detectAddresses();
+    expect(result.local.address).toContain('127.0.0.1');
+    expect(result.local.address).toContain('8765');
+    expect(result.local.hostname).toBeTruthy();
+  });
+
+  it('returns tailscale.available as boolean', () => {
+    const result = detectAddresses();
+    expect(typeof result.tailscale.available).toBe('boolean');
+  });
+
+  it('tailscale address is null when not available', () => {
+    const result = detectAddresses();
+    if (!result.tailscale.available) {
+      expect(result.tailscale.address).toBeNull();
+      expect(result.tailscale.hostname).toBeNull();
+    }
+  });
+
+  it('tailscale address contains 100.x when available', () => {
+    const result = detectAddresses();
+    if (result.tailscale.available) {
+      expect(result.tailscale.address).toContain('100.');
+      expect(result.tailscale.address).toContain('8765');
+    }
+  });
+});

--- a/src/api/tests/routes/previews.test.ts
+++ b/src/api/tests/routes/previews.test.ts
@@ -226,4 +226,45 @@ describe('Preview Routes', () => {
       expect(res.status).toBe(404);
     });
   });
+
+  // ─── Remote-aware URL generation ────────────────
+
+  describe('Remote-aware URLs', () => {
+    it('POST /preview uses Host header for URL in response', async () => {
+      vi.mocked(fs.existsSync)
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(false);
+
+      const res = await request(app)
+        .post('/preview')
+        .set('Host', '100.64.0.1:8765')
+        .send({ html: '<h1>Remote</h1>', title: 'Remote Preview' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.url).toContain('http://100.64.0.1:8765/preview/');
+      expect(res.body.url).not.toContain('127.0.0.1');
+    });
+
+    it('PUT /preview/:id uses Host header for URL in response', async () => {
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(samplePreview));
+
+      const res = await request(app)
+        .put('/preview/my-preview')
+        .set('Host', '100.64.0.1:8765')
+        .send({ html: '<h1>Updated</h1>' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.url).toContain('http://100.64.0.1:8765/preview/');
+      expect(res.body.url).not.toContain('127.0.0.1');
+    });
+
+    it('GET /preview/:id 404 page does not contain hardcoded localhost', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const res = await request(app).get('/preview/missing');
+
+      expect(res.status).toBe(404);
+      expect(res.text).not.toContain('127.0.0.1');
+    });
+  });
 });

--- a/src/bootstrap/runtime.ts
+++ b/src/bootstrap/runtime.ts
@@ -55,6 +55,7 @@ import { BehaviorObserver } from '../behavior/observer';
 import { WorkflowEngine } from '../workflow/engine';
 import { WorkspaceManager } from '../workspaces/manager';
 import { ClipboardManager } from '../clipboard/manager';
+import { PairingManager } from '../pairing/manager';
 import { DEFAULT_PARTITION } from '../utils/constants';
 import type { RuntimeManagers } from './types';
 
@@ -220,6 +221,7 @@ export async function initializeRuntimeManagers(opts: InitializeRuntimeOptions):
   runtime.workflowEngine = new WorkflowEngine();
   runtime.loginManager = new LoginManager();
   runtime.clipboardManager = new ClipboardManager();
+  runtime.pairingManager = new PairingManager();
   runtime.sessionRestoreManager = new SessionRestoreManager(runtime.syncManager);
 
   runtime.workspaceManager.setMainWindow(win);
@@ -398,6 +400,7 @@ export function createManagerRegistry(runtime: RuntimeManagers): ManagerRegistry
     pinboardManager: runtime.pinboardManager,
     googlePhotosManager: runtime.googlePhotosManager,
     clipboardManager: runtime.clipboardManager,
+    pairingManager: runtime.pairingManager,
   };
 }
 
@@ -470,4 +473,5 @@ export function destroyRuntime(opts: DestroyRuntimeOptions): void {
   runtime.workspaceManager.destroy();
   runtime.pinboardManager.destroy();
   runtime.syncManager.destroy();
+  runtime.pairingManager.destroy();
 }

--- a/src/bootstrap/types.ts
+++ b/src/bootstrap/types.ts
@@ -47,6 +47,7 @@ import type { WorkflowEngine } from '../workflow/engine';
 import type { LoginManager } from '../auth/login-manager';
 import type { ClipboardManager } from '../clipboard/manager';
 import type { GooglePhotosManager } from '../integrations/google-photos';
+import type { PairingManager } from '../pairing/manager';
 
 export interface RuntimeManagers {
   configManager: ConfigManager;
@@ -98,6 +99,7 @@ export interface RuntimeManagers {
   loginManager: LoginManager;
   googlePhotosManager: GooglePhotosManager;
   clipboardManager: ClipboardManager;
+  pairingManager: PairingManager;
 }
 
 export interface PendingTabRegister {

--- a/src/config/manager.ts
+++ b/src/config/manager.ts
@@ -33,6 +33,7 @@ export interface TandemConfig {
     agentName: string;
     agentDisplayName: string;
     quickLinks: QuickLinkConfig[];
+    apiListenHost: string;
   };
 
   // Screenshots
@@ -135,6 +136,7 @@ const DEFAULT_CONFIG: TandemConfig = {
     agentName: 'Wingman',
     agentDisplayName: 'AI Wingman',
     quickLinks: DEFAULT_QUICK_LINKS,
+    apiListenHost: '0.0.0.0',
   },
   screenshots: {
     clipboard: true,
@@ -329,6 +331,11 @@ export class ConfigManager {
           }
           if (raw.general.startPage === 'kees') {
             raw.general.startPage = 'wingman';
+          }
+          // Migrate apiListenHost: old default was 127.0.0.1 which blocks remote agent pairing.
+          // New default is 0.0.0.0 (local + remote simultaneously).
+          if (raw.general.apiListenHost === '127.0.0.1') {
+            raw.general.apiListenHost = '0.0.0.0';
           }
           delete raw.general.keesPanelPosition;
           delete raw.general.keesPanelDefaultOpen;

--- a/src/config/tests/config.test.ts
+++ b/src/config/tests/config.test.ts
@@ -276,6 +276,36 @@ describe('ConfigManager', () => {
       expect(config.general.startPage).toBe('wingman');
     });
 
+    it('migrates apiListenHost from 127.0.0.1 to 0.0.0.0', () => {
+      const savedConfig = JSON.stringify({
+        general: { apiListenHost: '127.0.0.1' },
+      });
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(savedConfig);
+
+      const cm = new ConfigManager();
+      const config = cm.getConfig();
+      expect(config.general.apiListenHost).toBe('0.0.0.0');
+    });
+
+    it('preserves apiListenHost when already 0.0.0.0', () => {
+      const savedConfig = JSON.stringify({
+        general: { apiListenHost: '0.0.0.0' },
+      });
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(savedConfig);
+
+      const cm = new ConfigManager();
+      const config = cm.getConfig();
+      expect(config.general.apiListenHost).toBe('0.0.0.0');
+    });
+
+    it('defaults apiListenHost to 0.0.0.0 for new installs', () => {
+      const cm = new ConfigManager();
+      const config = cm.getConfig();
+      expect(config.general.apiListenHost).toBe('0.0.0.0');
+    });
+
     it('normalizes saved quick links from disk', () => {
       const savedConfig = JSON.stringify({
         general: {

--- a/src/pairing/manager.ts
+++ b/src/pairing/manager.ts
@@ -107,10 +107,10 @@ interface PairingStore {
 // ─── Crypto helpers ─────────────────────────────────
 
 function randomChars(length: number): string {
-  const bytes = crypto.randomBytes(length);
   let result = '';
   for (let i = 0; i < length; i++) {
-    result += SAFE_CHARS[bytes[i]! % SAFE_CHARS.length];
+    const idx = crypto.randomInt(SAFE_CHARS.length);
+    result += SAFE_CHARS[idx];
   }
   return result;
 }

--- a/src/pairing/manager.ts
+++ b/src/pairing/manager.ts
@@ -1,0 +1,479 @@
+/**
+ * PairingManager — setup code generation, token exchange, and binding lifecycle.
+ *
+ * Implements the Tandem remote agent pairing model:
+ * - One-time setup codes (TDM-XXXX-XXXX, 5-minute TTL)
+ * - Durable binding tokens (256-bit, hashed with SHA-256)
+ * - Binding states: paired, paused, revoked
+ * - Binding removal with audit trail retention
+ *
+ * Storage: ~/.tandem/pairing/bindings.json (persistent bindings)
+ *          In-memory map (ephemeral setup codes)
+ */
+
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { EventEmitter } from 'events';
+import { tandemDir, ensureDir } from '../utils/paths';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('PairingManager');
+
+// ─── Constants ──────────────────────────────────────
+
+const SETUP_CODE_PREFIX = 'TDM';
+const TOKEN_PREFIX = 'tdm_ast_';
+const TOKEN_BYTES = 32; // 256 bits
+const SETUP_CODE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const MAX_SETUP_CODES_PER_HOUR = 10;
+const SAFE_CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // no O/0, I/1, l
+
+// ─── Types ──────────────────────────────────────────
+
+export type BindingState = 'paired' | 'paused' | 'revoked';
+
+export interface AgentBinding {
+  id: string;
+  machineId: string;
+  machineName: string;
+  agentLabel: string;
+  agentType: string;
+  bindingKind: 'local' | 'remote';
+  transportModes: Array<'http' | 'mcp'>;
+  tokenHash: string;
+  tokenPrefix: string;
+  state: BindingState;
+  createdAt: string;
+  lastUsedAt: string | null;
+  pausedAt: string | null;
+  revokedAt: string | null;
+}
+
+export interface BindingEvent {
+  id: string;
+  bindingId: string;
+  eventType: string;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  sourceIp: string | null;
+}
+
+export interface SetupCode {
+  code: string;
+  createdAt: number;
+  expiresAt: number;
+  consumed: boolean;
+}
+
+export interface ExchangeInput {
+  code: string;
+  machineId: string;
+  machineName: string;
+  agentLabel: string;
+  agentType: string;
+  bindingKind?: 'local' | 'remote';
+  transport?: Array<'http' | 'mcp'>;
+}
+
+export interface ExchangeResult {
+  token: string;
+  binding: AgentBinding;
+}
+
+export interface BindingSummary {
+  id: string;
+  machineId: string;
+  machineName: string;
+  agentLabel: string;
+  agentType: string;
+  bindingKind: 'local' | 'remote';
+  transportModes: Array<'http' | 'mcp'>;
+  state: BindingState;
+  createdAt: string;
+  lastUsedAt: string | null;
+  pausedAt: string | null;
+  revokedAt: string | null;
+  tokenPrefix: string;
+}
+
+// ─── Storage shape ──────────────────────────────────
+
+interface PairingStore {
+  bindings: AgentBinding[];
+  events: BindingEvent[];
+}
+
+// ─── Crypto helpers ─────────────────────────────────
+
+function randomChars(length: number): string {
+  const bytes = crypto.randomBytes(length);
+  let result = '';
+  for (let i = 0; i < length; i++) {
+    result += SAFE_CHARS[bytes[i]! % SAFE_CHARS.length];
+  }
+  return result;
+}
+
+function generateSetupCodeString(): string {
+  return `${SETUP_CODE_PREFIX}-${randomChars(4)}-${randomChars(4)}`;
+}
+
+function generateSecureToken(): string {
+  const bytes = crypto.randomBytes(TOKEN_BYTES);
+  return `${TOKEN_PREFIX}${bytes.toString('base64url')}`;
+}
+
+function hashToken(token: string): string {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
+function timingSafeCompare(a: string, b: string): boolean {
+  try {
+    const bufA = Buffer.from(a);
+    const bufB = Buffer.from(b);
+    return bufA.length === bufB.length && crypto.timingSafeEqual(bufA, bufB);
+  } catch {
+    return false;
+  }
+}
+
+// ─── PairingManager ────────────────────────────────
+
+export class PairingManager extends EventEmitter {
+  private bindings: AgentBinding[] = [];
+  private events: BindingEvent[] = [];
+  private setupCodes: Map<string, SetupCode> = new Map();
+  private codeGenerationTimestamps: number[] = [];
+  private storePath: string;
+  private loaded = false;
+
+  constructor() {
+    super();
+    this.storePath = path.join(tandemDir('pairing'), 'bindings.json');
+  }
+
+  // ─── Persistence ──────────────────────────────────
+
+  private ensureLoaded(): void {
+    if (this.loaded) return;
+    this.loaded = true;
+    try {
+      if (fs.existsSync(this.storePath)) {
+        const raw = fs.readFileSync(this.storePath, 'utf-8');
+        const data: PairingStore = JSON.parse(raw);
+        this.bindings = data.bindings ?? [];
+        this.events = data.events ?? [];
+      }
+    } catch (e) {
+      log.warn('Failed to load pairing store:', e instanceof Error ? e.message : e);
+    }
+  }
+
+  private save(): void {
+    try {
+      ensureDir(path.dirname(this.storePath));
+      const data: PairingStore = { bindings: this.bindings, events: this.events };
+      fs.writeFileSync(this.storePath, JSON.stringify(data, null, 2), { mode: 0o600 });
+    } catch (e) {
+      log.error('Failed to save pairing store:', e instanceof Error ? e.message : e);
+    }
+  }
+
+  private addEvent(bindingId: string, eventType: string, metadata: Record<string, unknown> = {}, sourceIp: string | null = null): void {
+    this.events.push({
+      id: crypto.randomUUID(),
+      bindingId,
+      eventType,
+      metadata,
+      createdAt: new Date().toISOString(),
+      sourceIp,
+    });
+  }
+
+  // ─── Setup codes ──────────────────────────────────
+
+  /** Generate a one-time setup code. Returns the code or throws if rate-limited. */
+  generateSetupCode(): SetupCode {
+    this.ensureLoaded();
+
+    // Rate limit: max N codes per hour
+    const oneHourAgo = Date.now() - 60 * 60 * 1000;
+    this.codeGenerationTimestamps = this.codeGenerationTimestamps.filter(ts => ts > oneHourAgo);
+    if (this.codeGenerationTimestamps.length >= MAX_SETUP_CODES_PER_HOUR) {
+      throw new Error('Too many setup codes generated. Please wait before trying again.');
+    }
+
+    // Cancel any existing unused codes
+    for (const [key, sc] of this.setupCodes) {
+      if (!sc.consumed) {
+        this.setupCodes.delete(key);
+      }
+    }
+
+    const code = generateSetupCodeString();
+    const now = Date.now();
+    const setupCode: SetupCode = {
+      code,
+      createdAt: now,
+      expiresAt: now + SETUP_CODE_TTL_MS,
+      consumed: false,
+    };
+
+    this.setupCodes.set(code, setupCode);
+    this.codeGenerationTimestamps.push(now);
+
+    log.info(`Setup code generated: ${code.substring(0, 7)}****`);
+    this.emit('setup-code-generated', { code });
+    return setupCode;
+  }
+
+  /** Get the current active (unconsumed, unexpired) setup code, if any. */
+  getActiveSetupCode(): SetupCode | null {
+    const now = Date.now();
+    for (const sc of this.setupCodes.values()) {
+      if (!sc.consumed && sc.expiresAt > now) {
+        return sc;
+      }
+    }
+    return null;
+  }
+
+  // ─── Token exchange ───────────────────────────────
+
+  /** Exchange a setup code for a durable binding token. */
+  exchangeSetupCode(input: ExchangeInput, sourceIp: string | null = null): ExchangeResult {
+    this.ensureLoaded();
+    const normalizedCode = input.code.toUpperCase().trim();
+
+    const setupCode = this.setupCodes.get(normalizedCode);
+    if (!setupCode) {
+      throw new Error('Invalid setup code');
+    }
+    if (setupCode.consumed) {
+      throw new Error('This setup code has already been used');
+    }
+    if (setupCode.expiresAt < Date.now()) {
+      this.setupCodes.delete(normalizedCode);
+      throw new Error('This setup code has expired');
+    }
+
+    // Consume the code
+    setupCode.consumed = true;
+
+    // Generate durable token
+    const token = generateSecureToken();
+    const tokenHashValue = hashToken(token);
+    const tokenPrefix = token.substring(0, 16); // tdm_ast_ + 8 chars
+
+    // Check for existing binding with same identity
+    const existingIndex = this.bindings.findIndex(
+      b => b.machineId === input.machineId
+        && b.agentLabel === input.agentLabel
+        && b.agentType === input.agentType,
+    );
+
+    const now = new Date().toISOString();
+    let binding: AgentBinding;
+
+    if (existingIndex >= 0) {
+      // Re-pair: update token and reset state
+      binding = this.bindings[existingIndex];
+      binding.tokenHash = tokenHashValue;
+      binding.tokenPrefix = tokenPrefix;
+      binding.machineName = input.machineName;
+      binding.bindingKind = input.bindingKind ?? 'local';
+      binding.transportModes = input.transport ?? ['http'];
+      binding.state = 'paired';
+      binding.lastUsedAt = now;
+      binding.pausedAt = null;
+      binding.revokedAt = null;
+
+      this.addEvent(binding.id, 're-paired', {
+        machineId: input.machineId,
+        agentLabel: input.agentLabel,
+      }, sourceIp);
+      log.info(`Binding re-paired: ${input.agentLabel} on ${input.machineName}`);
+    } else {
+      binding = {
+        id: crypto.randomUUID(),
+        machineId: input.machineId,
+        machineName: input.machineName,
+        agentLabel: input.agentLabel,
+        agentType: input.agentType,
+        bindingKind: input.bindingKind ?? 'local',
+        transportModes: input.transport ?? ['http'],
+        tokenHash: tokenHashValue,
+        tokenPrefix,
+        state: 'paired',
+        createdAt: now,
+        lastUsedAt: now,
+        pausedAt: null,
+        revokedAt: null,
+      };
+      this.bindings.push(binding);
+
+      this.addEvent(binding.id, 'paired', {
+        machineId: input.machineId,
+        machineName: input.machineName,
+        agentLabel: input.agentLabel,
+        agentType: input.agentType,
+      }, sourceIp);
+      log.info(`New binding created: ${input.agentLabel} on ${input.machineName}`);
+    }
+
+    this.save();
+    this.emit('binding-changed', binding);
+    return { token, binding };
+  }
+
+  // ─── Token validation ─────────────────────────────
+
+  /** Validate a binding token. Returns the binding if valid, null otherwise. Updates lastUsedAt. */
+  validateToken(token: string): AgentBinding | null {
+    this.ensureLoaded();
+    if (!token.startsWith(TOKEN_PREFIX)) return null;
+
+    const candidateHash = hashToken(token);
+    const tokenPrefix = token.substring(0, 16);
+
+    // Find binding by prefix first (fast), then verify full hash
+    const binding = this.bindings.find(b =>
+      b.tokenPrefix === tokenPrefix && timingSafeCompare(b.tokenHash, candidateHash),
+    );
+
+    if (!binding) return null;
+    if (binding.state !== 'paired') return null;
+
+    // Update last used
+    binding.lastUsedAt = new Date().toISOString();
+    this.save();
+    return binding;
+  }
+
+  // ─── Binding management ───────────────────────────
+
+  /** List all bindings (excludes removed ones, which are only in events). */
+  listBindings(): BindingSummary[] {
+    this.ensureLoaded();
+    return this.bindings.map(b => ({
+      id: b.id,
+      machineId: b.machineId,
+      machineName: b.machineName,
+      agentLabel: b.agentLabel,
+      agentType: b.agentType,
+      bindingKind: b.bindingKind,
+      transportModes: b.transportModes,
+      state: b.state,
+      createdAt: b.createdAt,
+      lastUsedAt: b.lastUsedAt,
+      pausedAt: b.pausedAt,
+      revokedAt: b.revokedAt,
+      tokenPrefix: b.tokenPrefix,
+    }));
+  }
+
+  /** Get a single binding by ID. */
+  getBinding(id: string): BindingSummary | null {
+    this.ensureLoaded();
+    const b = this.bindings.find(b => b.id === id);
+    if (!b) return null;
+    return {
+      id: b.id,
+      machineId: b.machineId,
+      machineName: b.machineName,
+      agentLabel: b.agentLabel,
+      agentType: b.agentType,
+      bindingKind: b.bindingKind,
+      transportModes: b.transportModes,
+      state: b.state,
+      createdAt: b.createdAt,
+      lastUsedAt: b.lastUsedAt,
+      pausedAt: b.pausedAt,
+      revokedAt: b.revokedAt,
+      tokenPrefix: b.tokenPrefix,
+    };
+  }
+
+  /** Pause a binding — temporarily disables auth without deleting. */
+  pauseBinding(id: string): AgentBinding | null {
+    this.ensureLoaded();
+    const binding = this.bindings.find(b => b.id === id);
+    if (!binding || binding.state !== 'paired') return null;
+
+    binding.state = 'paused';
+    binding.pausedAt = new Date().toISOString();
+    this.addEvent(id, 'paused');
+    this.save();
+    this.emit('binding-changed', binding);
+    log.info(`Binding paused: ${binding.agentLabel}`);
+    return binding;
+  }
+
+  /** Resume a paused binding. */
+  resumeBinding(id: string): AgentBinding | null {
+    this.ensureLoaded();
+    const binding = this.bindings.find(b => b.id === id);
+    if (!binding || binding.state !== 'paused') return null;
+
+    binding.state = 'paired';
+    binding.pausedAt = null;
+    this.addEvent(id, 'resumed');
+    this.save();
+    this.emit('binding-changed', binding);
+    log.info(`Binding resumed: ${binding.agentLabel}`);
+    return binding;
+  }
+
+  /** Revoke a binding — invalidates credential permanently. Must re-pair to connect again. */
+  revokeBinding(id: string): AgentBinding | null {
+    this.ensureLoaded();
+    const binding = this.bindings.find(b => b.id === id);
+    if (!binding || binding.state === 'revoked') return null;
+
+    binding.state = 'revoked';
+    binding.revokedAt = new Date().toISOString();
+    this.addEvent(id, 'revoked');
+    this.save();
+    this.emit('binding-changed', binding);
+    log.info(`Binding revoked: ${binding.agentLabel}`);
+    return binding;
+  }
+
+  /** Remove a binding from active list. Audit events are preserved. */
+  removeBinding(id: string): boolean {
+    this.ensureLoaded();
+    const index = this.bindings.findIndex(b => b.id === id);
+    if (index < 0) return false;
+
+    const binding = this.bindings[index];
+    this.addEvent(id, 'removed', {
+      agentLabel: binding.agentLabel,
+      machineName: binding.machineName,
+    });
+    this.bindings.splice(index, 1);
+    this.save();
+    this.emit('binding-removed', { id, agentLabel: binding.agentLabel });
+    log.info(`Binding removed: ${binding.agentLabel}`);
+    return true;
+  }
+
+  /** Validate a token and return the binding info (for /pairing/whoami). */
+  whoami(token: string): BindingSummary | null {
+    const binding = this.validateToken(token);
+    if (!binding) return null;
+    return this.getBinding(binding.id);
+  }
+
+  /** Get binding events for a specific binding. */
+  getBindingEvents(bindingId: string): BindingEvent[] {
+    this.ensureLoaded();
+    return this.events.filter(e => e.bindingId === bindingId);
+  }
+
+  /** Destroy / cleanup */
+  destroy(): void {
+    this.setupCodes.clear();
+    this.removeAllListeners();
+  }
+}

--- a/src/pairing/tests/manager.test.ts
+++ b/src/pairing/tests/manager.test.ts
@@ -1,0 +1,446 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { PairingManager } from '../manager';
+import type { ExchangeInput } from '../manager';
+
+// Mock fs and paths so we don't touch real disk
+vi.mock('fs');
+vi.mock('../../utils/paths', () => ({
+  tandemDir: (...subpath: string[]) => path.join('/tmp/tandem-test', ...subpath),
+  ensureDir: (dir: string) => dir,
+}));
+vi.mock('../../utils/logger', () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+function makeExchangeInput(overrides: Partial<ExchangeInput> = {}): ExchangeInput {
+  return {
+    code: 'TDM-AAAA-BBBB', // will be overridden by actual generated code
+    machineId: 'machine-123',
+    machineName: 'TestMachine',
+    agentLabel: 'Claude Code on TestMachine',
+    agentType: 'claude-code',
+    bindingKind: 'local',
+    transport: ['http'],
+    ...overrides,
+  };
+}
+
+describe('PairingManager', () => {
+  let manager: PairingManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // fs.existsSync returns false by default (no persisted data)
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(fs.writeFileSync).mockReturnValue(undefined);
+    manager = new PairingManager();
+  });
+
+  afterEach(() => {
+    manager.destroy();
+  });
+
+  // ─── Setup code generation ────────────────────
+
+  describe('generateSetupCode', () => {
+    it('generates a code with TDM prefix', () => {
+      const result = manager.generateSetupCode();
+      expect(result.code).toMatch(/^TDM-[A-Z0-9]{4}-[A-Z0-9]{4}$/);
+    });
+
+    it('sets expiry ~5 minutes from now', () => {
+      const before = Date.now();
+      const result = manager.generateSetupCode();
+      const after = Date.now();
+
+      const expectedMin = before + 5 * 60 * 1000;
+      const expectedMax = after + 5 * 60 * 1000;
+      expect(result.expiresAt).toBeGreaterThanOrEqual(expectedMin);
+      expect(result.expiresAt).toBeLessThanOrEqual(expectedMax);
+    });
+
+    it('marks code as unconsumed', () => {
+      const result = manager.generateSetupCode();
+      expect(result.consumed).toBe(false);
+    });
+
+    it('cancels previous unused code when generating new one', () => {
+      const first = manager.generateSetupCode();
+      const second = manager.generateSetupCode();
+      expect(first.code).not.toBe(second.code);
+
+      // First code should no longer be active
+      const active = manager.getActiveSetupCode();
+      expect(active?.code).toBe(second.code);
+    });
+
+    it('rate limits at 10 codes per hour', () => {
+      for (let i = 0; i < 10; i++) {
+        manager.generateSetupCode();
+      }
+      expect(() => manager.generateSetupCode()).toThrow(/Too many/);
+    });
+  });
+
+  // ─── getActiveSetupCode ───────────────────────
+
+  describe('getActiveSetupCode', () => {
+    it('returns null when no code generated', () => {
+      expect(manager.getActiveSetupCode()).toBeNull();
+    });
+
+    it('returns the active code', () => {
+      const code = manager.generateSetupCode();
+      const active = manager.getActiveSetupCode();
+      expect(active?.code).toBe(code.code);
+    });
+  });
+
+  // ─── Token exchange ───────────────────────────
+
+  describe('exchangeSetupCode', () => {
+    it('exchanges valid code for token and binding', () => {
+      const setupCode = manager.generateSetupCode();
+      const input = makeExchangeInput({ code: setupCode.code });
+      const result = manager.exchangeSetupCode(input);
+
+      expect(result.token).toMatch(/^tdm_ast_/);
+      expect(result.binding.state).toBe('paired');
+      expect(result.binding.machineId).toBe('machine-123');
+      expect(result.binding.agentLabel).toBe('Claude Code on TestMachine');
+      expect(result.binding.agentType).toBe('claude-code');
+    });
+
+    it('rejects invalid code', () => {
+      expect(() => manager.exchangeSetupCode(makeExchangeInput({ code: 'TDM-XXXX-YYYY' })))
+        .toThrow('Invalid setup code');
+    });
+
+    it('rejects already consumed code', () => {
+      const setupCode = manager.generateSetupCode();
+      const input = makeExchangeInput({ code: setupCode.code });
+      manager.exchangeSetupCode(input);
+
+      expect(() => manager.exchangeSetupCode(makeExchangeInput({ code: setupCode.code })))
+        .toThrow('already been used');
+    });
+
+    it('rejects expired code', () => {
+      const setupCode = manager.generateSetupCode();
+      // Manually expire it
+      setupCode.expiresAt = Date.now() - 1000;
+
+      expect(() => manager.exchangeSetupCode(makeExchangeInput({ code: setupCode.code })))
+        .toThrow('expired');
+    });
+
+    it('re-pairs existing binding with same identity', () => {
+      const code1 = manager.generateSetupCode();
+      const result1 = manager.exchangeSetupCode(makeExchangeInput({ code: code1.code }));
+
+      const code2 = manager.generateSetupCode();
+      const result2 = manager.exchangeSetupCode(makeExchangeInput({ code: code2.code }));
+
+      // Same binding ID, new token
+      expect(result2.binding.id).toBe(result1.binding.id);
+      expect(result2.token).not.toBe(result1.token);
+      expect(result2.binding.state).toBe('paired');
+    });
+
+    it('creates separate binding for different agent identity', () => {
+      const code1 = manager.generateSetupCode();
+      const result1 = manager.exchangeSetupCode(makeExchangeInput({ code: code1.code }));
+
+      const code2 = manager.generateSetupCode();
+      const result2 = manager.exchangeSetupCode(makeExchangeInput({
+        code: code2.code,
+        agentLabel: 'OpenClaw on TestMachine',
+        agentType: 'openclaw',
+      }));
+
+      expect(result2.binding.id).not.toBe(result1.binding.id);
+    });
+
+    it('normalizes code to uppercase', () => {
+      const setupCode = manager.generateSetupCode();
+      const lowerCode = setupCode.code.toLowerCase();
+      const result = manager.exchangeSetupCode(makeExchangeInput({ code: lowerCode }));
+      expect(result.token).toMatch(/^tdm_ast_/);
+    });
+  });
+
+  // ─── Token validation ─────────────────────────
+
+  describe('validateToken', () => {
+    it('validates a correct token', () => {
+      const setupCode = manager.generateSetupCode();
+      const { token } = manager.exchangeSetupCode(makeExchangeInput({ code: setupCode.code }));
+
+      const binding = manager.validateToken(token);
+      expect(binding).not.toBeNull();
+      expect(binding?.state).toBe('paired');
+    });
+
+    it('rejects invalid token', () => {
+      expect(manager.validateToken('tdm_ast_invalid')).toBeNull();
+    });
+
+    it('rejects non-prefixed token', () => {
+      expect(manager.validateToken('some_random_token')).toBeNull();
+    });
+
+    it('rejects token for paused binding', () => {
+      const setupCode = manager.generateSetupCode();
+      const { token, binding } = manager.exchangeSetupCode(makeExchangeInput({ code: setupCode.code }));
+
+      manager.pauseBinding(binding.id);
+      expect(manager.validateToken(token)).toBeNull();
+    });
+
+    it('rejects token for revoked binding', () => {
+      const setupCode = manager.generateSetupCode();
+      const { token, binding } = manager.exchangeSetupCode(makeExchangeInput({ code: setupCode.code }));
+
+      manager.revokeBinding(binding.id);
+      expect(manager.validateToken(token)).toBeNull();
+    });
+
+    it('updates lastUsedAt on validation', () => {
+      const setupCode = manager.generateSetupCode();
+      const { token, binding } = manager.exchangeSetupCode(makeExchangeInput({ code: setupCode.code }));
+
+      // Validate updates lastUsedAt
+      const result = manager.validateToken(token);
+      expect(result?.lastUsedAt).toBeDefined();
+      expect(new Date(result!.lastUsedAt!).getTime()).toBeGreaterThanOrEqual(
+        new Date(binding.lastUsedAt!).getTime()
+      );
+    });
+  });
+
+  // ─── Binding management ───────────────────────
+
+  describe('listBindings', () => {
+    it('returns empty array when no bindings', () => {
+      expect(manager.listBindings()).toEqual([]);
+    });
+
+    it('returns all bindings', () => {
+      const code = manager.generateSetupCode();
+      manager.exchangeSetupCode(makeExchangeInput({ code: code.code }));
+      const bindings = manager.listBindings();
+      expect(bindings).toHaveLength(1);
+      expect(bindings[0].agentLabel).toBe('Claude Code on TestMachine');
+    });
+
+    it('does not include tokenHash in summary', () => {
+      const code = manager.generateSetupCode();
+      manager.exchangeSetupCode(makeExchangeInput({ code: code.code }));
+      const bindings = manager.listBindings();
+      expect((bindings[0] as any).tokenHash).toBeUndefined();
+    });
+  });
+
+  describe('pauseBinding', () => {
+    it('pauses a paired binding', () => {
+      const code = manager.generateSetupCode();
+      const { binding } = manager.exchangeSetupCode(makeExchangeInput({ code: code.code }));
+
+      const result = manager.pauseBinding(binding.id);
+      expect(result?.state).toBe('paused');
+      expect(result?.pausedAt).toBeDefined();
+    });
+
+    it('returns null for non-paired binding', () => {
+      const code = manager.generateSetupCode();
+      const { binding } = manager.exchangeSetupCode(makeExchangeInput({ code: code.code }));
+
+      manager.pauseBinding(binding.id);
+      // Can't pause an already paused binding
+      expect(manager.pauseBinding(binding.id)).toBeNull();
+    });
+
+    it('returns null for non-existent binding', () => {
+      expect(manager.pauseBinding('non-existent')).toBeNull();
+    });
+  });
+
+  describe('resumeBinding', () => {
+    it('resumes a paused binding', () => {
+      const code = manager.generateSetupCode();
+      const { binding } = manager.exchangeSetupCode(makeExchangeInput({ code: code.code }));
+
+      manager.pauseBinding(binding.id);
+      const result = manager.resumeBinding(binding.id);
+      expect(result?.state).toBe('paired');
+      expect(result?.pausedAt).toBeNull();
+    });
+
+    it('returns null for non-paused binding', () => {
+      const code = manager.generateSetupCode();
+      const { binding } = manager.exchangeSetupCode(makeExchangeInput({ code: code.code }));
+
+      expect(manager.resumeBinding(binding.id)).toBeNull();
+    });
+  });
+
+  describe('revokeBinding', () => {
+    it('revokes a binding', () => {
+      const code = manager.generateSetupCode();
+      const { binding } = manager.exchangeSetupCode(makeExchangeInput({ code: code.code }));
+
+      const result = manager.revokeBinding(binding.id);
+      expect(result?.state).toBe('revoked');
+      expect(result?.revokedAt).toBeDefined();
+    });
+
+    it('returns null for already revoked binding', () => {
+      const code = manager.generateSetupCode();
+      const { binding } = manager.exchangeSetupCode(makeExchangeInput({ code: code.code }));
+
+      manager.revokeBinding(binding.id);
+      expect(manager.revokeBinding(binding.id)).toBeNull();
+    });
+
+    it('can revoke a paused binding', () => {
+      const code = manager.generateSetupCode();
+      const { binding } = manager.exchangeSetupCode(makeExchangeInput({ code: code.code }));
+
+      manager.pauseBinding(binding.id);
+      const result = manager.revokeBinding(binding.id);
+      expect(result?.state).toBe('revoked');
+    });
+  });
+
+  describe('removeBinding', () => {
+    it('removes a binding from active list', () => {
+      const code = manager.generateSetupCode();
+      const { binding } = manager.exchangeSetupCode(makeExchangeInput({ code: code.code }));
+
+      expect(manager.removeBinding(binding.id)).toBe(true);
+      expect(manager.listBindings()).toHaveLength(0);
+    });
+
+    it('returns false for non-existent binding', () => {
+      expect(manager.removeBinding('non-existent')).toBe(false);
+    });
+
+    it('preserves audit events after removal', () => {
+      const code = manager.generateSetupCode();
+      const { binding } = manager.exchangeSetupCode(makeExchangeInput({ code: code.code }));
+
+      manager.removeBinding(binding.id);
+      const events = manager.getBindingEvents(binding.id);
+      expect(events.length).toBeGreaterThan(0);
+      expect(events.some(e => e.eventType === 'removed')).toBe(true);
+    });
+  });
+
+  describe('whoami', () => {
+    it('returns binding summary for valid token', () => {
+      const code = manager.generateSetupCode();
+      const { token } = manager.exchangeSetupCode(makeExchangeInput({ code: code.code }));
+
+      const result = manager.whoami(token);
+      expect(result).not.toBeNull();
+      expect(result?.agentLabel).toBe('Claude Code on TestMachine');
+      expect((result as any).tokenHash).toBeUndefined();
+    });
+
+    it('returns null for invalid token', () => {
+      expect(manager.whoami('tdm_ast_invalid')).toBeNull();
+    });
+  });
+
+  // ─── Event emission ───────────────────────────
+
+  describe('events', () => {
+    it('emits setup-code-generated', () => {
+      const handler = vi.fn();
+      manager.on('setup-code-generated', handler);
+      manager.generateSetupCode();
+      expect(handler).toHaveBeenCalledOnce();
+    });
+
+    it('emits binding-changed on exchange', () => {
+      const handler = vi.fn();
+      manager.on('binding-changed', handler);
+      const code = manager.generateSetupCode();
+      manager.exchangeSetupCode(makeExchangeInput({ code: code.code }));
+      expect(handler).toHaveBeenCalledOnce();
+    });
+
+    it('emits binding-changed on pause', () => {
+      const handler = vi.fn();
+      const code = manager.generateSetupCode();
+      const { binding } = manager.exchangeSetupCode(makeExchangeInput({ code: code.code }));
+      manager.on('binding-changed', handler);
+      manager.pauseBinding(binding.id);
+      expect(handler).toHaveBeenCalledOnce();
+    });
+
+    it('emits binding-removed on remove', () => {
+      const handler = vi.fn();
+      const code = manager.generateSetupCode();
+      const { binding } = manager.exchangeSetupCode(makeExchangeInput({ code: code.code }));
+      manager.on('binding-removed', handler);
+      manager.removeBinding(binding.id);
+      expect(handler).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ─── Persistence ──────────────────────────────
+
+  describe('persistence', () => {
+    it('saves bindings to disk after exchange', () => {
+      const code = manager.generateSetupCode();
+      manager.exchangeSetupCode(makeExchangeInput({ code: code.code }));
+
+      expect(fs.writeFileSync).toHaveBeenCalled();
+      const callArgs = vi.mocked(fs.writeFileSync).mock.calls;
+      const lastCall = callArgs[callArgs.length - 1];
+      expect(String(lastCall[0])).toContain('bindings.json');
+
+      const data = JSON.parse(String(lastCall[1]));
+      expect(data.bindings).toHaveLength(1);
+      expect(data.events).toHaveLength(1);
+    });
+
+    it('loads existing bindings from disk', () => {
+      const existingData = {
+        bindings: [{
+          id: 'existing-id',
+          machineId: 'machine-1',
+          machineName: 'OldMachine',
+          agentLabel: 'Old Agent',
+          agentType: 'openclaw',
+          bindingKind: 'remote',
+          transportModes: ['http'],
+          tokenHash: 'abc123',
+          tokenPrefix: 'tdm_ast_12345678',
+          state: 'paired',
+          createdAt: '2026-01-01T00:00:00Z',
+          lastUsedAt: null,
+          pausedAt: null,
+          revokedAt: null,
+        }],
+        events: [],
+      };
+
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+      vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(existingData));
+
+      const freshManager = new PairingManager();
+      const bindings = freshManager.listBindings();
+      expect(bindings).toHaveLength(1);
+      expect(bindings[0].agentLabel).toBe('Old Agent');
+      freshManager.destroy();
+    });
+  });
+});

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -50,6 +50,7 @@ import type { SyncManager } from './sync/manager';
 import type { PinboardManager } from './pinboards/manager';
 import type { ClipboardManager } from './clipboard/manager';
 import type { GooglePhotosManager } from './integrations/google-photos';
+import type { PairingManager } from './pairing/manager';
 
 export interface ManagerRegistry {
   /** Tab lifecycle, grouping, metadata, and focus tracking. See src/tabs/manager.ts */
@@ -144,4 +145,6 @@ export interface ManagerRegistry {
   googlePhotosManager: GooglePhotosManager;
   /** Reads and saves clipboard content (text, HTML, images) to disk. See src/clipboard/manager.ts */
   clipboardManager: ClipboardManager;
+  /** Remote agent pairing with setup codes, binding tokens, and lifecycle management. See src/pairing/manager.ts */
+  pairingManager: PairingManager;
 }


### PR DESCRIPTION
## Summary

This adds phase 1 of remote agent connectivity to Tandem Browser.

It introduces a pairing and trust-admission model for AI agents, plus a simple onboarding flow for connecting agents either on the same machine or on another machine over Tailscale.

The result is:

- local agents can continue using MCP or HTTP
- remote agents can pair over Tailscale and use the HTTP API
- local and remote agents are supported at the same time
- Tandem exposes its own version-matched bootstrap/discovery surface

## What's included

### Pairing and binding lifecycle
- add `PairingManager`
- one-time setup codes with TTL
- durable binding tokens
- binding lifecycle controls:
  - pause
  - resume
  - revoke
  - remove
- persistent binding storage

### Bootstrap and discovery
- add:
  - `GET /agent`
  - `GET /agent/version`
  - `GET /agent/manifest`
  - `GET /skill`
- make bootstrap output request-aware so remote agents get correct host URLs
- document remote usage clearly in the bootstrap/skill surfaces

### Remote HTTP support
- allow paired binding tokens across the HTTP API
- add binding-token support for `/watch/live`
- remove remaining localhost-only response URL issues in preview routes
- audit and document local-only cases explicitly where appropriate

### Onboarding UX
- add onboarding-first "Connect your AI to Tandem" UI
- support two user-facing modes:
  - on this machine
  - on another machine
- detect local and Tailscale addresses
- generate a single instruction block for the user to give to their AI
- keep existing connected-agent management in the same UI

### Config and migration
- default `apiListenHost` to `0.0.0.0`
- migrate existing saved `127.0.0.1` values to `0.0.0.0`

### Tests and docs
- add/update tests for:
  - pairing lifecycle
  - bootstrap routes
  - pairing routes
  - preview request-aware URLs
  - config migration
- update README, skill docs, project docs, docs index, changelog
- add design, review, and test report docs for this feature

## Proven behavior

Validated in live testing:
- local pairing flow
- pause / resume / revoke / remove
- bootstrap/discovery routes
- remote Windows 11 + VS Code + Claude Code client over Tailscale
- broad remote HTTP API usage against a running Tandem instance

## Explicitly not included

This PR does **not** implement remote MCP transport.

Current transport story after this PR:
- local same-machine agents: MCP or HTTP
- remote agents over Tailscale: HTTP
- remote MCP: future work

## Notes

- remote support is Tailscale-only in this phase
- Tandem is not intended to be exposed to the public internet
- some server-side file operations still return paths on the Tandem host, which is expected behavior for remote callers