### PR TITLE
refactor(shell): migrate sidebar to ES module (passthrough)

### DIFF
--- a/shell/index.html
+++ b/shell/index.html
@@ -401,7 +401,7 @@
   <script src="lgl-integration.js"></script>
 
   <!-- Sidebar -->
-  <script src="js/sidebar.js"></script>
+  <script type="module" src="js/sidebar/index.js"></script>
 
   <script src="js/url-autocomplete.js"></script>
   <script src="js/tabs.js"></script>

--- a/shell/js/sidebar/index.js
+++ b/shell/js/sidebar/index.js
@@ -1,3 +1,12 @@
+/**
+ * Sidebar module entry point — panels, workspaces, tab context menu, drag-drop.
+ *
+ * Loaded from: shell/index.html as <script type="module" src="js/sidebar/index.js">
+ * window exports: ocSidebar (consumed by shell/js/shortcut-router.js:35 for the
+ *   Cmd+B bookmarks shortcut), __tandemShowTabContextMenu (consumed by main.js
+ *   via window.__tandemShowTabContextMenu, already set via window. inside the IIFE).
+ */
+
   // ═══════════════════════════════════════
   // SIDEBAR
   // ═══════════════════════════════════════
@@ -2288,4 +2297,7 @@
     return { init, loadConfig, activateItem, toggleVisibility };
   })();
 
+
+// Expose ocSidebar on window so classic scripts (shortcut-router.js) can reach it.
+window.ocSidebar = ocSidebar;
   document.addEventListener('DOMContentLoaded', () => ocSidebar.init());


### PR DESCRIPTION
## Summary
- Move `shell/js/sidebar.js` (2,291 LOC) verbatim into `shell/js/sidebar/index.js` and switch its `<script>` tag to `type="module"`.
- Passthrough refactor — **no logic changes**. This is Task 6 of the shell-js-esm-split project, the sidebar-side analog of PR #143 (wingman passthrough). It sets up the module tree for Tasks 7-12 which will extract focused slices.

## window.* exports preserved
- `window.ocSidebar` — **new** explicit binding at the bottom of `sidebar/index.js`. Required because `shell/js/shortcut-router.js:35` reads `typeof ocSidebar !== 'undefined'` to wire the Cmd+B bookmarks shortcut. In classic-script mode the shared realm lexical environment exposed this implicitly; ES modules are strictly module-scoped so we promote the binding to the global object to preserve behavior.
- `window.__tandemShowTabContextMenu` — already assigned inside the IIFE body (original line 2255), preserved verbatim.

## Verification
- `npm run verify` clean on first try: 2552 tests passing, 39 skipped, lint + compile + consistency all green.
- No strict-mode violations surfaced by ESM — the file was already strict-compliant.
- Git recognizes this as a rename (99% similarity).

## Test plan
- [x] Sidebar renders on startup, all icons visible
- [x] Tabs appear on open, left-click switches, right-click shows context menu (tests `window.__tandemShowTabContextMenu`)
- [ ] **Cmd+B** opens the bookmarks panel (tests `window.ocSidebar.activateItem` via shortcut-router.js)
- [x] Bookmarks panel: list renders, add/delete/search work
- [x] History panel: opens, searches
- [x] Pinboard panel: create pinboard, add item, reorder
- [x] Workspace switch works, workspace CRUD works
- [x] Tab drag-drop (reorder, move between workspaces)
- [x] Panel resize drag
- [x] Sidebar setup panel opens/closes
- [x] Webview binding: new tab creates webview, navigation works
- [ ] No console errors on module load