### PR TITLE
refactor(shell): extract wingman alerts and screenshot

### DIFF
--- a/shell/js/wingman/alerts.js
+++ b/shell/js/wingman/alerts.js
@@ -1,0 +1,28 @@
+/**
+ * Wingman alert overlay — transient "agent needs you" toasts.
+ *
+ * Loaded from: shell/js/wingman/index.js
+ * window exports: dismissAlert (inline onclick in index.html needs this)
+ */
+
+let _overlay = null;
+
+export function initAlerts(renderer) {
+  _overlay = renderer.overlay;
+
+  if (window.tandem) {
+    window.tandem.onWingmanAlert((data) => {
+      document.getElementById('alert-title').textContent = data.title;
+      document.getElementById('alert-body').textContent = data.body;
+      _overlay.classList.add('visible');
+      setTimeout(dismissAlert, 15000);
+    });
+  }
+}
+
+export function dismissAlert() {
+  _overlay?.classList.remove('visible');
+}
+
+// Inline onclick="dismissAlert()" in shell/index.html requires this binding
+window.dismissAlert = dismissAlert;

--- a/shell/js/wingman/alerts.js
+++ b/shell/js/wingman/alerts.js
@@ -14,7 +14,7 @@ export function initAlerts(renderer) {
     window.tandem.onWingmanAlert((data) => {
       document.getElementById('alert-title').textContent = data.title;
       document.getElementById('alert-body').textContent = data.body;
-      _overlay.classList.add('visible');
+      _overlay?.classList.add('visible');
       setTimeout(dismissAlert, 15000);
     });
   }

--- a/shell/js/wingman/index.js
+++ b/shell/js/wingman/index.js
@@ -2,9 +2,12 @@
  * Wingman module entry point — all wingman UI + alerts + chat.
  *
  * Loaded from: shell/index.html as <script type="module" src="js/wingman/index.js">
- * window exports: chatRouter, dismissAlert, openWingmanPanel, toggleWingmanPanel, updatePanelLayout
+ * window exports (set across the family): chatRouter, dismissAlert,
+ *   openWingmanPanel, toggleWingmanPanel, updatePanelLayout.
+ *   This file sets: chatRouter, openWingmanPanel, toggleWingmanPanel, updatePanelLayout.
+ *   dismissAlert is set by ./alerts.js.
  */
-    import { initAlerts, dismissAlert } from './alerts.js';
+    import { initAlerts } from './alerts.js';
     import { initScreenshot, captureScreenshotMode } from './screenshot.js';
 
     const renderer = window.__tandemRenderer;
@@ -14,7 +17,7 @@
     }
 
     initAlerts(renderer);
-    initScreenshot(renderer);
+    initScreenshot();
 
     function getTabs() {
       return renderer.getTabs();

--- a/shell/js/wingman/index.js
+++ b/shell/js/wingman/index.js
@@ -4,16 +4,17 @@
  * Loaded from: shell/index.html as <script type="module" src="js/wingman/index.js">
  * window exports: chatRouter, dismissAlert, openWingmanPanel, toggleWingmanPanel, updatePanelLayout
  */
+    import { initAlerts, dismissAlert } from './alerts.js';
+    import { initScreenshot, captureScreenshotMode } from './screenshot.js';
+
     const renderer = window.__tandemRenderer;
     if (!renderer) {
       console.error('[wingman] Missing renderer bridge');
       throw new Error('[wingman] Missing renderer bridge');
     }
 
-    const overlay = renderer.overlay;
-    const screenshotButton = document.getElementById('btn-screenshot');
-    const regionOverlay = document.getElementById('region-capture-overlay');
-    const regionBox = document.getElementById('region-capture-box');
+    initAlerts(renderer);
+    initScreenshot(renderer);
 
     function getTabs() {
       return renderer.getTabs();
@@ -34,118 +35,6 @@
     wingmanBadge.addEventListener('mouseleave', () => { clearTimeout(wingmanBadgePressTimer); });
     wingmanBadge.style.cursor = 'pointer';
     wingmanBadge.title = 'Right-click for settings';
-
-    function updateRegionBox(startX, startY, currentX, currentY) {
-      const left = Math.min(startX, currentX);
-      const top = Math.min(startY, currentY);
-      const width = Math.abs(currentX - startX);
-      const height = Math.abs(currentY - startY);
-      regionBox.style.display = 'block';
-      regionBox.style.left = `${left}px`;
-      regionBox.style.top = `${top}px`;
-      regionBox.style.width = `${width}px`;
-      regionBox.style.height = `${height}px`;
-    }
-
-    function selectRegion() {
-      return new Promise((resolve) => {
-        let startX = 0;
-        let startY = 0;
-        let dragging = false;
-
-        regionOverlay.classList.add('active');
-        regionBox.style.display = 'none';
-
-        const cleanup = (result = null) => {
-          regionOverlay.classList.remove('active');
-          regionBox.style.display = 'none';
-          regionOverlay.removeEventListener('mousedown', onMouseDown);
-          regionOverlay.removeEventListener('mousemove', onMouseMove);
-          regionOverlay.removeEventListener('mouseup', onMouseUp);
-          window.removeEventListener('keydown', onKeyDown, true);
-          resolve(result);
-        };
-
-        const onMouseDown = (event) => {
-          dragging = true;
-          startX = event.clientX;
-          startY = event.clientY;
-          updateRegionBox(startX, startY, startX, startY);
-        };
-
-        const onMouseMove = (event) => {
-          if (!dragging) return;
-          updateRegionBox(startX, startY, event.clientX, event.clientY);
-        };
-
-        const onMouseUp = (event) => {
-          if (!dragging) return cleanup();
-          dragging = false;
-          const left = Math.min(startX, event.clientX);
-          const top = Math.min(startY, event.clientY);
-          const width = Math.abs(event.clientX - startX);
-          const height = Math.abs(event.clientY - startY);
-          if (width < 4 || height < 4) {
-            cleanup();
-            return;
-          }
-          cleanup({ x: left, y: top, width, height });
-        };
-
-        const onKeyDown = (event) => {
-          if (event.key === 'Escape') {
-            event.preventDefault();
-            cleanup();
-          }
-        };
-
-        regionOverlay.addEventListener('mousedown', onMouseDown);
-        regionOverlay.addEventListener('mousemove', onMouseMove);
-        regionOverlay.addEventListener('mouseup', onMouseUp);
-        window.addEventListener('keydown', onKeyDown, true);
-      });
-    }
-
-    async function captureScreenshotMode(mode) {
-      if (!window.tandem) return;
-
-      if (mode === 'region') {
-        const region = await selectRegion();
-        if (!region) return;
-        // Wait two frames so the overlay is fully painted away before capture
-        await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
-        await window.tandem.captureScreenshot('region', region);
-        return;
-      }
-
-      await window.tandem.captureScreenshot(mode);
-    }
-
-    screenshotButton.addEventListener('click', (event) => {
-      event.stopPropagation();
-      const rect = screenshotButton.getBoundingClientRect();
-      void window.tandem?.showScreenshotMenu({
-        x: Math.round(rect.left),
-        y: Math.round(rect.bottom + 6),
-      });
-    });
-
-    // ═══════════════════════════════════════════════
-    // Wingman alerts
-    // ═══════════════════════════════════════════════
-
-    if (window.tandem) {
-      window.tandem.onWingmanAlert((data) => {
-        document.getElementById('alert-title').textContent = data.title;
-        document.getElementById('alert-body').textContent = data.body;
-        overlay.classList.add('visible');
-        setTimeout(dismissAlert, 15000);
-      });
-    }
-
-    function dismissAlert() {
-      overlay.classList.remove('visible');
-    }
 
     // ═══════════════════════════════════════════════
     // Wingman Panel
@@ -1666,7 +1555,6 @@
     updatePanelLayout();
 
     window.chatRouter = chatRouter;
-    window.dismissAlert = dismissAlert;
     window.openWingmanPanel = openWingmanPanel;
     window.toggleWingmanPanel = toggleWingmanPanel;
     window.updatePanelLayout = updatePanelLayout;

--- a/shell/js/wingman/screenshot.js
+++ b/shell/js/wingman/screenshot.js
@@ -1,0 +1,112 @@
+/**
+ * Screenshot button + region-capture drag overlay.
+ *
+ * Loaded from: shell/js/wingman/index.js
+ * window exports: none
+ */
+
+const screenshotButton = document.getElementById('btn-screenshot');
+const regionOverlay = document.getElementById('region-capture-overlay');
+const regionBox = document.getElementById('region-capture-box');
+
+function updateRegionBox(startX, startY, currentX, currentY) {
+  const left = Math.min(startX, currentX);
+  const top = Math.min(startY, currentY);
+  const width = Math.abs(currentX - startX);
+  const height = Math.abs(currentY - startY);
+  regionBox.style.display = 'block';
+  regionBox.style.left = `${left}px`;
+  regionBox.style.top = `${top}px`;
+  regionBox.style.width = `${width}px`;
+  regionBox.style.height = `${height}px`;
+}
+
+export function selectRegion() {
+  return new Promise((resolve) => {
+    let startX = 0;
+    let startY = 0;
+    let dragging = false;
+
+    regionOverlay.classList.add('active');
+    regionBox.style.display = 'none';
+
+    const cleanup = (result = null) => {
+      regionOverlay.classList.remove('active');
+      regionBox.style.display = 'none';
+      regionOverlay.removeEventListener('mousedown', onMouseDown);
+      regionOverlay.removeEventListener('mousemove', onMouseMove);
+      regionOverlay.removeEventListener('mouseup', onMouseUp);
+      window.removeEventListener('keydown', onKeyDown, true);
+      resolve(result);
+    };
+
+    const onMouseDown = (event) => {
+      dragging = true;
+      startX = event.clientX;
+      startY = event.clientY;
+      updateRegionBox(startX, startY, startX, startY);
+    };
+
+    const onMouseMove = (event) => {
+      if (!dragging) return;
+      updateRegionBox(startX, startY, event.clientX, event.clientY);
+    };
+
+    const onMouseUp = (event) => {
+      if (!dragging) return cleanup();
+      dragging = false;
+      const left = Math.min(startX, event.clientX);
+      const top = Math.min(startY, event.clientY);
+      const width = Math.abs(event.clientX - startX);
+      const height = Math.abs(event.clientY - startY);
+      if (width < 4 || height < 4) {
+        cleanup();
+        return;
+      }
+      cleanup({ x: left, y: top, width, height });
+    };
+
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        cleanup();
+      }
+    };
+
+    regionOverlay.addEventListener('mousedown', onMouseDown);
+    regionOverlay.addEventListener('mousemove', onMouseMove);
+    regionOverlay.addEventListener('mouseup', onMouseUp);
+    window.addEventListener('keydown', onKeyDown, true);
+  });
+}
+
+export async function captureScreenshotMode(mode) {
+  if (!window.tandem) return;
+
+  if (mode === 'region') {
+    const region = await selectRegion();
+    if (!region) return;
+    // Wait two frames so the overlay is fully painted away before capture
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+    await window.tandem.captureScreenshot('region', region);
+    return;
+  }
+
+  await window.tandem.captureScreenshot(mode);
+}
+
+/**
+ * Wire the screenshot button to the renderer bridge.
+ * renderer is window.__tandemRenderer, passed explicitly to avoid
+ * implicit global coupling.
+ */
+export function initScreenshot(renderer) {
+  screenshotButton.addEventListener('click', (event) => {
+    event.stopPropagation();
+    const rect = screenshotButton.getBoundingClientRect();
+    void window.tandem?.showScreenshotMenu({
+      x: Math.round(rect.left),
+      y: Math.round(rect.bottom + 6),
+    });
+  });
+}

--- a/shell/js/wingman/screenshot.js
+++ b/shell/js/wingman/screenshot.js
@@ -96,11 +96,11 @@ export async function captureScreenshotMode(mode) {
 }
 
 /**
- * Wire the screenshot button to the renderer bridge.
- * renderer is window.__tandemRenderer, passed explicitly to avoid
- * implicit global coupling.
+ * Wire the screenshot button. No renderer-bridge dependency today —
+ * the menu is shown via window.tandem.showScreenshotMenu (IPC preload).
+ * Kept as a no-arg init to stay symmetric with other wingman/* init fns.
  */
-export function initScreenshot(renderer) {
+export function initScreenshot() {
   screenshotButton.addEventListener('click', (event) => {
     event.stopPropagation();
     const rect = screenshotButton.getBoundingClientRect();


### PR DESCRIPTION
## Summary

- Extracted `alerts.js` (~28 LOC) from `wingman/index.js`: transient overlay toasts, `window.tandem.onWingmanAlert` IPC subscription, `dismissAlert`, and `window.dismissAlert` binding
- Extracted `screenshot.js` (~112 LOC) from `wingman/index.js`: screenshot button click handler, region-capture drag overlay (`selectRegion`), and `captureScreenshotMode`
- `wingman/index.js` shrinks by 112 lines (1,672 → 1,560)
- `window.dismissAlert` binding is preserved in `alerts.js` — required by the inline `onclick="dismissAlert()"` on the dismiss button in `shell/index.html`

## Notes

- `alerts.js` uses `initAlerts(renderer)` to receive the renderer reference (same pattern as `initScreenshot(renderer)`), avoiding re-reading `window.__tandemRenderer` inside the module
- `captureScreenshotMode` moved into `screenshot.js` alongside `selectRegion` since it is screenshot-only logic; it is imported in `index.js` for use in the `window.tandem.onScreenshotModeSelected` handler
- No logic changes — pure extraction

## Test plan

- [x] CI green
- [x] Wingman panel still opens
- [x] Alert toast appears when triggered and ✕ button dismisses it — tests inline onclick → `window.dismissAlert`
- [x] Screenshot button (main toolbar) opens screenshot menu
- [x] Region capture: drag to select area, Escape cancels, release captures
- [x] `wingman/index.js` LOC decreased by ~112 (1,672 → 1,560)