### PR TITLE
chore: audit and clean up dev setup script references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -392,16 +392,15 @@ Tested:
 | `refactor:` | none | code restructuring |
 | `test:` | none | tests |
 
-### Important: No Emoji Before the Type Prefix
+### Emoji in Commit Messages
+
+The auto-versioning hook strips leading emoji, so both forms work:
 
 ```text
 ✅ feat: sidebar manager + config API
-✅ fix: version bump hook matches emoji commits
-❌ 🗂️ feat: sidebar manager  ← emoji breaks the auto-versioning hook
+✅ 🗂️ feat: sidebar manager          ← hook strips the emoji prefix
+✅ feat: sidebar manager 🗂️           ← also fine
 ```
-
-Emoji are allowed after the description:
-`feat: sidebar manager 🗂️`
 
 ### CHANGELOG.md Format
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,20 @@ For manual app testing:
 npm start
 ```
 
+### Auto-versioning hook (optional)
+
+The repo includes a `post-commit` hook that auto-bumps the version in
+`package.json` and updates `CHANGELOG.md`. It only fires on the `main` branch,
+so feature-branch contributors can ignore it.
+
+If you merge directly to main and want the hook active:
+
+```bash
+./setup-dev.sh
+```
+
+See [git-hooks/README.md](git-hooks/README.md) for details.
+
 If your change affects the Electron shell, screenshots, permissions, packaging,
 or the local API lifecycle, do a manual app sanity check in addition to
 `npm run verify`.

--- a/git-hooks/README.md
+++ b/git-hooks/README.md
@@ -2,16 +2,24 @@
 
 ## post-commit
 
-Runs after every commit and automatically:
-- Parses commit message (conventional commits)
+Runs after every commit **on the `main` branch only** and automatically:
+
+- Parses the commit message (conventional commits)
+- Strips leading emoji so `🗂️ feat: …` is recognised as `feat:`
 - Bumps version in `package.json` based on commit type:
   - `fix:` → patch (0.14.3 → 0.14.4)
-  - `feat:` → minor (0.14.3 → 0.15.0)  
+  - `feat:` → minor (0.14.3 → 0.15.0)
   - `feat!:` or `BREAKING CHANGE` → major (0.14.3 → 1.0.0)
 - Updates `CHANGELOG.md` with new entry
+- Updates `shell/about.html` version string
 - Creates follow-up commit: `chore: bump to vX.Y.Z`
 
-## Installation
+Commits on feature branches are not affected.
+
+## Installation (optional)
+
+The hook is only needed if you merge directly to `main`.
+Feature-branch contributors can skip this step.
 
 Run from repo root:
 ```bash

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-# Tandem Browser — Development Setup
-# Run this after cloning to configure auto-versioning + git hooks
+# Tandem Browser — Development Setup (optional)
+# Installs the auto-versioning git hook used on the main branch.
+# Feature-branch contributors do not need this — the hook only fires on main.
 
 echo "🔧 Tandem Browser Development Setup"
 echo ""
@@ -10,6 +11,7 @@ echo "📦 Installing git hooks..."
 git config core.hooksPath git-hooks
 chmod +x git-hooks/post-commit
 echo "   ✅ Auto-versioning hook installed (git-hooks/post-commit)"
+echo "   ℹ️  The hook only runs on the main branch."
 
 # 2. Check git config
 echo ""
@@ -37,7 +39,7 @@ else
 fi
 
 if [ ! -d "node_modules" ]; then
-  echo "   ⚠️  node_modules missing — run 'pnpm install' or 'npm install'"
+  echo "   ⚠️  node_modules missing — run 'npm install'"
 else
   echo "   ✅ node_modules installed"
 fi
@@ -45,7 +47,7 @@ fi
 echo ""
 echo "✅ Setup complete!"
 echo ""
-echo "📝 Commit convention:"
+echo "📝 Commit convention (version bumps happen automatically on main):"
 echo "   fix: ...     → patch bump (0.14.3 → 0.14.4)"
 echo "   feat: ...    → minor bump (0.14.3 → 0.15.0)"
 echo "   feat!: ...   → major bump (0.14.3 → 1.0.0)"


### PR DESCRIPTION
## Summary

This PR audits the root-level dev setup flow around `setup-dev.sh` and the git hook documentation, then updates the repo to match the current contributor workflow.

## What changed

- **setup-dev.sh**: removed stale `pnpm` reference (repo is npm-first), clarified the hook is main-branch-only, marked the script as optional
- **git-hooks/README.md**: documented that the hook only fires on `main`, added emoji-stripping behavior, noted `shell/about.html` update, marked installation as optional for feature-branch contributors
- **CONTRIBUTING.md**: added a short "Auto-versioning hook" subsection so contributors know it exists and can ignore it on feature branches
- **AGENTS.md**: fixed stale emoji warning — the hook now strips leading emoji, so `🗂️ feat:` works correctly; updated the guidance accordingly

## Why

The repo root still exposes `setup-dev.sh`, but the documented workflow (`npm install` → `npm run verify`) never mentioned it. The git-hooks README didn't say the hook is main-branch-only. AGENTS.md warned against emoji prefixes that the hook has handled since emoji-stripping was added. This PR makes the setup path explicit, current, and easier to trust.

## Scope

Repo hygiene and docs/setup flow only.
No product behavior changes.

## Test plan

- [x] Reviewed all references to `setup-dev.sh`, `git-hooks`, `post-commit`, and `auto-versioning` across the repo
- [x] Confirmed the post-commit hook strips emoji (line 15 of `git-hooks/post-commit`)
- [x] Confirmed the hook exits early on non-main branches (line 4)
- [x] Verified no CHANGELOG.md historical entries were modified