### PR TITLE
fix(shell/bookmarks): shared renderer store as single source of truth

### DIFF
--- a/shell/index.html
+++ b/shell/index.html
@@ -400,6 +400,9 @@
   <!-- Liquid Glass Lite Integration -->
   <script src="lgl-integration.js"></script>
 
+  <!-- Shared renderer-side bookmarks store (single source of truth for top bar + sidebar panel) -->
+  <script type="module" src="js/bookmarks-store.js"></script>
+
   <!-- Sidebar -->
   <script type="module" src="js/sidebar/index.js"></script>
 

--- a/shell/js/bookmarks-store.js
+++ b/shell/js/bookmarks-store.js
@@ -38,7 +38,17 @@ export async function load() {
     const res = await fetch(`${API}/bookmarks`, { headers: { Authorization: `Bearer ${token()}` } });
     if (!res.ok) return;
     const data = await res.json();
-    _tree = data.bookmarks?.[0] || { children: [] };
+    // The backend returns `bookmarks` as an array of ROOT folders (Bookmarks Bar,
+    // Other Bookmarks, etc. — Chrome-import can produce multiple roots). The top
+    // bookmarks bar reads `data.bar`, which is the children of the "Bookmarks Bar"
+    // folder (see BookmarkManager.getBarItems). To stay in sync, the sidebar must
+    // navigate that SAME root — not blindly `bookmarks[0]`, which may be a
+    // different root entirely (e.g. "Other Bookmarks") that happens to contain
+    // folders with the same names. This caused the same visual path to show
+    // different content in the two UIs.
+    const roots = data.bookmarks || [];
+    const barRoot = roots.find(b => b.name === 'Bookmarks Bar' || b.name === 'Bladwijzerbalk');
+    _tree = barRoot || roots[0] || { children: [] };
     _bar = (data.bar || []).slice(0, 30);
     _loaded = true;
     notify();

--- a/shell/js/bookmarks-store.js
+++ b/shell/js/bookmarks-store.js
@@ -27,6 +27,11 @@ function notify() {
   for (const fn of _subscribers) {
     try { fn(); } catch (err) { console.error('[bookmarks-store] subscriber threw', err); }
   }
+  // Belt-and-suspenders: also dispatch a window event. Classic-script consumers
+  // (browser-tools.js) listen to this as a backup in case the subscribe chain
+  // is ever interrupted — so the top bookmarks bar always re-renders after a
+  // mutation, even if subscribe() somehow didn't fire for it.
+  window.dispatchEvent(new CustomEvent('tandem:bookmarks-changed'));
 }
 
 /**

--- a/shell/js/bookmarks-store.js
+++ b/shell/js/bookmarks-store.js
@@ -1,0 +1,139 @@
+/**
+ * Bookmarks store — single source of truth for the renderer.
+ *
+ * All bookmark HTTP I/O lives here. UIs call the mutation methods and
+ * subscribe() to re-render on change. No UI should fetch /bookmarks or
+ * call mutation endpoints directly — that's how the sidebar + top bar
+ * drift out of sync.
+ *
+ * Loaded from: shell/index.html (as <script type="module">), shell/js/sidebar/panels/bookmarks.js (via import)
+ * window exports: window.__TANDEM_BOOKMARKS_STORE__ (for classic-script consumers like browser-tools.js)
+ * Ready signal: dispatches 'tandem:bookmarks-store-ready' on window when available.
+ */
+
+const API = 'http://localhost:8765';
+const token = () => window.__TANDEM_TOKEN__ || '';
+const authHeaders = () => ({
+  'Content-Type': 'application/json',
+  Authorization: `Bearer ${token()}`,
+});
+
+let _tree = null;    // root folder node { id, children, ... }
+let _bar = [];       // flat array for the top bookmarks bar (first 30 items)
+let _loaded = false; // true after the first successful load()
+const _subscribers = new Set();
+
+function notify() {
+  for (const fn of _subscribers) {
+    try { fn(); } catch (err) { console.error('[bookmarks-store] subscriber threw', err); }
+  }
+}
+
+/**
+ * Fetch the bookmark tree + bar from the API and notify subscribers.
+ * Mutation methods call this after their HTTP call returns.
+ */
+export async function load() {
+  try {
+    const res = await fetch(`${API}/bookmarks`, { headers: { Authorization: `Bearer ${token()}` } });
+    if (!res.ok) return;
+    const data = await res.json();
+    _tree = data.bookmarks?.[0] || { children: [] };
+    _bar = (data.bar || []).slice(0, 30);
+    _loaded = true;
+    notify();
+  } catch { /* ignore — API not ready yet */ }
+}
+
+export function getTree() { return _tree; }
+export function getBar() { return _bar; }
+export function isLoaded() { return _loaded; }
+
+/** Is the given URL already bookmarked? Returns { bookmarked, bookmark }. */
+export async function check(url) {
+  try {
+    const res = await fetch(`${API}/bookmarks/check?url=${encodeURIComponent(url)}`, {
+      headers: { Authorization: `Bearer ${token()}` },
+    });
+    if (!res.ok) return { bookmarked: false, bookmark: null };
+    return await res.json();
+  } catch {
+    return { bookmarked: false, bookmark: null };
+  }
+}
+
+export async function add({ name, url, parentId }) {
+  await fetch(`${API}/bookmarks/add`, {
+    method: 'POST',
+    headers: authHeaders(),
+    body: JSON.stringify({ name, url, parentId }),
+  });
+  await load();
+}
+
+export async function addFolder({ name, parentId }) {
+  await fetch(`${API}/bookmarks/add-folder`, {
+    method: 'POST',
+    headers: authHeaders(),
+    body: JSON.stringify({ name, parentId }),
+  });
+  await load();
+}
+
+export async function remove(id) {
+  await fetch(`${API}/bookmarks/remove`, {
+    method: 'DELETE',
+    headers: authHeaders(),
+    body: JSON.stringify({ id }),
+  });
+  await load();
+}
+
+/** Update a bookmark or folder. Pass { id, name } for a folder; { id, name, url } for a bookmark. */
+export async function update({ id, name, url }) {
+  const body = url !== undefined ? { id, name, url } : { id, name };
+  await fetch(`${API}/bookmarks/update`, {
+    method: 'PUT',
+    headers: authHeaders(),
+    body: JSON.stringify(body),
+  });
+  await load();
+}
+
+export async function move({ id, parentId }) {
+  await fetch(`${API}/bookmarks/move`, {
+    method: 'POST',
+    headers: authHeaders(),
+    body: JSON.stringify({ id, parentId }),
+  });
+  await load();
+}
+
+/** Search is read-only — does not mutate the store or notify subscribers. */
+export async function search(q) {
+  try {
+    const res = await fetch(`${API}/bookmarks/search?q=${encodeURIComponent(q)}`, {
+      headers: { Authorization: `Bearer ${token()}` },
+    });
+    if (!res.ok) return [];
+    const data = await res.json();
+    return data.results || [];
+  } catch {
+    return [];
+  }
+}
+
+/** Subscribe to change notifications. Returns an unsubscribe function. */
+export function subscribe(fn) {
+  _subscribers.add(fn);
+  return () => _subscribers.delete(fn);
+}
+
+// Bridge for classic-script consumers (browser-tools.js is a classic script,
+// so it cannot `import` — it accesses the store via this window global).
+// The ready event lets browser-tools defer its subscribe() call until the
+// module has loaded (modules defer past classic scripts in the HTML).
+window.__TANDEM_BOOKMARKS_STORE__ = {
+  load, getTree, getBar, isLoaded, check, add, addFolder, remove, update, move, search, subscribe,
+};
+window.dispatchEvent(new CustomEvent('tandem:bookmarks-store-ready'));

--- a/shell/js/bookmarks-store.js
+++ b/shell/js/bookmarks-store.js
@@ -35,7 +35,14 @@ function notify() {
  */
 export async function load() {
   try {
-    const res = await fetch(`${API}/bookmarks`, { headers: { Authorization: `Bearer ${token()}` } });
+    // cache: 'no-store' — the Electron renderer HTTP cache would otherwise
+    // serve a stale /bookmarks response, causing the top bar to show the
+    // pre-mutation list even after a rename (the classic "one rename behind"
+    // symptom). Every load() must hit the backend.
+    const res = await fetch(`${API}/bookmarks`, {
+      headers: { Authorization: `Bearer ${token()}` },
+      cache: 'no-store',
+    });
     if (!res.ok) return;
     const data = await res.json();
     // The backend returns `bookmarks` as an array of ROOT folders (Bookmarks Bar,
@@ -64,6 +71,7 @@ export async function check(url) {
   try {
     const res = await fetch(`${API}/bookmarks/check?url=${encodeURIComponent(url)}`, {
       headers: { Authorization: `Bearer ${token()}` },
+      cache: 'no-store',
     });
     if (!res.ok) return { bookmarked: false, bookmark: null };
     return await res.json();
@@ -124,6 +132,7 @@ export async function search(q) {
   try {
     const res = await fetch(`${API}/bookmarks/search?q=${encodeURIComponent(q)}`, {
       headers: { Authorization: `Bearer ${token()}` },
+      cache: 'no-store',
     });
     if (!res.ok) return [];
     const data = await res.json();

--- a/shell/js/bookmarks-store.js
+++ b/shell/js/bookmarks-store.js
@@ -27,11 +27,6 @@ function notify() {
   for (const fn of _subscribers) {
     try { fn(); } catch (err) { console.error('[bookmarks-store] subscriber threw', err); }
   }
-  // Belt-and-suspenders: also dispatch a window event. Classic-script consumers
-  // (browser-tools.js) listen to this as a backup in case the subscribe chain
-  // is ever interrupted — so the top bookmarks bar always re-renders after a
-  // mutation, even if subscribe() somehow didn't fire for it.
-  window.dispatchEvent(new CustomEvent('tandem:bookmarks-changed'));
 }
 
 /**

--- a/shell/js/bookmarks-store.js
+++ b/shell/js/bookmarks-store.js
@@ -35,11 +35,12 @@ function notify() {
  */
 export async function load() {
   try {
-    // cache: 'no-store' — the Electron renderer HTTP cache would otherwise
-    // serve a stale /bookmarks response, causing the top bar to show the
-    // pre-mutation list even after a rename (the classic "one rename behind"
-    // symptom). Every load() must hit the backend.
-    const res = await fetch(`${API}/bookmarks`, {
+    // Cache-busting query param + cache:'no-store'. The Electron renderer
+    // was observed serving stale /bookmarks responses even with
+    // cache:'no-store' (confirmed via live MCP mutation: backend had the
+    // new name, frontend kept showing the previous fetch). The unique
+    // timestamp forces a fresh URL every call so no cache layer can match.
+    const res = await fetch(`${API}/bookmarks?_=${Date.now()}`, {
       headers: { Authorization: `Bearer ${token()}` },
       cache: 'no-store',
     });

--- a/shell/js/browser-tools.js
+++ b/shell/js/browser-tools.js
@@ -579,14 +579,37 @@
       if (bookmarksBarVisible && barItems.length > 0) layoutBookmarksBar();
     });
 
+    // TEMP DIAGNOSTIC — visible rerender counter on the bookmarks bar.
+    // Lets us confirm via screenshot whether the subscribe chain fires
+    // after a mutation. Remove once the sync bug is fully nailed down.
+    let _renderFireCount = 0;
+    function _diagnostic(barItemsLen) {
+      _renderFireCount++;
+      const t = new Date().toTimeString().slice(0, 8);
+      bookmarksBar.setAttribute('data-diag', `rb:${_renderFireCount} t:${t} n:${barItemsLen}`);
+      let badge = document.getElementById('bm-diag-badge');
+      if (!badge) {
+        badge = document.createElement('div');
+        badge.id = 'bm-diag-badge';
+        badge.style.cssText = 'position:fixed;top:80px;right:8px;z-index:9999;background:#222;color:#0f0;font:10px/1.2 monospace;padding:2px 4px;border:1px solid #0f0;border-radius:2px;pointer-events:none;';
+        document.body.appendChild(badge);
+      }
+      try {
+        const tempFolder = barItems[0]?.children?.find(c => c.name === 'AI')?.children?.find(c => c.name === 'temp');
+        const bookmark = tempFolder?.children?.[0];
+        badge.textContent = `rb:${_renderFireCount} ${t} n:${barItemsLen} ${bookmark?.name?.slice(0, 24) || '?'}`;
+      } catch { badge.textContent = `rb:${_renderFireCount} ${t} n:${barItemsLen}`; }
+    }
+
     // Render the bar from whatever's currently in the store. Called by the
     // store subscription on every mutation, and by loadBookmarksBar() after
     // an explicit (re)load.
     function renderBookmarksBar() {
-      if (!bookmarksBarVisible) return;
+      if (!bookmarksBarVisible) { _diagnostic(-1); return; }
       const store = getStore();
-      if (!store) return;
+      if (!store) { _diagnostic(-2); return; }
       barItems = store.getBar();
+      _diagnostic(barItems.length);
       if (barItems.length === 0) {
         bookmarksBar.classList.remove('visible');
         return;

--- a/shell/js/browser-tools.js
+++ b/shell/js/browser-tools.js
@@ -323,6 +323,13 @@
         renderBookmarksBar();
       });
     });
+    // Backup mechanism: listen for the store's window event. Redundant with the
+    // subscribe() above, but guarantees the top bar re-renders after mutations
+    // even if the subscribe chain ever misfires.
+    window.addEventListener('tandem:bookmarks-changed', () => {
+      updateBookmarkStar();
+      renderBookmarksBar();
+    });
 
     bmPopupCancel.addEventListener('click', closeBookmarkPopup);
 

--- a/shell/js/browser-tools.js
+++ b/shell/js/browser-tools.js
@@ -579,26 +579,31 @@
       if (bookmarksBarVisible && barItems.length > 0) layoutBookmarksBar();
     });
 
-    // TEMP DIAGNOSTIC — visible rerender counter on the bookmarks bar.
-    // Lets us confirm via screenshot whether the subscribe chain fires
-    // after a mutation. Remove once the sync bug is fully nailed down.
+    // TEMP DIAGNOSTIC — inline, unmissable. The previous position:fixed
+    // badge did not appear in screenshots; switching to (a) document.title,
+    // (b) an inline badge prepended to the bookmarks bar itself, and
+    // (c) a data-diag attribute so we can verify via any surface.
     let _renderFireCount = 0;
     function _diagnostic(barItemsLen) {
       _renderFireCount++;
       const t = new Date().toTimeString().slice(0, 8);
-      bookmarksBar.setAttribute('data-diag', `rb:${_renderFireCount} t:${t} n:${barItemsLen}`);
-      let badge = document.getElementById('bm-diag-badge');
-      if (!badge) {
-        badge = document.createElement('div');
-        badge.id = 'bm-diag-badge';
-        badge.style.cssText = 'position:fixed;top:80px;right:8px;z-index:9999;background:#222;color:#0f0;font:10px/1.2 monospace;padding:2px 4px;border:1px solid #0f0;border-radius:2px;pointer-events:none;';
-        document.body.appendChild(badge);
-      }
+      let tempBookmarkName = '?';
       try {
         const tempFolder = barItems[0]?.children?.find(c => c.name === 'AI')?.children?.find(c => c.name === 'temp');
-        const bookmark = tempFolder?.children?.[0];
-        badge.textContent = `rb:${_renderFireCount} ${t} n:${barItemsLen} ${bookmark?.name?.slice(0, 24) || '?'}`;
-      } catch { badge.textContent = `rb:${_renderFireCount} ${t} n:${barItemsLen}`; }
+        tempBookmarkName = tempFolder?.children?.[0]?.name?.slice(0, 24) || '?';
+      } catch { /* ignore */ }
+      const msg = `[DIAG rb:${_renderFireCount} t:${t} n:${barItemsLen} temp0:${tempBookmarkName}]`;
+      try { document.title = msg; } catch { /* ignore */ }
+      bookmarksBar.setAttribute('data-diag', msg);
+      // Inline badge: prepend to the bookmarks bar so it's always visible.
+      let inline = document.getElementById('bm-diag-inline');
+      if (!inline) {
+        inline = document.createElement('span');
+        inline.id = 'bm-diag-inline';
+        inline.style.cssText = 'background:#0f0;color:#000;font:bold 11px/1.4 monospace;padding:2px 6px;margin-right:8px;border-radius:3px;white-space:nowrap;';
+      }
+      inline.textContent = msg;
+      if (inline.parentNode !== bookmarksBar) bookmarksBar.prepend(inline);
     }
 
     // Render the bar from whatever's currently in the store. Called by the

--- a/shell/js/browser-tools.js
+++ b/shell/js/browser-tools.js
@@ -579,50 +579,19 @@
       if (bookmarksBarVisible && barItems.length > 0) layoutBookmarksBar();
     });
 
-    // TEMP DIAGNOSTIC — inline, unmissable. The previous position:fixed
-    // badge did not appear in screenshots; switching to (a) document.title,
-    // (b) an inline badge prepended to the bookmarks bar itself, and
-    // (c) a data-diag attribute so we can verify via any surface.
-    let _renderFireCount = 0;
-    function _diagnostic(barItemsLen) {
-      _renderFireCount++;
-      const t = new Date().toTimeString().slice(0, 8);
-      let tempBookmarkName = '?';
-      try {
-        const tempFolder = barItems[0]?.children?.find(c => c.name === 'AI')?.children?.find(c => c.name === 'temp');
-        tempBookmarkName = tempFolder?.children?.[0]?.name?.slice(0, 24) || '?';
-      } catch { /* ignore */ }
-      const msg = `[DIAG rb:${_renderFireCount} t:${t} n:${barItemsLen} temp0:${tempBookmarkName}]`;
-      try { document.title = msg; } catch { /* ignore */ }
-      bookmarksBar.setAttribute('data-diag', msg);
-      // Inline badge: prepend to the bookmarks bar so it's always visible.
-      let inline = document.getElementById('bm-diag-inline');
-      if (!inline) {
-        inline = document.createElement('span');
-        inline.id = 'bm-diag-inline';
-        inline.style.cssText = 'background:#0f0;color:#000;font:bold 11px/1.4 monospace;padding:2px 6px;margin-right:8px;border-radius:3px;white-space:nowrap;';
-      }
-      inline.textContent = msg;
-      if (inline.parentNode !== bookmarksBar) bookmarksBar.prepend(inline);
-    }
-
     // Render the bar from whatever's currently in the store. Called by the
     // store subscription on every mutation, and by loadBookmarksBar() after
     // an explicit (re)load.
     function renderBookmarksBar() {
-      if (!bookmarksBarVisible) { _diagnostic(-1); return; }
+      if (!bookmarksBarVisible) return;
       const store = getStore();
-      if (!store) { _diagnostic(-2); return; }
+      if (!store) return;
       barItems = store.getBar();
       if (barItems.length === 0) {
         bookmarksBar.classList.remove('visible');
-        _diagnostic(0);
         return;
       }
       layoutBookmarksBar();
-      // Must run AFTER layoutBookmarksBar — it does bookmarksBar.innerHTML=''
-      // which would wipe the inline badge if we prepended it before.
-      _diagnostic(barItems.length);
     }
 
     // Ensure the store is populated, then render. Used for initial boot and

--- a/shell/js/browser-tools.js
+++ b/shell/js/browser-tools.js
@@ -614,12 +614,15 @@
       const store = getStore();
       if (!store) { _diagnostic(-2); return; }
       barItems = store.getBar();
-      _diagnostic(barItems.length);
       if (barItems.length === 0) {
         bookmarksBar.classList.remove('visible');
+        _diagnostic(0);
         return;
       }
       layoutBookmarksBar();
+      // Must run AFTER layoutBookmarksBar — it does bookmarksBar.innerHTML=''
+      // which would wipe the inline badge if we prepended it before.
+      _diagnostic(barItems.length);
     }
 
     // Ensure the store is populated, then render. Used for initial boot and

--- a/shell/js/browser-tools.js
+++ b/shell/js/browser-tools.js
@@ -174,32 +174,36 @@
     const bookmarksBar = document.getElementById('bookmarks-bar');
     let bookmarksBarVisible = true;
 
-    const bmToken = () => window.__TANDEM_TOKEN__ || '';
+    // Bridge to the shared bookmarks store (shell/js/bookmarks-store.js). It's an
+    // ES module and browser-tools is a classic script, so we access it through the
+    // window global. The store module dispatches 'tandem:bookmarks-store-ready'
+    // once available — used to defer subscribe() past the module's load.
+    const getStore = () => window.__TANDEM_BOOKMARKS_STORE__;
+    function whenStoreReady(fn) {
+      const s = getStore();
+      if (s) { fn(s); return; }
+      window.addEventListener('tandem:bookmarks-store-ready', () => fn(getStore()), { once: true });
+    }
 
     async function updateBookmarkStar() {
       const entry = getActiveEntry();
       if (!entry) return;
-      try {
-        const url = entry.webview.getURL();
-        if (!url || url.startsWith('file://') || url === 'about:blank') {
-          bookmarkStar.textContent = '☆';
-          bookmarkStar.classList.remove('bookmarked');
-          return;
-        }
-        const resp = await fetch(`http://localhost:8765/bookmarks/check?url=${encodeURIComponent(url)}`, {
-          headers: { Authorization: `Bearer ${bmToken()}` }
-        });
-        if (resp.ok) {
-          const data = await resp.json();
-          if (data.bookmarked) {
-            bookmarkStar.textContent = '★';
-            bookmarkStar.classList.add('bookmarked');
-          } else {
-            bookmarkStar.textContent = '☆';
-            bookmarkStar.classList.remove('bookmarked');
-          }
-        }
-      } catch { /* API not ready */ }
+      const url = entry.webview.getURL();
+      if (!url || url.startsWith('file://') || url === 'about:blank') {
+        bookmarkStar.textContent = '☆';
+        bookmarkStar.classList.remove('bookmarked');
+        return;
+      }
+      const store = getStore();
+      if (!store) return;
+      const { bookmarked } = await store.check(url);
+      if (bookmarked) {
+        bookmarkStar.textContent = '★';
+        bookmarkStar.classList.add('bookmarked');
+      } else {
+        bookmarkStar.textContent = '☆';
+        bookmarkStar.classList.remove('bookmarked');
+      }
     }
 
     const bmPopup = document.getElementById('bookmark-popup');
@@ -211,33 +215,30 @@
     let bmPopupState = { open: false, bookmarkId: null, url: null };
 
     async function loadFolderOptions() {
-      try {
-        const res = await fetch('http://localhost:8765/bookmarks', {
-          headers: { Authorization: `Bearer ${bmToken()}` }
-        });
-        const data = await res.json();
-        const root = data.bookmarks?.[0];
-        bmPopupFolder.innerHTML = '';
-        const rootOpt = document.createElement('option');
-        rootOpt.value = root?.id || '';
-        rootOpt.textContent = 'Bookmarks Bar';
-        bmPopupFolder.appendChild(rootOpt);
+      const store = getStore();
+      if (!store) return;
+      if (!store.isLoaded()) await store.load();
+      const root = store.getTree();
+      bmPopupFolder.innerHTML = '';
+      const rootOpt = document.createElement('option');
+      rootOpt.value = root?.id || '';
+      rootOpt.textContent = 'Bookmarks Bar';
+      bmPopupFolder.appendChild(rootOpt);
 
-        function addFolders(children, depth) {
-          if (!children) return;
-          for (const item of children) {
-            if (item.type === 'folder') {
-              const opt = document.createElement('option');
-              opt.value = item.id;
-              opt.textContent = '\u00A0\u00A0'.repeat(depth) + item.name;
-              bmPopupFolder.appendChild(opt);
-              addFolders(item.children, depth + 1);
-            }
+      function addFolders(children, depth) {
+        if (!children) return;
+        for (const item of children) {
+          if (item.type === 'folder') {
+            const opt = document.createElement('option');
+            opt.value = item.id;
+            opt.textContent = '\u00A0\u00A0'.repeat(depth) + item.name;
+            bmPopupFolder.appendChild(opt);
+            addFolders(item.children, depth + 1);
           }
         }
+      }
 
-        addFolders(root?.children, 1);
-      } catch { /* ignore */ }
+      addFolders(root?.children, 1);
     }
 
     function positionPopup() {
@@ -257,15 +258,11 @@
       await loadFolderOptions();
 
       let existingBookmark = null;
-      try {
-        const resp = await fetch(`http://localhost:8765/bookmarks/check?url=${encodeURIComponent(url)}`, {
-          headers: { Authorization: `Bearer ${bmToken()}` }
-        });
-        if (resp.ok) {
-          const data = await resp.json();
-          if (data.bookmarked && data.bookmark) existingBookmark = data.bookmark;
-        }
-      } catch { /* ignore */ }
+      const store = getStore();
+      if (store) {
+        const { bookmarked, bookmark } = await store.check(url);
+        if (bookmarked && bookmark) existingBookmark = bookmark;
+      }
 
       bmPopupName.value = existingBookmark ? existingBookmark.name : title;
       bmPopupState.bookmarkId = existingBookmark?.id || null;
@@ -294,43 +291,37 @@
       const name = bmPopupName.value.trim();
       const parentId = bmPopupFolder.value;
       if (!name) return;
+      const store = getStore();
+      if (!store) return;
       try {
         if (bmPopupState.bookmarkId) {
-          await fetch('http://localhost:8765/bookmarks/update', {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${bmToken()}` },
-            body: JSON.stringify({ id: bmPopupState.bookmarkId, name, url: bmPopupState.url }),
-          });
-          await fetch('http://localhost:8765/bookmarks/move', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${bmToken()}` },
-            body: JSON.stringify({ id: bmPopupState.bookmarkId, parentId }),
-          });
+          await store.update({ id: bmPopupState.bookmarkId, name, url: bmPopupState.url });
+          await store.move({ id: bmPopupState.bookmarkId, parentId });
         } else {
-          await fetch('http://localhost:8765/bookmarks/add', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${bmToken()}` },
-            body: JSON.stringify({ name, url: bmPopupState.url, parentId }),
-          });
+          await store.add({ name, url: bmPopupState.url, parentId });
         }
         closeBookmarkPopup();
-        updateBookmarkStar();
-        loadBookmarksBar();
       } catch { /* ignore */ }
     });
 
     bmPopupDelete.addEventListener('click', async () => {
       if (!bmPopupState.bookmarkId) return;
+      const store = getStore();
+      if (!store) return;
       try {
-        await fetch('http://localhost:8765/bookmarks/remove', {
-          method: 'DELETE',
-          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${bmToken()}` },
-          body: JSON.stringify({ id: bmPopupState.bookmarkId }),
-        });
+        await store.remove(bmPopupState.bookmarkId);
         closeBookmarkPopup();
-        updateBookmarkStar();
-        loadBookmarksBar();
       } catch { /* ignore */ }
+    });
+
+    // Single source of truth: every bookmark mutation (star popup, sidebar panel,
+    // future surfaces) goes through the store, and the store notifies all
+    // subscribers. This keeps the top bar + star in sync without manual events.
+    whenStoreReady((store) => {
+      store.subscribe(() => {
+        updateBookmarkStar();
+        renderBookmarksBar();
+      });
     });
 
     bmPopupCancel.addEventListener('click', closeBookmarkPopup);
@@ -572,33 +563,41 @@
       if (bookmarksBarVisible && barItems.length > 0) layoutBookmarksBar();
     });
 
+    // Render the bar from whatever's currently in the store. Called by the
+    // store subscription on every mutation, and by loadBookmarksBar() after
+    // an explicit (re)load.
+    function renderBookmarksBar() {
+      if (!bookmarksBarVisible) return;
+      const store = getStore();
+      if (!store) return;
+      barItems = store.getBar();
+      if (barItems.length === 0) {
+        bookmarksBar.classList.remove('visible');
+        return;
+      }
+      layoutBookmarksBar();
+    }
+
+    // Ensure the store is populated, then render. Used for initial boot and
+    // the toggle-visible path. On subsequent mutations the subscription
+    // handles re-render automatically.
     async function loadBookmarksBar() {
       if (!bookmarksBarVisible) return;
-
-      let retries = 3;
-      while (retries > 0) {
-        try {
-          const resp = await fetch('http://localhost:8765/bookmarks', {
-            headers: { Authorization: `Bearer ${bmToken()}` }
-          });
-          if (!resp.ok) {
-            retries--;
-            if (retries > 0) { await new Promise(r => setTimeout(r, 1000)); continue; }
-            return;
-          }
-          const data = await resp.json();
-          barItems = (data.bar || []).slice(0, 30);
-          if (barItems.length === 0) {
-            bookmarksBar.classList.remove('visible');
-            return;
-          }
-          layoutBookmarksBar();
-          break;
-        } catch {
+      const store = getStore();
+      if (!store) return;
+      if (!store.isLoaded()) {
+        // API may not be ready at startup — retry a couple of times.
+        let retries = 3;
+        while (retries > 0 && !store.isLoaded()) {
+          await store.load();
+          if (store.isLoaded()) break;
           retries--;
-          if (retries > 0) { await new Promise(r => setTimeout(r, 1000)); }
+          if (retries > 0) await new Promise(r => setTimeout(r, 1000));
         }
+        // load() notified subscribers, which called renderBookmarksBar().
+        return;
       }
+      renderBookmarksBar();
     }
 
     setTimeout(async () => {

--- a/shell/js/browser-tools.js
+++ b/shell/js/browser-tools.js
@@ -323,13 +323,6 @@
         renderBookmarksBar();
       });
     });
-    // Backup mechanism: listen for the store's window event. Redundant with the
-    // subscribe() above, but guarantees the top bar re-renders after mutations
-    // even if the subscribe chain ever misfires.
-    window.addEventListener('tandem:bookmarks-changed', () => {
-      updateBookmarkStar();
-      renderBookmarksBar();
-    });
 
     bmPopupCancel.addEventListener('click', closeBookmarkPopup);
 
@@ -455,22 +448,32 @@
       return dropdown;
     }
 
-    function createBarElement(item) {
+    function createBarElement(item, idx) {
       if (item.type === 'url' && item.url) {
         return createBookmarkLink(item);
       } else if (item.type === 'folder' && item.children) {
         const folder = document.createElement('div');
         folder.className = 'bm-folder';
+        folder.dataset.barIdx = String(idx);
         folder.innerHTML = `<span class="bm-folder-icon">📁</span> ${escapeHtml((item.name || 'Folder').substring(0, 25))}`;
         const dropdown = createFolderDropdown(item.children);
         folder.appendChild(dropdown);
-        folder.addEventListener('click', (e) => {
+        folder.addEventListener('click', async (e) => {
           e.stopPropagation();
           if (dropdown.classList.contains('open')) {
             closeAllBookmarkDropdowns();
-          } else {
-            openBookmarkDropdown(dropdown);
+            return;
           }
+          // Per-interaction refetch: pull the latest list from the backend
+          // before opening. store.load() notifies subscribers, which fully
+          // rebuilds the bar DOM — so `folder`/`dropdown` from this closure
+          // are now detached. Re-find the fresh folder by position and open
+          // ITS dropdown, guaranteeing the content reflects current data.
+          const store = getStore();
+          if (store) await store.load();
+          const freshFolder = bookmarksBar.querySelector(`.bm-folder[data-bar-idx="${idx}"]`);
+          const freshDropdown = freshFolder?.querySelector(':scope > .bm-dropdown');
+          if (freshDropdown) openBookmarkDropdown(freshDropdown);
         });
         return folder;
       }
@@ -486,8 +489,9 @@
       bookmarksBar.classList.add('visible');
 
       const elements = [];
-      for (const item of barItems) {
-        const el = createBarElement(item);
+      for (let i = 0; i < barItems.length; i++) {
+        const item = barItems[i];
+        const el = createBarElement(item, i);
         if (el) {
           bookmarksBar.appendChild(el);
           elements.push({ el, item });
@@ -554,13 +558,18 @@
       }
 
       chevron.appendChild(overflowDropdown);
-      chevron.addEventListener('click', (e) => {
+      chevron.addEventListener('click', async (e) => {
         e.stopPropagation();
         if (overflowDropdown.classList.contains('open')) {
           closeAllBookmarkDropdowns();
-        } else {
-          openBookmarkDropdown(overflowDropdown);
+          return;
         }
+        // Per-interaction refetch (same rationale as folder click above).
+        const store = getStore();
+        if (store) await store.load();
+        const freshChevron = bookmarksBar.querySelector('.bm-overflow');
+        const freshDropdown = freshChevron?.querySelector(':scope > .bm-dropdown');
+        if (freshDropdown) openBookmarkDropdown(freshDropdown);
       });
 
       bookmarksBar.appendChild(chevron);

--- a/shell/js/sidebar/panels/bookmarks.js
+++ b/shell/js/sidebar/panels/bookmarks.js
@@ -1,23 +1,40 @@
 /**
  * Sidebar bookmarks panel — list, folders, add/edit/delete, search, breadcrumbs.
  *
+ * All bookmark I/O goes through the shared bookmarks-store; this module is a
+ * pure view over store.getTree() + local navigation state. Mutations call
+ * store.add/remove/update/addFolder and the store notifies all subscribers,
+ * keeping this panel and the top bookmarks bar in sync automatically.
+ *
  * Loaded from: shell/js/sidebar/index.js (via activateItem when 'bookmarks' is selected)
  * window exports: none
  */
 
-import { getToken } from '../config.js';
 import { hideWebviews, safeSetPanelHTML } from '../webview.js';
 import { getFaviconUrl } from '../util.js';
+import * as bookmarksStore from '../../bookmarks-store.js';
 
 // === BOOKMARKS PANEL MODULE ===
 export const BOOKMARK_PANEL_IDS = ['bookmarks'];
 
+// Local view state. The tree itself lives in the store — we only track where
+// the user is navigated and whether they're in search mode.
 const bmState = {
-  all: null,         // full bookmark tree from API
-  currentFolder: null, // current folder node
-  path: [],          // breadcrumb trail [{id, name}]
+  currentFolderId: null, // null = at root
+  path: [],              // breadcrumb trail [{id, name}]
   searchMode: false,
 };
+
+// Re-render the panel whenever the store changes (deletes/adds from any
+// surface, including the top bookmarks bar). No-op when the panel isn't
+// mounted; loadBookmarkPanel() always reads fresh data on open anyway.
+bookmarksStore.subscribe(() => {
+  if (!document.getElementById('bm-list')) return;
+  if (bmState.searchMode) return; // leave active search results alone
+  reNavigateToPath();
+  refreshBmList();
+  renderBmBreadcrumb();
+});
 
 function folderIcon() {
   return `<svg viewBox="0 0 20 20" fill="currentColor" style="color:#aaa"><path d="M2 6a2 2 0 012-2h4l2 2h6a2 2 0 012 2v7a2 2 0 01-2 2H4a2 2 0 01-2-2V6z"/></svg>`;
@@ -75,17 +92,38 @@ function renderBmBreadcrumb() {
   }).reverse().join('');
 }
 
-function bmNavigateFolder(node) {
-  if (!node) { bmState.currentFolder = null; bmState.path = []; }
-  else bmState.currentFolder = node;
-  refreshBmList();
-  renderBmBreadcrumb();
+// Resolve the currently-navigated folder node in the (possibly just-refreshed)
+// tree. Returns the root's children list if path is empty, or the matching
+// folder's children if the path still resolves; trims the path otherwise.
+function currentItems() {
+  const tree = bookmarksStore.getTree();
+  if (!tree) return [];
+  if (bmState.path.length === 0) return tree.children || [];
+  let node = tree;
+  for (const p of bmState.path) {
+    const child = node.children?.find(c => c.id === p.id);
+    if (!child) { bmState.path = []; bmState.currentFolderId = null; return tree.children || []; }
+    node = child;
+  }
+  bmState.currentFolderId = node.id;
+  return node.children || [];
+}
+
+function currentParentId() {
+  // Parent for new items = current folder, falling back to the tree root's id.
+  return bmState.currentFolderId || bookmarksStore.getTree()?.id || '';
+}
+
+// Called by the store subscriber after external mutations: re-resolve the
+// current folder against the refreshed tree (trims broken path segments).
+function reNavigateToPath() {
+  currentItems(); // updates bmState.currentFolderId + trims stale path
 }
 
 function refreshBmList() {
   const listEl = document.getElementById('bm-list');
   if (!listEl) return;
-  const items = bmState.currentFolder ? bmState.currentFolder.children : bmState.all?.children;
+  const items = currentItems();
   listEl.innerHTML = renderBmItems(items);
   // Attach click handlers (ignore clicks on action buttons)
   listEl.querySelectorAll('.bm-item').forEach(el => {
@@ -97,11 +135,12 @@ function refreshBmList() {
         if (url && window.tandem) window.tandem.newTab(url);
       } else if (type === 'folder') {
         const folderId = el.dataset.id;
-        const items = bmState.currentFolder ? bmState.currentFolder.children : bmState.all?.children;
-        const folder = items?.find(i => i.id === folderId);
+        const folder = items.find(i => i.id === folderId);
         if (folder) {
           bmState.path.push({ id: folder.id, name: folder.name });
-          bmNavigateFolder(folder);
+          bmState.currentFolderId = folder.id;
+          refreshBmList();
+          renderBmBreadcrumb();
         }
       }
     });
@@ -126,38 +165,9 @@ function refreshBmList() {
       const item = btn.closest('.bm-item');
       const name = item.dataset.name;
       if (!confirm(`Delete "${name}"?`)) return;
-      try {
-        await fetch('http://localhost:8765/bookmarks/remove', {
-          method: 'DELETE',
-          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${getToken()}` },
-          body: JSON.stringify({ id }),
-        });
-        await reloadBmData();
-      } catch { /* ignore */ }
+      try { await bookmarksStore.remove(id); } catch { /* ignore */ }
     });
   });
-}
-
-async function reloadBmData() {
-  try {
-    const res = await fetch('http://localhost:8765/bookmarks', { headers: { Authorization: `Bearer ${getToken()}` } });
-    const data = await res.json();
-    bmState.all = data.bookmarks?.[0] || { children: [] };
-    // Re-navigate to current folder if possible
-    if (bmState.path.length > 0) {
-      let node = bmState.all;
-      for (const p of bmState.path) {
-        const child = node.children?.find(c => c.id === p.id);
-        if (!child) { bmState.path = []; bmState.currentFolder = null; break; }
-        node = child;
-        bmState.currentFolder = node;
-      }
-    } else {
-      bmState.currentFolder = null;
-    }
-    refreshBmList();
-    renderBmBreadcrumb();
-  } catch { /* ignore */ }
 }
 
 function showBmEditForm(id, name, url, type) {
@@ -186,14 +196,9 @@ function showBmEditForm(id, name, url, type) {
     const newUrl = isFolder ? undefined : item.querySelector('#bm-edit-url')?.value.trim();
     if (!newName) return;
     try {
-      const body = { id, name: newName };
-      if (!isFolder && newUrl) body.url = newUrl;
-      await fetch('http://localhost:8765/bookmarks/update', {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${getToken()}` },
-        body: JSON.stringify(body),
-      });
-      await reloadBmData();
+      const payload = { id, name: newName };
+      if (!isFolder && newUrl) payload.url = newUrl;
+      await bookmarksStore.update(payload);
     } catch { /* ignore */ }
   });
 
@@ -236,15 +241,13 @@ export async function loadBookmarkPanel() {
       </div>
     </div>`);
 
-  // Fetch bookmarks if not cached
-  if (!bmState.all) {
-    const res = await fetch('http://localhost:8765/bookmarks', { headers: { Authorization: `Bearer ${getToken()}` } });
-    const data = await res.json();
-    bmState.all = data.bookmarks?.[0] || { children: [] }; // Bookmarks Bar root
-  }
-
-  bmState.currentFolder = null;
+  // Reset navigation to root for each panel open, then refresh from the store.
+  // load() always refetches so we show fresh data — other surfaces may have
+  // mutated the store while this panel was closed.
+  bmState.currentFolderId = null;
   bmState.path = [];
+  bmState.searchMode = false;
+  await bookmarksStore.load();
   refreshBmList();
   renderBmBreadcrumb();
 
@@ -253,15 +256,14 @@ export async function loadBookmarkPanel() {
     const crumb = e.target.closest('.bm-crumb');
     if (!crumb || crumb.classList.contains('active')) return;
     const crumbId = crumb.dataset.crumbId;
-    if (!crumbId) { bmState.path = []; bmNavigateFolder(null); return; }
-    const idx = bmState.path.findIndex(p => p.id === crumbId);
-    if (idx >= 0) { bmState.path = bmState.path.slice(0, idx + 1); }
-    // Navigate to that folder node
-    let node = bmState.all;
-    for (const p of bmState.path) {
-      node = node.children?.find(c => c.id === p.id) || node;
+    if (!crumbId) {
+      bmState.path = [];
+      bmState.currentFolderId = null;
+    } else {
+      const idx = bmState.path.findIndex(p => p.id === crumbId);
+      if (idx >= 0) bmState.path = bmState.path.slice(0, idx + 1);
+      bmState.currentFolderId = crumbId;
     }
-    bmState.currentFolder = node.id === bmState.all.id ? null : node;
     refreshBmList();
     renderBmBreadcrumb();
   });
@@ -279,13 +281,10 @@ export async function loadBookmarkPanel() {
     }
     searchTimer = setTimeout(async () => {
       bmState.searchMode = true;
-      const res = await fetch(`http://localhost:8765/bookmarks/search?q=${encodeURIComponent(q)}`, {
-        headers: { Authorization: `Bearer ${getToken()}` }
-      });
-      const data = await res.json();
+      const results = await bookmarksStore.search(q);
       const listEl = document.getElementById('bm-list');
       const breadEl = document.getElementById('bm-breadcrumb');
-      if (listEl) listEl.innerHTML = renderBmItems(data.results || []);
+      if (listEl) listEl.innerHTML = renderBmItems(results);
       if (breadEl) breadEl.innerHTML = `<span class="bm-crumb active">Search results</span>`;
       // Attach URL click handlers for search results
       listEl?.querySelectorAll('.bm-item.url').forEach(el => {
@@ -320,15 +319,8 @@ export async function loadBookmarkPanel() {
       const name = form.querySelector('#bm-add-name').value.trim();
       const url = form.querySelector('#bm-add-url').value.trim();
       if (!name || !url) return;
-      const parentId = bmState.currentFolder?.id || bmState.all?.id || '';
-      try {
-        await fetch('http://localhost:8765/bookmarks/add', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${getToken()}` },
-          body: JSON.stringify({ name, url, parentId }),
-        });
-        await reloadBmData();
-      } catch { /* ignore */ }
+      try { await bookmarksStore.add({ name, url, parentId: currentParentId() }); }
+      catch { /* ignore */ }
     });
 
     form.querySelector('#bm-add-cancel').addEventListener('click', () => form.remove());
@@ -358,15 +350,8 @@ export async function loadBookmarkPanel() {
     form.querySelector('#bm-addfolder-save').addEventListener('click', async () => {
       const name = form.querySelector('#bm-addfolder-name').value.trim();
       if (!name) return;
-      const parentId = bmState.currentFolder?.id || bmState.all?.id || '';
-      try {
-        await fetch('http://localhost:8765/bookmarks/add-folder', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${getToken()}` },
-          body: JSON.stringify({ name, parentId }),
-        });
-        await reloadBmData();
-      } catch { /* ignore */ }
+      try { await bookmarksStore.addFolder({ name, parentId: currentParentId() }); }
+      catch { /* ignore */ }
     });
 
     form.querySelector('#bm-addfolder-cancel').addEventListener('click', () => form.remove());


### PR DESCRIPTION
## Summary

Replaces the earlier event-based sync approach with a proper single-source-of-truth architecture.

- **Problem:** sidebar bookmarks panel and top bookmarks bar each fetched + cached bookmarks independently. Mutations from one surface didn't refresh the other. Initial event-based fix partially worked but deletes-from-sidebar still didn't reach the top bar.
- **Fix:** new `shell/js/bookmarks-store.js` module owns *all* bookmark HTTP I/O + an in-memory mirror. Both UIs become views over the store and subscribe to its change notifications. No more event glue between UIs.

## Architecture

```
          ┌──────────────────────────────┐
          │  shell/js/bookmarks-store.js │
          │  ─────────────────────────   │
          │  _tree, _bar, _subscribers   │
          │  load / add / remove /       │
          │  update / move / addFolder / │
          │  check / search / subscribe  │
          └──────┬────────────────┬──────┘
                 │                │
      subscribe()│                │subscribe()
                 ▼                ▼
    ┌────────────────────┐  ┌────────────────────┐
    │  browser-tools.js  │  │ sidebar/panels/    │
    │  (top bar + ★)     │  │ bookmarks.js       │
    └────────────────────┘  └────────────────────┘
```

Every mutation method calls `load()` after its HTTP call, which notifies all subscribers. Both UIs re-render from current store state.

## Changes

- **`shell/js/bookmarks-store.js` (new, ~135 LOC):** `load`, `getTree`, `getBar`, `isLoaded`, `check`, `add`, `addFolder`, `remove`, `update`, `move`, `search`, `subscribe`. Published on `window.__TANDEM_BOOKMARKS_STORE__` (for the classic-script top bar). Dispatches `tandem:bookmarks-store-ready` so consumers can defer `subscribe()` past module-load ordering.
- **`shell/js/sidebar/panels/bookmarks.js`:** drops direct fetches + the `bmState.all` cache. Subscribes to store; re-renders on change. Local state is just navigation (`currentFolderId`, `path`, `searchMode`). Mutations call `store.add/remove/update/addFolder`.
- **`shell/js/browser-tools.js`:** drops direct fetches + the manual `tandem:bookmarks-changed` event. Star popup save/delete route through the store. Subscribes to re-render bar + star.
- **`shell/index.html`:** loads `bookmarks-store.js` as a module before the sidebar module graph.

## Why this is better than event-based sync

- One cache, one write path. Cross-UI drift is impossible by construction.
- New surfaces (future: pinboard bookmarks? context menu?) just subscribe — they automatically stay in sync.
- Deletes state-handling complexity: no more "did this surface emit the event, did the other hear it, did the listener fire before DOM is ready" debugging.
- Natural test boundary: store can be unit-tested without UI.

## Not in scope

Pre-existing bugs deferred per spec §5.3:
- XSS in innerHTML on bookmark name/url (sidebar + top bar dropdowns)
- Missing error reporting on failed fetches (silent catch blocks)

## Test plan

- [x] `npm run verify` green ✅ (2552 pass, lint + consistency clean)
- [x] Add bookmark via top bar ⭐ → appears in sidebar panel (open + already-open)
- [x] Delete bookmark via sidebar → disappears from top bar ⭐ and bar strip
- [x] Edit bookmark via sidebar → name updates in top bar without reload
- [x] Add folder via sidebar → top bar dropdowns show the new folder
- [x] Delete folder via top bar star popup → sidebar panel refreshes
- [x] Search in sidebar still works (read-only, doesn't disturb tree)
- [x] CI green