### PR TITLE
refactor(shell): extract wingman panel shell to ES module

### DIFF
--- a/shell/js/wingman/index.js
+++ b/shell/js/wingman/index.js
@@ -4,11 +4,13 @@
  * Loaded from: shell/index.html as <script type="module" src="js/wingman/index.js">
  * window exports (set across the family): chatRouter, dismissAlert,
  *   openWingmanPanel, toggleWingmanPanel, updatePanelLayout.
- *   This file sets: chatRouter, openWingmanPanel, toggleWingmanPanel, updatePanelLayout.
+ *   This file sets: chatRouter.
  *   dismissAlert is set by ./alerts.js.
+ *   openWingmanPanel, toggleWingmanPanel, updatePanelLayout are set by ./panel.js.
  */
     import { initAlerts } from './alerts.js';
     import { initScreenshot, captureScreenshotMode } from './screenshot.js';
+    import { initPanel } from './panel.js';
 
     const renderer = window.__tandemRenderer;
     if (!renderer) {
@@ -43,8 +45,6 @@
     // Wingman Panel
     // ═══════════════════════════════════════════════
 
-    const wingmanPanel = document.getElementById('wingman-panel');
-    const panelBody = document.getElementById('panel-body');
     const panelToggleBtn = document.getElementById('wingman-panel-toggle');
     const activityEl = document.getElementById('activity-feed');
     const handoffListEl = document.getElementById('handoff-list');
@@ -83,10 +83,6 @@
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
         .replace(/\n/g, '<br>');
-    }
-
-    function isWingmanPanelOpen() {
-      return wingmanPanel.classList.contains('open');
     }
 
     function getHandoffAttentionLevel(handoff) {
@@ -229,55 +225,15 @@
       scheduleHandoffAttentionEscalation();
     }
 
-    function setActivePanelTab(tab) {
-      document.querySelectorAll('.panel-tab').forEach(b => b.classList.remove('active'));
-      const targetButton = document.querySelector(`[data-panel-tab="${tab}"]`);
-      if (targetButton) {
-        targetButton.classList.add('active');
-      }
-      document.getElementById('panel-activity').style.display = tab === 'activity' ? 'flex' : 'none';
-      document.getElementById('panel-chat').style.display = tab === 'chat' ? 'flex' : 'none';
-      if (tab === 'chat') {
-        window.chatRouter?.ensureConnected();
-      }
-      document.getElementById('panel-screenshots').style.display = tab === 'screenshots' ? 'flex' : 'none';
-    }
-
-    function getPreferredPanelTabOnOpen() {
-      return openHandoffs.size > 0 ? 'activity' : 'chat';
-    }
-
-    function openWingmanPanel(preferredTab) {
-      if (!wingmanPanel.classList.contains('open')) {
-        wingmanPanel.classList.add('open');
-      }
-      setActivePanelTab(preferredTab || getPreferredPanelTabOnOpen());
-      updatePanelLayout();
-      acknowledgeVisibleHandoffs();
-    }
-
-    // Panel tab switching
-    document.querySelectorAll('.panel-tab').forEach(btn => {
-      btn.addEventListener('click', () => {
-        setActivePanelTab(btn.dataset.panelTab);
-        // ClaroNote disabled — decoupled, coming in a later update
-        // document.getElementById('panel-claronote').style.display = tab === 'claronote' ? 'flex' : 'none';
-        // if (tab === 'claronote') { window.initClaroNote?.(); }
-      });
+    const { isWingmanPanelOpen } = initPanel({
+      hooks: {
+        getPreferredTabOnOpen: () => openHandoffs.size > 0 ? 'activity' : 'chat',
+        onPanelOpened: () => acknowledgeVisibleHandoffs(),
+        onPanelClosed: () => scheduleHandoffAttentionEscalation(),
+      },
     });
 
-    // Panel toggle from main process
     if (window.tandem) {
-      window.tandem.onPanelToggle((data) => {
-        if (data.open) {
-          openWingmanPanel();
-        } else {
-          wingmanPanel.classList.remove('open');
-          updatePanelLayout();
-          scheduleHandoffAttentionEscalation();
-        }
-      });
-
       async function activateHandoff(handoffId) {
         await fetch(`http://localhost:8765/handoffs/${handoffId}/activate`, { method: 'POST' });
       }
@@ -1473,91 +1429,4 @@
       });
     })();
 
-    // Panel resize
-    const resizeHandle = document.getElementById('panel-resize');
-    const webviewContainer = document.getElementById('webview-container');
-    let resizing = false;
-
-    // Restore saved panel width
-    const savedPanelWidth = localStorage.getItem('wingman-panel-width');
-    if (savedPanelWidth) {
-      const w = parseInt(savedPanelWidth);
-      if (w >= 280 && w <= 700) wingmanPanel.style.width = w + 'px';
-    }
-
-    function updatePanelLayout() {
-      const isOpen = wingmanPanel.classList.contains('open');
-      const pw = wingmanPanel.offsetWidth;
-      if (isOpen) {
-        webviewContainer.style.marginRight = pw + 'px';
-        resizeHandle.style.right = pw + 'px';
-        resizeHandle.style.display = 'block';
-        panelToggleBtn.textContent = '▶';
-        panelToggleBtn.style.right = pw + 'px';
-        wingmanBadge.classList.add('panel-open');
-      } else {
-        webviewContainer.style.marginRight = '0';
-        resizeHandle.style.display = 'none';
-        panelToggleBtn.textContent = '◀';
-        panelToggleBtn.style.right = '0';
-        wingmanBadge.classList.remove('panel-open');
-      }
-      // Sync panel open state to backend so notifications are suppressed when panel is visible
-      if (window.tandem?.setPanelOpen) window.tandem.setPanelOpen(isOpen);
-    }
-
-    // Toggle panel function
-    function toggleWingmanPanel() {
-      if (wingmanPanel.classList.contains('open')) {
-        wingmanPanel.classList.remove('open');
-        updatePanelLayout();
-        scheduleHandoffAttentionEscalation();
-      } else {
-        openWingmanPanel();
-      }
-    }
-
-    // Listen for transition end to update layout smoothly
-    wingmanPanel.addEventListener('transitionend', updatePanelLayout);
-
-    // Toggle button click
-    panelToggleBtn.addEventListener('click', toggleWingmanPanel);
-
-    // Wingman badge single click toggles panel
-    wingmanBadge.addEventListener('click', (e) => {
-      if (wingmanBadgePressTimer) clearTimeout(wingmanBadgePressTimer);
-      toggleWingmanPanel();
-    });
-
-    resizeHandle.addEventListener('mousedown', (e) => {
-      resizing = true;
-      resizeHandle.classList.add('dragging');
-      wingmanPanel.style.transition = 'none';
-      e.preventDefault();
-    });
-    document.addEventListener('mousemove', (e) => {
-      if (!resizing) return;
-      const panelWidth = window.innerWidth - e.clientX;
-      if (panelWidth >= 280 && panelWidth <= 700) {
-        wingmanPanel.style.width = panelWidth + 'px';
-        webviewContainer.style.marginRight = panelWidth + 'px';
-        resizeHandle.style.right = panelWidth + 'px';
-        panelToggleBtn.style.right = panelWidth + 'px';
-      }
-    });
-    document.addEventListener('mouseup', () => {
-      if (resizing) {
-        resizing = false;
-        resizeHandle.classList.remove('dragging');
-        wingmanPanel.style.transition = '';
-        localStorage.setItem('wingman-panel-width', wingmanPanel.offsetWidth);
-      }
-    });
-
-    // Initial layout
-    updatePanelLayout();
-
     window.chatRouter = chatRouter;
-    window.openWingmanPanel = openWingmanPanel;
-    window.toggleWingmanPanel = toggleWingmanPanel;
-    window.updatePanelLayout = updatePanelLayout;

--- a/shell/js/wingman/index.js
+++ b/shell/js/wingman/index.js
@@ -26,26 +26,17 @@
     }
 
     // ═══════════════════════════════════════════════
-    // Wingman badge → right-click or long-press → open settings
-    const wingmanBadge = document.querySelector('.wingman-badge');
-    wingmanBadge.addEventListener('contextmenu', (e) => {
-      e.preventDefault();
-      window.openSettings?.();
-    });
-    let wingmanBadgePressTimer = null;
-    wingmanBadge.addEventListener('mousedown', () => {
-      wingmanBadgePressTimer = setTimeout(() => window.openSettings?.(), 600);
-    });
-    wingmanBadge.addEventListener('mouseup', () => { clearTimeout(wingmanBadgePressTimer); });
-    wingmanBadge.addEventListener('mouseleave', () => { clearTimeout(wingmanBadgePressTimer); });
-    wingmanBadge.style.cursor = 'pointer';
-    wingmanBadge.title = 'Right-click for settings';
-
-    // ═══════════════════════════════════════════════
     // Wingman Panel
     // ═══════════════════════════════════════════════
 
-    const panelToggleBtn = document.getElementById('wingman-panel-toggle');
+    // Forward declarations — reassigned below after initPanel(). The
+    // `isWingmanPanelOpen` sentinel returns false so any accidental
+    // pre-init call doesn't throw a TDZ ReferenceError.
+    let isWingmanPanelOpen = () => false;
+    let panelToggleBtn = null;
+    let wingmanBadge = null;
+    let wingmanBadgePressTimer = null;
+
     const activityEl = document.getElementById('activity-feed');
     const handoffListEl = document.getElementById('handoff-list');
     const handoffEmptyEl = document.getElementById('handoff-empty');
@@ -225,13 +216,31 @@
       scheduleHandoffAttentionEscalation();
     }
 
-    const { isWingmanPanelOpen } = initPanel({
+    ({ isWingmanPanelOpen, panelToggleBtn, wingmanBadge } = initPanel({
       hooks: {
         getPreferredTabOnOpen: () => openHandoffs.size > 0 ? 'activity' : 'chat',
         onPanelOpened: () => acknowledgeVisibleHandoffs(),
         onPanelClosed: () => scheduleHandoffAttentionEscalation(),
       },
+    }));
+
+    // ═══════════════════════════════════════════════
+    // Wingman badge → right-click or long-press → open settings.
+    // Registered after initPanel so `wingmanBadge` is resolved; the
+    // badge single-click (bound inside initPanel) still fires correctly
+    // because browser event order on a physical click is
+    // mousedown → mouseup → click, not listener-registration order.
+    wingmanBadge.addEventListener('contextmenu', (e) => {
+      e.preventDefault();
+      window.openSettings?.();
     });
+    wingmanBadge.addEventListener('mousedown', () => {
+      wingmanBadgePressTimer = setTimeout(() => window.openSettings?.(), 600);
+    });
+    wingmanBadge.addEventListener('mouseup', () => { clearTimeout(wingmanBadgePressTimer); });
+    wingmanBadge.addEventListener('mouseleave', () => { clearTimeout(wingmanBadgePressTimer); });
+    wingmanBadge.style.cursor = 'pointer';
+    wingmanBadge.title = 'Right-click for settings';
 
     if (window.tandem) {
       async function activateHandoff(handoffId) {

--- a/shell/js/wingman/panel.js
+++ b/shell/js/wingman/panel.js
@@ -1,0 +1,165 @@
+/**
+ * Wingman panel shell — DOM refs, tab switching, open/toggle, resize drag,
+ * layout sync with webview.
+ *
+ * Loaded from: shell/js/wingman/index.js
+ * window exports: openWingmanPanel, toggleWingmanPanel, updatePanelLayout
+ *   (set here so classic scripts + main-process IPC can call them).
+ */
+
+export function initPanel({ hooks = {} } = {}) {
+  const {
+    getPreferredTabOnOpen = () => 'chat',
+    onPanelOpened = () => {},
+    onPanelClosed = () => {},
+  } = hooks;
+
+  const wingmanPanel = document.getElementById('wingman-panel');
+  const panelToggleBtn = document.getElementById('wingman-panel-toggle');
+  const resizeHandle = document.getElementById('panel-resize');
+  const webviewContainer = document.getElementById('webview-container');
+  const wingmanBadge = document.querySelector('.wingman-badge');
+
+  let resizing = false;
+
+  // Restore saved panel width
+  const savedPanelWidth = localStorage.getItem('wingman-panel-width');
+  if (savedPanelWidth) {
+    const w = parseInt(savedPanelWidth);
+    if (w >= 280 && w <= 700) wingmanPanel.style.width = w + 'px';
+  }
+
+  function isWingmanPanelOpen() {
+    return wingmanPanel.classList.contains('open');
+  }
+
+  function setActivePanelTab(tab) {
+    document.querySelectorAll('.panel-tab').forEach(b => b.classList.remove('active'));
+    const targetButton = document.querySelector(`[data-panel-tab="${tab}"]`);
+    if (targetButton) {
+      targetButton.classList.add('active');
+    }
+    document.getElementById('panel-activity').style.display = tab === 'activity' ? 'flex' : 'none';
+    document.getElementById('panel-chat').style.display = tab === 'chat' ? 'flex' : 'none';
+    if (tab === 'chat') {
+      window.chatRouter?.ensureConnected();
+    }
+    document.getElementById('panel-screenshots').style.display = tab === 'screenshots' ? 'flex' : 'none';
+  }
+
+  function updatePanelLayout() {
+    const isOpen = wingmanPanel.classList.contains('open');
+    const pw = wingmanPanel.offsetWidth;
+    if (isOpen) {
+      webviewContainer.style.marginRight = pw + 'px';
+      resizeHandle.style.right = pw + 'px';
+      resizeHandle.style.display = 'block';
+      panelToggleBtn.textContent = '▶';
+      panelToggleBtn.style.right = pw + 'px';
+      wingmanBadge.classList.add('panel-open');
+    } else {
+      webviewContainer.style.marginRight = '0';
+      resizeHandle.style.display = 'none';
+      panelToggleBtn.textContent = '◀';
+      panelToggleBtn.style.right = '0';
+      wingmanBadge.classList.remove('panel-open');
+    }
+    // Sync panel open state to backend so notifications are suppressed when panel is visible
+    if (window.tandem?.setPanelOpen) window.tandem.setPanelOpen(isOpen);
+  }
+
+  function openWingmanPanel(preferredTab) {
+    if (!wingmanPanel.classList.contains('open')) {
+      wingmanPanel.classList.add('open');
+    }
+    setActivePanelTab(preferredTab || getPreferredTabOnOpen());
+    updatePanelLayout();
+    onPanelOpened();
+  }
+
+  function toggleWingmanPanel() {
+    if (wingmanPanel.classList.contains('open')) {
+      wingmanPanel.classList.remove('open');
+      updatePanelLayout();
+      onPanelClosed();
+    } else {
+      openWingmanPanel();
+    }
+  }
+
+  // Panel tab switching
+  document.querySelectorAll('.panel-tab').forEach(btn => {
+    btn.addEventListener('click', () => {
+      setActivePanelTab(btn.dataset.panelTab);
+      // ClaroNote disabled — decoupled, coming in a later update
+      // document.getElementById('panel-claronote').style.display = tab === 'claronote' ? 'flex' : 'none';
+      // if (tab === 'claronote') { window.initClaroNote?.(); }
+    });
+  });
+
+  // Panel toggle from main process
+  if (window.tandem) {
+    window.tandem.onPanelToggle((data) => {
+      if (data.open) {
+        openWingmanPanel();
+      } else {
+        wingmanPanel.classList.remove('open');
+        updatePanelLayout();
+        onPanelClosed();
+      }
+    });
+  }
+
+  // Listen for transition end to update layout smoothly
+  wingmanPanel.addEventListener('transitionend', updatePanelLayout);
+
+  // Toggle button click
+  panelToggleBtn.addEventListener('click', toggleWingmanPanel);
+
+  // Wingman badge single click toggles panel. The long-press-to-settings
+  // timer lives in index.js; its own mouseup/mouseleave clears it before
+  // 'click' fires, so we don't need to see the timer here.
+  wingmanBadge.addEventListener('click', () => {
+    toggleWingmanPanel();
+  });
+
+  resizeHandle.addEventListener('mousedown', (e) => {
+    resizing = true;
+    resizeHandle.classList.add('dragging');
+    wingmanPanel.style.transition = 'none';
+    e.preventDefault();
+  });
+  document.addEventListener('mousemove', (e) => {
+    if (!resizing) return;
+    const panelWidth = window.innerWidth - e.clientX;
+    if (panelWidth >= 280 && panelWidth <= 700) {
+      wingmanPanel.style.width = panelWidth + 'px';
+      webviewContainer.style.marginRight = panelWidth + 'px';
+      resizeHandle.style.right = panelWidth + 'px';
+      panelToggleBtn.style.right = panelWidth + 'px';
+    }
+  });
+  document.addEventListener('mouseup', () => {
+    if (resizing) {
+      resizing = false;
+      resizeHandle.classList.remove('dragging');
+      wingmanPanel.style.transition = '';
+      localStorage.setItem('wingman-panel-width', wingmanPanel.offsetWidth);
+    }
+  });
+
+  // Initial layout
+  updatePanelLayout();
+
+  window.openWingmanPanel = openWingmanPanel;
+  window.toggleWingmanPanel = toggleWingmanPanel;
+  window.updatePanelLayout = updatePanelLayout;
+
+  return {
+    openWingmanPanel,
+    toggleWingmanPanel,
+    updatePanelLayout,
+    setActivePanelTab,
+    isWingmanPanelOpen,
+  };
+}

--- a/shell/js/wingman/panel.js
+++ b/shell/js/wingman/panel.js
@@ -4,7 +4,11 @@
  *
  * Loaded from: shell/js/wingman/index.js
  * window exports: openWingmanPanel, toggleWingmanPanel, updatePanelLayout
- *   (set here so classic scripts + main-process IPC can call them).
+ *   (set inside initPanel so classic scripts + main-process IPC can call them).
+ *
+ * initPanel return shape: { openWingmanPanel, toggleWingmanPanel,
+ *   updatePanelLayout, setActivePanelTab, isWingmanPanelOpen, panelToggleBtn,
+ *   wingmanBadge } — exposed so index.js (handoff layer) can reuse the refs.
  */
 
 export function initPanel({ hooks = {} } = {}) {
@@ -25,7 +29,7 @@ export function initPanel({ hooks = {} } = {}) {
   // Restore saved panel width
   const savedPanelWidth = localStorage.getItem('wingman-panel-width');
   if (savedPanelWidth) {
-    const w = parseInt(savedPanelWidth);
+    const w = parseInt(savedPanelWidth, 10);
     if (w >= 280 && w <= 700) wingmanPanel.style.width = w + 'px';
   }
 
@@ -117,8 +121,10 @@ export function initPanel({ hooks = {} } = {}) {
   panelToggleBtn.addEventListener('click', toggleWingmanPanel);
 
   // Wingman badge single click toggles panel. The long-press-to-settings
-  // timer lives in index.js; its own mouseup/mouseleave clears it before
-  // 'click' fires, so we don't need to see the timer here.
+  // timer lives in index.js; its mouseup/mouseleave listeners (registered
+  // in index.js after initPanel) clear the long-press timer before the
+  // click event reaches us — browser event order on a physical click is
+  // mousedown → mouseup → click regardless of listener registration order.
   wingmanBadge.addEventListener('click', () => {
     toggleWingmanPanel();
   });
@@ -161,5 +167,7 @@ export function initPanel({ hooks = {} } = {}) {
     updatePanelLayout,
     setActivePanelTab,
     isWingmanPanelOpen,
+    panelToggleBtn,
+    wingmanBadge,
   };
 }


### PR DESCRIPTION
## Summary

Task 3 of the shell-JS ESM split. Extracts the wingman panel shell (DOM refs, tab switching, open/toggle, resize drag, layout sync) from `shell/js/wingman/index.js` into a new `shell/js/wingman/panel.js`.

- Panel module exposes an `initPanel({ hooks })` factory so the handoff layer in `index.js` keeps control over preferred-tab-on-open and can react to panel open/close without importing handoff state into `panel.js`.
- `wingmanBadge` and `panelToggleBtn` DOM refs are owned by `panel.js` and exposed via the `initPanel` return so `index.js` can reuse them for handoff-attention UI without re-querying.
- Pre-init sentinel on `isWingmanPanelOpen` (`let ... = () => false`) removes a latent TDZ ordering assumption.
- `window.*` contract unchanged: `openWingmanPanel`, `toggleWingmanPanel`, `updatePanelLayout` are set inside `initPanel` (mirroring how `alerts.js` owns `window.dismissAlert`).

LOC: `index.js` 1563 → 1441 (−122). `panel.js` 173 LOC (new). No other files changed.

## window.* bindings moved

All three panel-related window exports moved from `index.js` bottom to inside `initPanel`:

- `window.openWingmanPanel`
- `window.toggleWingmanPanel`
- `window.updatePanelLayout`

No renames. No additions. Classic-script + main-process consumers still see the same symbols.

## Test plan

- [x] `npm run verify` green locally (✅ passed here)
- [x] Wingman panel toggle button (◀/▶ on the right) opens and closes the panel
- [ ] Cmd+K shortcut still toggles the panel (pre-existing bug tracked separately — expected no change from this PR)
- [x] Clicking on panel tabs (Activity / Chat / Screenshots) switches the active tab, and switching to Chat triggers `chatRouter.ensureConnected()`
- [x] Panel resize drag from the left edge works; width is clamped 280–700px
- [x] Panel width persists across reload (localStorage `wingman-panel-width`)
- [x] Wingman badge single-click toggles the panel; right-click opens settings; long-press (600ms) opens settings
- [x] Handoff attention UI on badge + toggle button still updates correctly when handoffs open/close
- [x] Main-process `panel-toggle` IPC (from menu/shortcut) opens/closes the panel