### PR TITLE
refactor(shell): migrate wingman to ES module

### DIFF
--- a/shell/index.html
+++ b/shell/index.html
@@ -412,7 +412,7 @@
   <script src="js/window-chrome.js"></script>
   <script src="js/draw.js"></script>
   <script src="js/browser-tools.js"></script>
-  <script src="js/wingman.js"></script>
+  <script type="module" src="js/wingman/index.js"></script>
   <!-- ClaroNote disabled — decoupled, coming in a later update -->
   <!-- <script src="js/claronote.js"></script> -->
   <script src="js/extensions.js"></script>

--- a/shell/js/wingman/index.js
+++ b/shell/js/wingman/index.js
@@ -1,8 +1,13 @@
-(() => {
+/**
+ * Wingman module entry point — all wingman UI + alerts + chat.
+ *
+ * Loaded from: shell/index.html as <script type="module" src="js/wingman/index.js">
+ * window exports: chatRouter, dismissAlert, openWingmanPanel, toggleWingmanPanel, updatePanelLayout
+ */
     const renderer = window.__tandemRenderer;
     if (!renderer) {
       console.error('[wingman] Missing renderer bridge');
-      return;
+      throw new Error('[wingman] Missing renderer bridge');
     }
 
     const overlay = renderer.overlay;
@@ -1665,4 +1670,3 @@
     window.openWingmanPanel = openWingmanPanel;
     window.toggleWingmanPanel = toggleWingmanPanel;
     window.updatePanelLayout = updatePanelLayout;
-})();


### PR DESCRIPTION
## Summary

- Move `shell/js/wingman.js` → `shell/js/wingman/index.js` (verbatim content, IIFE wrapper stripped)
- Update `shell/index.html` script tag: `<script src="js/wingman.js">` → `<script type="module" src="js/wingman/index.js">`
- Delete `shell/js/wingman.js`

## Rationale

First step in splitting the 1,668-line `wingman.js` into focused ES modules (Tasks 2–5 of the ESM refactor plan). This PR exists only to prove that ES modules load correctly in the Electron renderer before any logic is moved. Zero behaviour changes.

**One strict-mode fix:** the original IIFE used a top-level `return` to bail out when `window.__tandemRenderer` is missing. Top-level `return` is a syntax error in ES modules, so it is converted to `throw new Error(...)` — equivalent semantics, same visible effect (module stops executing, error is logged to DevTools).

All five `window.*` exports are unchanged:
- `window.chatRouter`
- `window.dismissAlert`
- `window.openWingmanPanel`
- `window.toggleWingmanPanel`
- `window.updatePanelLayout`

## Test plan

- [x] CI green
- [ ] Wingman panel opens (Cmd+K)
- [x] Chat sends + streams response
- [ ] `dismissAlert()` works via inline onclick
- [ ] Screenshot + region capture work
- [ ] Voice input works
- [ ] Live mode + emergency stop work