### PR TITLE
docs: align website, API docs, and README with shipped remote pairing

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ npm install
 npm start
 ```
 
-macOS is the primary platform. Linux works. Windows is not validated yet.
+macOS is the primary platform. Linux works. Windows is validated as a remote agent host.
 
 ## Start Here
 
@@ -160,25 +160,29 @@ on the same tailnet. Tandem is never exposed to the public internet.
 
 1. Open Tandem Settings > Connected Agents
 2. Select "On another machine" and generate a setup code
-3. On the remote machine, exchange the code for a durable token:
+3. Tandem generates a ready-to-use instruction block — copy it to your AI agent
+4. The AI exchanges the setup code for a permanent token and connects
 
-   ```bash
-   curl -X POST http://<tandem-tailscale-ip>:8765/pairing/exchange \
-     -H "Content-Type: application/json" \
-     -d '{"code":"TDM-XXXX-XXXX","machineId":"...","machineName":"...","agentLabel":"...","agentType":"..."}'
-   ```
-
-4. Use the returned token for all subsequent requests:
-
-   ```bash
-   curl -sS http://<tandem-tailscale-ip>:8765/status \
-     -H "Authorization: Bearer <token>"
-   ```
-
-The token is permanent until the user pauses, revokes, or removes it from
-Tandem's Connected Agents UI.
+The token is permanent until you pause, revoke, or remove it from the
+Connected Agents UI.
 
 Remote agents use the HTTP API. Remote MCP is not yet available.
+
+<details>
+<summary>Manual pairing (for scripts or custom tooling)</summary>
+
+```bash
+# Exchange setup code for token
+curl -X POST http://<tandem-tailscale-ip>:8765/pairing/exchange \
+  -H "Content-Type: application/json" \
+  -d '{"code":"TDM-XXXX-XXXX","machineId":"...","machineName":"...","agentLabel":"...","agentType":"..."}'
+
+# Use the returned token
+curl -sS http://<tandem-tailscale-ip>:8765/status \
+  -H "Authorization: Bearer <token>"
+```
+
+</details>
 
 ### Discovery
 

--- a/docs/api.html
+++ b/docs/api.html
@@ -113,7 +113,7 @@ footer a:hover{color:var(--text2)}
 <div class="hero">
 <div class="hero-label">HTTP API Reference</div>
 <h1>Full programmatic control over a real browser</h1>
-<p>Every endpoint runs on <code style="background:var(--bg3);padding:.15rem .4rem;border-radius:3px;font-size:.8rem;color:var(--green)">localhost:8765</code>. All responses return <code style="background:var(--bg3);padding:.15rem .4rem;border-radius:3px;font-size:.8rem;color:var(--green)">{ ok: true, data }</code> on success.</p>
+<p>Default port <code style="background:var(--bg3);padding:.15rem .4rem;border-radius:3px;font-size:.8rem;color:var(--green)">8765</code>. Accessible locally and remotely over Tailscale. Authenticate with <code style="background:var(--bg3);padding:.15rem .4rem;border-radius:3px;font-size:.8rem;color:var(--green)">Authorization: Bearer &lt;token&gt;</code>.</p>
 <div class="hero-stats">
 <div class="stat"><span class="stat-num">280+</span><span class="stat-label">Endpoints</span></div>
 <div class="stat"><span class="stat-num">19</span><span class="stat-label">Domains</span></div>
@@ -590,10 +590,11 @@ footer a:hover{color:var(--text2)}
 <!-- Info boxes -->
 <section>
 <div class="info-box">
-<p><strong>Base URL:</strong> <code>http://localhost:8765</code></p>
-<p style="margin-top:.5rem"><strong>Response format:</strong> All endpoints return <code>{ ok: true, data: ... }</code> on success and <code>{ ok: false, error: "message" }</code> on failure.</p>
+<p><strong>Base URL:</strong> <code>http://localhost:8765</code> (local) or <code>http://&lt;tailscale-ip&gt;:8765</code> (remote)</p>
+<p style="margin-top:.5rem"><strong>Auth:</strong> <code>Authorization: Bearer &lt;token&gt;</code> &mdash; local token from <code>~/.tandem/api-token</code> or binding token from pairing.</p>
+<p style="margin-top:.5rem"><strong>Discovery:</strong> <code>GET /agent/manifest</code> returns the full endpoint list as structured JSON. <code>GET /agent</code> returns a human-readable bootstrap page.</p>
 <p style="margin-top:.5rem"><strong>Tab targeting:</strong> Use the <code>X-Tab-Id</code> header to target a specific background tab without focusing it.</p>
-<p style="margin-top:.5rem"><strong>MCP alternative:</strong> Every HTTP endpoint has a corresponding MCP tool. See <a href="https://github.com/hydro13/tandem-browser/blob/main/skill/SKILL.md">skill/SKILL.md</a> for the MCP tool reference.</p>
+<p style="margin-top:.5rem"><strong>MCP alternative:</strong> Every HTTP endpoint has a corresponding MCP tool (same-machine agents only). See <a href="https://github.com/hydro13/tandem-browser/blob/main/skill/SKILL.md">skill/SKILL.md</a> for the MCP tool reference.</p>
 </div>
 </section>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -158,7 +158,7 @@ footer a:hover{color:var(--text2)}
 <div class="proof-strip">
 <div class="proof-card"><strong>Human-AI symbiosis</strong><span>Built around humans and agents working together in the same browser, not taking turns through prompts.</span></div>
 <div class="proof-card"><strong>Open source, MIT</strong><span>Real public repo, source available now, developer preview, not vaporware.</span></div>
-<div class="proof-card"><strong>Works with your AI stack</strong><span>MCP for agent clients, HTTP for custom tooling, local-first by default.</span></div>
+<div class="proof-card"><strong>Works with your AI stack</strong><span>MCP for local agents, HTTP for local and remote. Connect from the same machine or over Tailscale.</span></div>
 <div class="proof-card"><strong>Worth watching for teams</strong><span>Shared human-AI browser workflows, not detached automation or brittle wrappers.</span></div>
 </div>
 </div>
@@ -325,14 +325,16 @@ footer a:hover{color:var(--text2)}
 <div class="step-content">
 <h3>Start the browser</h3>
 <p><code>npm start</code><br>
-The browser opens. The API starts on <code>localhost:8765</code>.</p>
+The browser opens. The API starts automatically.</p>
 </div>
 </div>
 <div class="step">
 <div class="step-num">3</div>
 <div class="step-content">
 <h3>Connect your AI</h3>
-<p>Add the MCP server to Claude Desktop, claude.ai, or any MCP-compatible agent. Or talk HTTP to <code>localhost:8765</code> from any tool.</p>
+<p>Open Settings &rarr; Connected Agents. Choose whether your AI is on this machine or on another machine. Tandem generates the instructions &mdash; just copy them to your AI.</p>
+<p style="margin-top:.4rem"><strong>Same machine:</strong> MCP (250 tools) or HTTP API (300+ endpoints).<br>
+<strong>Remote machine:</strong> HTTP API over a private Tailscale network. Both machines must be on the same tailnet. Tandem is never exposed to the public internet.</p>
 </div>
 </div>
 </div>


### PR DESCRIPTION
## Summary

Post-merge copy alignment after remote agent pairing landed in #132.

Public-facing docs and website copy still implied localhost-only, MCP-first, no in-app onboarding. This fixes the three surfaces with the most visible drift.

## What changed

### docs/index.html (website)
- **Get started step 3** — was "Add MCP server or talk HTTP to localhost:8765". Now leads with the actual flow: Settings → Connected Agents → Tandem generates instructions. Covers same-machine (MCP/HTTP) and remote (Tailscale HTTP).
- **Proof card** — was "MCP for agent clients, HTTP for custom tooling, local-first by default". Now: "MCP for local agents, HTTP for local and remote. Connect from the same machine or over Tailscale."

### docs/api.html (API docs)
- **Hero text** — was "Every endpoint runs on localhost:8765". Now: "Default port 8765. Accessible locally and remotely over Tailscale." with auth info.
- **Info box** — was "Base URL: http://localhost:8765". Now shows local + Tailscale base URLs, auth methods, discovery endpoints, and marks MCP as same-machine only.

### README.md
- **Remote section** — was curl-first as the primary mental model. Now UI-first: Settings → generate instructions → copy to AI. Curl examples moved to a collapsible details block for scripts/custom tooling.
- **Quick Start** — was "Windows is not validated yet" (contradicted the Status section). Fixed to "Windows is validated as a remote agent host."

## Not changed (already correct)

- shell/settings.html — in-app copy was already accurate
- Bootstrap routes (/agent, /skill) — already accurate
- PROJECT.md, skill/SKILL.md — already updated in #132