### PR TITLE
docs: align onboarding copy across README, website, and settings UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,24 @@ Depending on what you want to do:
 Tandem supports AI agents running on the same machine or on a remote machine
 over a private Tailscale network. Both can be active at the same time.
 
+The primary onboarding flow is now inside Tandem itself:
+
+1. Open **Settings -> Connected Agents**
+2. Choose **On this machine** or **On another machine**
+3. Let Tandem generate the connection instructions
+4. Paste those instructions into your AI agent
+
+Tandem handles the setup-code flow and publishes its own bootstrap/discovery
+surface for the agent at `/agent`, `/agent/manifest`, `/agent/version`, and
+`/skill`.
+
 ### On the same machine (MCP or HTTP)
+
+If your AI runs on the same machine as Tandem, the simplest path is:
+
+1. Open **Settings -> Connected Agents**
+2. Choose **On this machine**
+3. Copy the generated instructions into your AI
 
 **MCP** — Add to your MCP client configuration (Claude Code, Claude Desktop,
 Cursor, Windsurf, or any MCP client):
@@ -158,15 +175,16 @@ curl -sS http://127.0.0.1:8765/tabs/list \
 Remote agents connect over a private Tailscale network. Both machines must be
 on the same tailnet. Tandem is never exposed to the public internet.
 
-1. Open Tandem Settings > Connected Agents
-2. Select "On another machine" and generate a setup code
-3. Tandem generates a ready-to-use instruction block — copy it to your AI agent
-4. The AI exchanges the setup code for a permanent token and connects
+1. Open **Settings -> Connected Agents**
+2. Choose **On another machine**
+3. Tandem detects the Tailscale address and generates a ready-to-use instruction block
+4. Paste that instruction block into your remote AI agent
+5. The AI reads `/agent`, exchanges the setup code for a permanent token, and connects
 
-The token is permanent until you pause, revoke, or remove it from the
+The token stays valid until you pause, revoke, or remove it from the
 Connected Agents UI.
 
-Remote agents use the HTTP API. Remote MCP is not yet available.
+Remote agents use the HTTP API today. Remote MCP is not yet available.
 
 <details>
 <summary>Manual pairing (for scripts or custom tooling)</summary>

--- a/docs/index.html
+++ b/docs/index.html
@@ -158,7 +158,7 @@ footer a:hover{color:var(--text2)}
 <div class="proof-strip">
 <div class="proof-card"><strong>Human-AI symbiosis</strong><span>Built around humans and agents working together in the same browser, not taking turns through prompts.</span></div>
 <div class="proof-card"><strong>Open source, MIT</strong><span>Real public repo, source available now, developer preview, not vaporware.</span></div>
-<div class="proof-card"><strong>Works with your AI stack</strong><span>MCP for local agents, HTTP for local and remote. Connect from the same machine or over Tailscale.</span></div>
+<div class="proof-card"><strong>Works with your AI stack</strong><span>MCP for same-machine agents, HTTP for same-machine and remote agents. Connect locally or over Tailscale.</span></div>
 <div class="proof-card"><strong>Worth watching for teams</strong><span>Shared human-AI browser workflows, not detached automation or brittle wrappers.</span></div>
 </div>
 </div>
@@ -332,9 +332,10 @@ The browser opens. The API starts automatically.</p>
 <div class="step-num">3</div>
 <div class="step-content">
 <h3>Connect your AI</h3>
-<p>Open Settings &rarr; Connected Agents. Choose whether your AI is on this machine or on another machine. Tandem generates the instructions &mdash; just copy them to your AI.</p>
+<p>Open Settings &rarr; Connected Agents. Choose whether your AI is on this machine or on another machine. Tandem generates the instructions, you paste them into your AI, and the agent discovers the rest through Tandem's own bootstrap surface.</p>
 <p style="margin-top:.4rem"><strong>Same machine:</strong> MCP (250 tools) or HTTP API (300+ endpoints).<br>
-<strong>Remote machine:</strong> HTTP API over a private Tailscale network. Both machines must be on the same tailnet. Tandem is never exposed to the public internet.</p>
+<strong>Another machine:</strong> HTTP API over a private Tailscale network. Both machines must be on the same tailnet. Tandem is never exposed to the public internet.</p>
+<p style="margin-top:.4rem;color:var(--text2)">Remote MCP is not available yet. Remote agents use Tandem's HTTP API after pairing.</p>
 </div>
 </div>
 </div>

--- a/shell/settings.html
+++ b/shell/settings.html
@@ -2286,6 +2286,7 @@
         const addr = detectedAddresses ? detectedAddresses.local.address : 'http://127.0.0.1:8765';
         info.innerHTML = `
           <p class="field-desc">Your AI and Tandem are on the same machine.</p>
+          <p class="field-desc" style="margin-top:4px;">Tandem will generate a ready-to-paste instruction block for your AI.</p>
           <div style="font-size:13px;color:var(--text-dim);margin-top:6px;">
             Tandem address: <strong style="color:var(--text)">${esc(addr)}</strong>
           </div>`;
@@ -2296,6 +2297,7 @@
           const addr = detectedAddresses.tailscale.address;
           info.innerHTML = `
             <p class="field-desc">Your AI runs on another machine in your Tailscale network.</p>
+            <p class="field-desc" style="margin-top:4px;">Tandem will generate a ready-to-paste instruction block for your remote AI.</p>
             <div style="font-size:13px;color:var(--text-dim);margin-top:6px;">
               Tandem address: <strong style="color:var(--text)">${esc(addr)}</strong>
             </div>
@@ -2320,36 +2322,38 @@
 
       if (mode === 'local') {
         return [
-          `Connect to Tandem Browser running on this machine.`,
+          `Connect to Tandem Browser on this machine.`,
           ``,
           `Tandem address: ${addr}`,
           `Setup code: ${code}`,
           ``,
-          `Steps:`,
-          `1. Read ${addr}/agent to learn how this Tandem instance works.`,
-          `2. Exchange the setup code for a connection token:`,
-          `   POST ${addr}/pairing/exchange`,
-          `   Body: { "code": "${code}", "machineId": "<your-machine-id>", "machineName": "<your-hostname>", "agentLabel": "<your-name>", "agentType": "<your-type>", "bindingKind": "local" }`,
-          `3. Use the returned token as: Authorization: Bearer <token>`,
-          `4. The token is permanent. Store it securely.`,
+          `Read ${addr}/agent first. It explains how this Tandem instance works.`,
+          ``,
+          `Then exchange the setup code for a connection token:`,
+          `POST ${addr}/pairing/exchange`,
+          `Body: { "code": "${code}", "machineId": "<your-machine-id>", "machineName": "<your-hostname>", "agentLabel": "<your-name>", "agentType": "<your-type>", "bindingKind": "local" }`,
+          ``,
+          `Use the returned token as: Authorization: Bearer <token>`,
+          `Store it securely.`,
         ].join('\n');
       } else {
         return [
-          `Connect to Tandem Browser on a remote machine via Tailscale.`,
+          `Connect to Tandem Browser on another machine via Tailscale.`,
           `Both machines must be on the same Tailscale network.`,
           ``,
           `Tandem address: ${addr}`,
           `Setup code: ${code}`,
           ``,
-          `Steps:`,
-          `1. Read ${addr}/agent to learn how this Tandem instance works.`,
-          `2. Exchange the setup code for a connection token:`,
-          `   POST ${addr}/pairing/exchange`,
-          `   Body: { "code": "${code}", "machineId": "<your-machine-id>", "machineName": "<your-hostname>", "agentLabel": "<your-name>", "agentType": "<your-type>", "bindingKind": "remote" }`,
-          `3. Use the returned token as: Authorization: Bearer <token>`,
-          `4. The token is permanent. Store it securely.`,
+          `Read ${addr}/agent first. It explains how this Tandem instance works.`,
           ``,
-          `Note: This connection only works over Tailscale. Tandem is not exposed to the public internet.`,
+          `Then exchange the setup code for a connection token:`,
+          `POST ${addr}/pairing/exchange`,
+          `Body: { "code": "${code}", "machineId": "<your-machine-id>", "machineName": "<your-hostname>", "agentLabel": "<your-name>", "agentType": "<your-type>", "bindingKind": "remote" }`,
+          ``,
+          `Use the returned token as: Authorization: Bearer <token>`,
+          `Store it securely.`,
+          ``,
+          `This connection works only over Tailscale. Tandem is not exposed to the public internet.`,
         ].join('\n');
       }
     }


### PR DESCRIPTION
## Summary

This follow-up PR aligns the public-facing onboarding copy with the remote-agent pairing work that already landed.

It updates:
- `README.md`
- `docs/index.html`
- `shell/settings.html`

## What changed

- README now tells the onboarding story in a more UI-first way
- website copy now reflects the actual same-machine vs another-machine flow
- in-app Connected Agents copy is clearer and more product-aligned
- remote remains explicitly Tailscale-only
- remote MCP is still explicitly called out as not available yet

## Why

The previous feature PR shipped the functionality, but some public-facing copy still reflected an older, more technical or localhost-centered mental model.

This PR makes the product story match what Tandem actually does today.

## Scope

Docs/copy only.
No behavior changes.