### PR TITLE
docs: update public copy for remote MCP support

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -31,7 +31,7 @@ The security layer exists because when an AI has access to your browser, your th
 Data stays local. Sessions are isolated. Nothing leaves the machine through Tandem Browser without going through a filter first.
 
 **GitHub:** `hydro13/tandem-browser`  
-**Current version:** `0.73.0`  
+**Current version:** `0.73.1`  
 **Repository status:** Public developer preview  
 **Started:** February 11, 2026
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ curl -sS http://127.0.0.1:8765/tabs/list \
 
 300+ endpoints for everything the MCP tools can do, plus lower-level access.
 
-### On another machine (Tailscale + HTTP)
+### On another machine (Tailscale)
 
 Remote agents connect over a private Tailscale network. Both machines must be
 on the same tailnet. Tandem is never exposed to the public internet.
@@ -184,7 +184,25 @@ on the same tailnet. Tandem is never exposed to the public internet.
 The token stays valid until you pause, revoke, or remove it from the
 Connected Agents UI.
 
-Remote agents use the HTTP API today. Remote MCP is not yet available.
+**MCP** (recommended for Claude Code, Cursor, and other MCP clients):
+
+```json
+{
+  "mcpServers": {
+    "tandem": {
+      "type": "streamable-http",
+      "url": "http://<tandem-tailscale-ip>:8765/mcp",
+      "headers": {
+        "Authorization": "Bearer <your-binding-token>"
+      }
+    }
+  }
+}
+```
+
+**HTTP API** works the same way as local, using the binding token as Bearer auth.
+
+Both transports give remote agents the same 250 tools and 300+ endpoints as local agents.
 
 <details>
 <summary>Manual pairing (for scripts or custom tooling)</summary>
@@ -274,7 +292,7 @@ contributors, not yet a polished mass-user release.
 - Secondary platform: Linux
 - Windows: validated as a remote agent host (VS Code + Claude Code over Tailscale)
 - Binaries: not published yet (source-only)
-- Current version: `0.73.0`
+- Current version: `0.73.1`
 - Package metadata: [package.json](package.json)
 
 ## Community

--- a/docs/index.html
+++ b/docs/index.html
@@ -140,7 +140,7 @@ footer a:hover{color:var(--text2)}
 </header>
 
 <div class="hero">
-<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v0.73.0</div>
+<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v0.73.1</div>
 <h1>Tandem Browser is the <em>human-AI symbiotic browser</em></h1>
 <p>A local-first browser where humans and AI agents work in shared context. Same tabs, same sessions, same authenticated browser state, with explicit handoffs when the human needs to step in. Not generic browser automation, an actual shared browser workspace for the web that already exists.</p>
 <div class="hero-stats">
@@ -158,7 +158,7 @@ footer a:hover{color:var(--text2)}
 <div class="proof-strip">
 <div class="proof-card"><strong>Human-AI symbiosis</strong><span>Built around humans and agents working together in the same browser, not taking turns through prompts.</span></div>
 <div class="proof-card"><strong>Open source, MIT</strong><span>Real public repo, source available now, developer preview, not vaporware.</span></div>
-<div class="proof-card"><strong>Works with your AI stack</strong><span>MCP for same-machine agents, HTTP for same-machine and remote agents. Connect locally or over Tailscale.</span></div>
+<div class="proof-card"><strong>Works with your AI stack</strong><span>MCP and HTTP for local and remote agents. Connect on the same machine or over a private Tailscale network.</span></div>
 <div class="proof-card"><strong>Worth watching for teams</strong><span>Shared human-AI browser workflows, not detached automation or brittle wrappers.</span></div>
 </div>
 </div>
@@ -333,9 +333,8 @@ The browser opens. The API starts automatically.</p>
 <div class="step-content">
 <h3>Connect your AI</h3>
 <p>Open Settings &rarr; Connected Agents. Choose whether your AI is on this machine or on another machine. Tandem generates the instructions, you paste them into your AI, and the agent discovers the rest through Tandem's own bootstrap surface.</p>
-<p style="margin-top:.4rem"><strong>Same machine:</strong> MCP (250 tools) or HTTP API (300+ endpoints).<br>
-<strong>Another machine:</strong> HTTP API over a private Tailscale network. Both machines must be on the same tailnet. Tandem is never exposed to the public internet.</p>
-<p style="margin-top:.4rem;color:var(--text2)">Remote MCP is not available yet. Remote agents use Tandem's HTTP API after pairing.</p>
+<p style="margin-top:.4rem"><strong>Same machine:</strong> MCP via stdio (250 tools) or HTTP API (300+ endpoints).<br>
+<strong>Another machine:</strong> MCP via Streamable HTTP or HTTP API, over a private Tailscale network. Both machines must be on the same tailnet. Tandem is never exposed to the public internet.</p>
 </div>
 </div>
 </div>

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tandem-browser
-description: Use Tandem Browser's MCP server (local agents) or HTTP API (local and remote agents) to inspect, browse, and interact with the user's shared browser safely. Prefer targeted tabs and sessions, use snapshot refs before raw DOM or JS, verify action completion explicitly, and leave durable handoffs instead of retrying blindly.
+description: Use Tandem Browser's MCP server (local and remote agents) or HTTP API (local and remote agents) to inspect, browse, and interact with the user's shared browser safely. Prefer targeted tabs and sessions, use snapshot refs before raw DOM or JS, verify action completion explicitly, and leave durable handoffs instead of retrying blindly.
 homepage: https://github.com/hydro13/tandem-browser
 user-invocable: false
 metadata: {"openclaw":{"emoji":"🚲","requires":{"bins":["curl","node"]}}}
@@ -29,7 +29,7 @@ instead of a sandbox browser, especially for:
 ## Connecting to Tandem
 
 Tandem supports agents on the same machine (MCP or HTTP) and on remote machines
-over a private Tailscale network (HTTP only). Both can be active at the same
+over a private Tailscale network (MCP or HTTP). Both can be active at the same
 time.
 
 ### Discovery
@@ -63,10 +63,12 @@ Practical notes:
 - MCP and HTTP are connection layers to Tandem, not substitutes for a running
   Tandem instance
 
-### Option 1: MCP Server (same machine only)
+### Option 1: MCP Server (local or remote)
 
-The MCP server exposes 250 tools with full API parity. Add to your MCP client
-configuration (e.g. `~/.claude/settings.json` for Claude Code):
+The MCP server exposes 250 tools with full API parity.
+
+**Same machine (stdio):** Add to your MCP client configuration
+(e.g. `~/.claude/settings.json` for Claude Code):
 
 ```json
 {
@@ -79,18 +81,32 @@ configuration (e.g. `~/.claude/settings.json` for Claude Code):
 }
 ```
 
+**Remote machine (Streamable HTTP over Tailscale):** Pair first via
+Settings > Connected Agents, then configure:
+
+```json
+{
+  "mcpServers": {
+    "tandem": {
+      "type": "streamable-http",
+      "url": "http://<tandem-tailscale-ip>:8765/mcp",
+      "headers": {
+        "Authorization": "Bearer <your-binding-token>"
+      }
+    }
+  }
+}
+```
+
 Start Tandem (`npm start`), and the agent can connect to the running MCP server.
 All MCP tools mirror the HTTP API below, so the same capabilities are available
 through either connection method when the client supports them.
 
-MCP uses stdio transport and requires the agent to run on the same machine as
-Tandem. Remote MCP is not yet available.
-
 ### Option 2: HTTP API (local or remote)
 
-Use direct HTTP when the client can call the API itself, or when the agent is
-on a remote machine. Local agents use the token from `~/.tandem/api-token`.
-Remote agents use a binding token obtained through Tandem's pairing flow.
+Use direct HTTP when the client can call the API itself. Local agents use the
+token from `~/.tandem/api-token`. Remote agents use a binding token obtained
+through Tandem's pairing flow.
 
 ```bash
 API="http://127.0.0.1:8765"            # or http://<tailscale-ip>:8765 for remote


### PR DESCRIPTION
## Summary

Remote MCP is shipped. Public copy still said remote agents were HTTP-only in several places. This PR fixes that.

## What changed

- **README.md**: remote section now includes MCP config example, header no longer says "HTTP", removed "Remote MCP is not yet available"
- **docs/index.html**: proof card and get-started section updated to reflect MCP for both local and remote
- **skill/SKILL.md**: MCP option covers both stdio (local) and Streamable HTTP (remote), description updated
- Version references bumped to 0.73.1

## What did not change

- No code changes
- No new features described that are not already shipped
- Bootstrap/discovery routes were already updated in the remote MCP PR