### PR TITLE
refactor(shell/sidebar): extract workspaces + tab-context-menu (PR 12/12)

### DIFF
--- a/shell/js/sidebar/index.js
+++ b/shell/js/sidebar/index.js
@@ -1,17 +1,21 @@
 /**
- * Sidebar module entry point — panels, workspaces, tab context menu, drag-drop.
+ * Sidebar module entry point — pure orchestration. Renders the sidebar item
+ * strip, routes clicks to panel modules (bookmarks, history, pinboard,
+ * workspaces, messengers), wires drag-drop and panel-resize, and handles the
+ * customize/tips/pin/close buttons. All panel-specific logic lives in
+ * ./panels/* and ./tab-context-menu.js.
  *
  * Loaded from: shell/index.html as <script type="module" src="js/sidebar/index.js">
  * window exports: ocSidebar (consumed by shell/js/shortcut-router.js:35 for the
- *   Cmd+B bookmarks shortcut), __tandemShowTabContextMenu (consumed by main.js
- *   via window.__tandemShowTabContextMenu, already set via window. inside the IIFE).
+ *   Cmd+B bookmarks shortcut). __tandemShowTabContextMenu is installed by
+ *   tab-context-menu.js as a side effect of its import.
  */
 
-import { ICONS, WORKSPACE_ICONS } from './constants.js';
+import { ICONS } from './constants.js';
 import {
   getToken, getConfig, setConfig,
   isSetupPanelOpen, setSetupPanelOpen,
-  getWorkspaces, setWorkspaces,
+  getWorkspaces,
   getActiveWorkspaceId, setActiveWorkspaceId,
 } from './config.js';
 import { initDragDrop } from './drag-drop.js';
@@ -24,84 +28,24 @@ import {
 } from './webview.js';
 import { loadHistoryPanel } from './panels/history.js';
 import { BOOKMARK_PANEL_IDS, loadBookmarkPanel } from './panels/bookmarks.js';
-import { PINBOARD_PANEL_IDS, loadPinboardPanel, refreshPinboardIfOpen } from './panels/pinboard.js';
+import { PINBOARD_PANEL_IDS, loadPinboardPanel } from './panels/pinboard.js';
+import {
+  WORKSPACE_PANEL_ID,
+  openWorkspacePanel,
+  loadWorkspaces,
+  filterTabBar,
+  getIconSvg,
+  switchWorkspace,
+  setWorkspacesRender,
+} from './panels/workspaces.js';
+// Importing tab-context-menu installs window.__tandemShowTabContextMenu as a
+// side effect; moveTabToWorkspace is passed to initDragDrop below.
+import { moveTabToWorkspace } from './tab-context-menu.js';
 
   // ═══════════════════════════════════════
   // SIDEBAR
   // ═══════════════════════════════════════
   const ocSidebar = (() => {
-
-    function getIconSvg(slug) {
-      if (WORKSPACE_ICONS[slug]) return WORKSPACE_ICONS[slug];
-      // If the slug isn't a known icon name, render it directly (supports emoji icons)
-      if (slug && typeof slug === 'string' && slug.trim()) {
-        return `<span class="workspace-emoji-icon">${slug}</span>`;
-      }
-      return WORKSPACE_ICONS.home;
-    }
-
-    async function loadQuickLinksConfig() {
-      const response = await fetch('http://localhost:8765/config', {
-        headers: { Authorization: `Bearer ${getToken()}` }
-      });
-      if (!response.ok) throw new Error('Failed to load quick links');
-      return response.json();
-    }
-
-    function isQuickLinkableUrl(url) {
-      return /^https?:\/\//i.test(url || '');
-    }
-
-    function normalizeQuickLinkUrl(url) {
-      const parsed = new URL(url);
-      parsed.hash = '';
-      return parsed.toString();
-    }
-
-    async function addQuickLink(url, label) {
-      const data = await loadQuickLinksConfig();
-      const normalizedUrl = normalizeQuickLinkUrl(url);
-      const quickLinks = (data.general?.quickLinks || []).filter((link) => {
-        try {
-          return normalizeQuickLinkUrl(link?.url) !== normalizedUrl;
-        } catch {
-          return true;
-        }
-      });
-      quickLinks.push({ label, url: normalizedUrl });
-      const response = await fetch('http://localhost:8765/config', {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${getToken()}`
-        },
-        body: JSON.stringify({ general: { quickLinks } })
-      });
-      if (!response.ok) throw new Error('Failed to save quick links');
-      return response.json();
-    }
-
-    async function removeQuickLink(url) {
-      const data = await loadQuickLinksConfig();
-      const normalizedUrl = normalizeQuickLinkUrl(url);
-      const quickLinks = (data.general?.quickLinks || []).filter((link) => {
-        try {
-          return normalizeQuickLinkUrl(link?.url) !== normalizedUrl;
-        } catch {
-          return true;
-        }
-      });
-      const response = await fetch('http://localhost:8765/config', {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${getToken()}`
-        },
-        body: JSON.stringify({ general: { quickLinks } })
-      });
-      if (!response.ok) throw new Error('Failed to save quick links');
-      return response.json();
-    }
 
     async function loadConfig() {
       const r = await fetch('http://localhost:8765/sidebar/config', { headers: { Authorization: `Bearer ${getToken()}` } });
@@ -220,6 +164,8 @@ import { PINBOARD_PANEL_IDS, loadPinboardPanel, refreshPinboardIfOpen } from './
         loadHistoryPanel();
       } else if (newActive && PINBOARD_PANEL_IDS.includes(newActive)) {
         loadPinboardPanel();
+      } else if (newActive === WORKSPACE_PANEL_ID) {
+        openWorkspacePanel();
       } else {
         hideWebviews();
         const content = document.getElementById('sidebar-panel-content');
@@ -263,256 +209,11 @@ import { PINBOARD_PANEL_IDS, loadPinboardPanel, refreshPinboardIfOpen } from './
 
     const setupPanel = createSetupPanel({ hideWebviews, safeSetPanelHTML, render });
 
-    // === WORKSPACE FUNCTIONS ===
-    async function loadWorkspaces() {
-      try {
-        const r = await fetch('http://localhost:8765/workspaces', { headers: { Authorization: `Bearer ${getToken()}` } });
-        const data = await r.json();
-        if (data.ok) {
-          setWorkspaces(data.workspaces);
-          setActiveWorkspaceId(data.activeId);
-          render();
-          filterTabBar();
-        }
-      } catch (e) { /* workspace API not yet available during startup */ }
-    }
-
-    async function switchWorkspace(id) {
-      try {
-        const r = await fetch(`http://localhost:8765/workspaces/${id}/switch`, {
-          method: 'POST', headers: { Authorization: `Bearer ${getToken()}` }
-        });
-        const data = await r.json();
-        if (data.ok) {
-          setActiveWorkspaceId(data.workspace.id);
-          // Update the local workspace's tabIds
-          const ws = getWorkspaces().find(w => w.id === id);
-          if (ws) Object.assign(ws, data.workspace);
-          render();
-          filterTabBar();
-        }
-      } catch (e) { console.error('switchWorkspace failed:', e); }
-    }
-
-    function getNextWorkspaceName() {
-      const existing = getWorkspaces().map(w => w.name);
-      let n = 1;
-      while (existing.includes(`Workspace ${n}`)) n++;
-      return `Workspace ${n}`;
-    }
-
-    function renderIconGrid(selectedIcon) {
-      const slugs = Object.keys(WORKSPACE_ICONS);
-      return slugs.map(slug => {
-        const isSelected = slug === selectedIcon;
-        return `<button class="ws-icon-grid-btn ${isSelected ? 'selected' : ''}" data-icon-slug="${slug}" title="${slug}">
-          <span class="ws-icon-grid-svg">${WORKSPACE_ICONS[slug]}</span>
-        </button>`;
-      }).join('');
-    }
-
-    function showWorkspaceForm(content, mode, existingWs) {
-      const isEdit = mode === 'edit';
-      const title = isEdit ? 'Edit workspace' : 'Create workspace';
-      const btnLabel = isEdit ? 'Save' : 'Create';
-      const defaultIcon = isEdit ? existingWs.icon : Object.keys(WORKSPACE_ICONS)[0];
-      const defaultName = isEdit ? existingWs.name : getNextWorkspaceName();
-
-      safeSetPanelHTML(`
-        <div class="ws-form-sheet">
-          <div class="ws-form-title">${title}</div>
-          <div class="ws-form-section-label">Icon</div>
-          <div class="ws-icon-grid" id="ws-icon-grid">${renderIconGrid(defaultIcon)}</div>
-          <div class="ws-form-section-label">Name</div>
-          <input type="text" class="ws-form-input" id="ws-form-name" value="${defaultName}" placeholder="${getNextWorkspaceName()}" />
-          <div class="ws-form-actions">
-            <button class="ws-form-btn-cancel" id="ws-form-cancel">Cancel</button>
-            <button class="ws-form-btn-primary" id="ws-form-submit">${btnLabel}</button>
-          </div>
-          ${isEdit ? `<button class="ws-form-btn-delete" id="ws-form-delete">Delete workspace</button>` : ''}
-          <div class="ws-form-delete-confirm" id="ws-form-delete-confirm" style="display:none;">
-            <span>Are you sure? Tabs will move to Default.</span>
-            <div class="ws-form-delete-confirm-actions">
-              <button class="ws-form-btn-cancel" id="ws-form-delete-no">No</button>
-              <button class="ws-form-btn-danger" id="ws-form-delete-yes">Yes, delete</button>
-            </div>
-          </div>
-        </div>`);
-
-      let selectedIcon = defaultIcon;
-
-      // Icon grid selection
-      content.querySelectorAll('.ws-icon-grid-btn').forEach(btn => {
-        btn.addEventListener('click', () => {
-          content.querySelectorAll('.ws-icon-grid-btn').forEach(b => b.classList.remove('selected'));
-          btn.classList.add('selected');
-          selectedIcon = btn.dataset.iconSlug;
-        });
-      });
-
-      // Auto-focus name input
-      const nameInput = content.querySelector('#ws-form-name');
-      nameInput.focus();
-      nameInput.select();
-
-      // Cancel
-      content.querySelector('#ws-form-cancel').addEventListener('click', () => {
-        openWorkspacePanel();
-      });
-
-      // Submit
-      content.querySelector('#ws-form-submit').addEventListener('click', async () => {
-        const name = nameInput.value.trim();
-        if (!name) return;
-        try {
-          if (isEdit) {
-            const r = await fetch(`http://localhost:8765/workspaces/${existingWs.id}`, {
-              method: 'PUT',
-              headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${getToken()}` },
-              body: JSON.stringify({ name, icon: selectedIcon })
-            });
-            const data = await r.json();
-            if (data.ok) {
-              const idx = getWorkspaces().findIndex(w => w.id === existingWs.id);
-              if (idx >= 0) getWorkspaces()[idx] = data.workspace;
-              render();
-            }
-          } else {
-            const r = await fetch('http://localhost:8765/workspaces', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${getToken()}` },
-              body: JSON.stringify({ name, icon: selectedIcon })
-            });
-            const data = await r.json();
-            if (data.ok) {
-              getWorkspaces().push(data.workspace);
-              render();
-            }
-          }
-        } catch (e) { console.error('workspace form submit failed:', e); }
-        openWorkspacePanel();
-      });
-
-      // Enter key on input submits
-      nameInput.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter') content.querySelector('#ws-form-submit').click();
-        if (e.key === 'Escape') openWorkspacePanel();
-      });
-
-      // Delete (edit mode only)
-      if (isEdit) {
-        content.querySelector('#ws-form-delete').addEventListener('click', () => {
-          content.querySelector('#ws-form-delete').style.display = 'none';
-          content.querySelector('#ws-form-delete-confirm').style.display = '';
-        });
-        content.querySelector('#ws-form-delete-no').addEventListener('click', () => {
-          content.querySelector('#ws-form-delete-confirm').style.display = 'none';
-          content.querySelector('#ws-form-delete').style.display = '';
-        });
-        content.querySelector('#ws-form-delete-yes').addEventListener('click', async () => {
-          try {
-            await fetch(`http://localhost:8765/workspaces/${existingWs.id}`, {
-              method: 'DELETE', headers: { Authorization: `Bearer ${getToken()}` }
-            });
-            await loadWorkspaces();
-          } catch (e) { console.error('workspace delete failed:', e); }
-          openWorkspacePanel();
-        });
-      }
-    }
-
-    function filterTabBar() {
-      // Find active workspace
-      const ws = getWorkspaces().find(w => w.id === getActiveWorkspaceId());
-      if (!ws) return;
-      const allowedTabIds = new Set(ws.tabIds);
-
-      // Get all tab elements from the tab bar
-      const tabEls = document.querySelectorAll('#tab-bar .tab[data-tab-id]');
-      const visibleTabIds = [];
-      tabEls.forEach(el => {
-        const tabId = el.dataset.tabId;
-        // Get webContentsId for this tab from the webview
-        const wv = document.querySelector(`webview[data-tab-id="${tabId}"]`);
-        if (!wv) return;
-        const wcId = wv.getWebContentsId ? wv.getWebContentsId() : null;
-        const visible = wcId !== null && allowedTabIds.has(wcId);
-        el.style.display = visible ? '' : 'none';
-        if (visible) {
-          visibleTabIds.push(tabId);
-        } else {
-          wv.classList.remove('active');
-        }
-      });
-
-      if (visibleTabIds.length === 0) return;
-
-      const activeWebview = document.querySelector('webview.active[data-tab-id]');
-      const activeTabId = activeWebview?.dataset?.tabId || null;
-      if (!activeTabId || !visibleTabIds.includes(activeTabId)) {
-        if (window.tandem) {
-          window.tandem.focusTab(visibleTabIds[0]);
-        }
-      }
-    }
-
-    async function openWorkspacePanel() {
-      setSetupPanelOpen(false);
-      getConfig().activeItemId = '__workspaces';
-      const panel = document.getElementById('sidebar-panel');
-      const titleEl = document.getElementById('sidebar-panel-title');
-      const content = document.getElementById('sidebar-panel-content');
-
-      titleEl.textContent = 'Workspaces';
-      panel.classList.add('open');
-      setPanelWidth(getPanelWidth('__workspaces'));
-
-      // Hide webviews
-      hideWebviews();
-      content.classList.remove('webview-mode');
-
-      // Refresh workspace data
-      await loadWorkspaces();
-
-      const rows = getWorkspaces().map(ws => {
-        const isActive = ws.id === getActiveWorkspaceId();
-        return `
-          <div class="ws-panel-item ${isActive ? 'active' : ''}" data-ws-panel-id="${ws.id}">
-            <div class="ws-panel-icon-svg">${getIconSvg(ws.icon)}</div>
-            <span class="ws-panel-name">${ws.name}</span>
-            ${isActive ? '<span class="ws-panel-check">✓</span>' : ''}
-            ${!ws.isDefault ? `<button class="ws-panel-edit" data-ws-edit="${ws.id}" title="Edit">···</button>` : ''}
-          </div>`;
-      }).join('');
-
-      safeSetPanelHTML(`
-        <div class="ws-panel">
-          <button class="ws-panel-add" id="ws-panel-add-btn">+ Add workspace</button>
-          ${rows}
-        </div>`);
-
-      // Event handlers
-      content.querySelector('#ws-panel-add-btn')?.addEventListener('click', () => {
-        showWorkspaceForm(content, 'create', null);
-      });
-      content.querySelectorAll('.ws-panel-item').forEach(el => {
-        el.addEventListener('click', async (e) => {
-          if (e.target.closest('.ws-panel-edit')) return;
-          await switchWorkspace(el.dataset.wsPanelId);
-          await openWorkspacePanel();
-        });
-      });
-      content.querySelectorAll('.ws-panel-edit').forEach(btn => {
-        btn.addEventListener('click', (e) => {
-          e.stopPropagation();
-          const id = btn.dataset.wsEdit;
-          const ws = getWorkspaces().find(w => w.id === id);
-          if (ws) showWorkspaceForm(content, 'edit', ws);
-        });
-      });
-    }
-
     function init() {
+      // Let the workspaces panel module trigger re-renders here when it
+      // mutates workspace state (create/edit/delete/switch).
+      setWorkspacesRender(render);
+
       loadConfig();
       // Load workspaces after a short delay to ensure API is ready
       setTimeout(loadWorkspaces, 500);
@@ -621,331 +322,6 @@ import { PINBOARD_PANEL_IDS, loadPinboardPanel, refreshPinboardIfOpen } from './
       // Pinboard item-added refresh hook is installed by the pinboard panel
       // module itself on first open (see panels/pinboard.js).
     }
-
-    // === TAB CONTEXT MENU (custom DOM, no IPC) ===
-    let ctxMenuEl = null;
-
-    function getWebContentsIdForTab(domTabId) {
-      const wv = document.querySelector(`webview[data-tab-id="${domTabId}"]`);
-      return wv && wv.getWebContentsId ? wv.getWebContentsId() : null;
-    }
-
-    function getTabWorkspaceId(domTabId) {
-      const wcId = getWebContentsIdForTab(domTabId);
-      if (wcId === null) return null;
-      const ws = getWorkspaces().find(w => w.tabIds && w.tabIds.includes(wcId));
-      return ws ? ws.id : null;
-    }
-
-    async function moveTabToWorkspace(domTabId, targetWsId) {
-      const wcId = getWebContentsIdForTab(domTabId);
-      if (wcId === null) return;
-      try {
-        await fetch(`http://localhost:8765/workspaces/${targetWsId}/move-tab`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${getToken()}` },
-          body: JSON.stringify({ tabId: wcId })
-        });
-        await loadWorkspaces();
-        filterTabBar();
-        const ws = getWorkspaces().find(w => w.id === targetWsId);
-        console.log(`Tab moved to workspace ${ws ? ws.name : targetWsId}`);
-      } catch (e) { console.error('moveTabToWorkspace failed:', e); }
-    }
-
-    function closeCtxMenu() {
-      if (ctxMenuEl) { ctxMenuEl.remove(); ctxMenuEl = null; }
-    }
-
-    async function showTabContextMenu(domTabId, x, y) {
-      closeCtxMenu();
-
-      const wv = document.querySelector('webview[data-tab-id="'+domTabId+'"]');
-      const isMuted = wv ? wv.audioMuted : false;
-      const currentWsId = getTabWorkspaceId(domTabId);
-      const targets = getWorkspaces().filter(ws => ws.id !== currentWsId);
-
-      // Pre-fetch pinboards (fast — same-machine API call)
-      let pbBoards = [];
-      try {
-        const pbRes = await fetch('http://localhost:8765/pinboards', { headers: { Authorization: `Bearer ${getToken()}` } });
-        const pbData = await pbRes.json();
-        pbBoards = pbData.boards || [];
-      } catch { /* Tandem not running or no boards */ }
-
-      const menu = document.createElement('div');
-      menu.className = 'tandem-ctx-menu';
-      menu.style.left = x + 'px';
-      menu.style.top = y + 'px';
-
-      function addItem(label, onClick) {
-        const item = document.createElement('div');
-        item.className = 'tandem-ctx-menu-item';
-        item.textContent = label;
-        item.addEventListener('click', () => { closeCtxMenu(); onClick(item); });
-        menu.appendChild(item);
-        return item;
-      }
-
-      function addSep() {
-        const sep = document.createElement('div');
-        sep.className = 'tandem-ctx-separator';
-        menu.appendChild(sep);
-      }
-
-      // — New Tab
-      addItem('New Tab', () => { window.tandem.newTab(); });
-
-      addSep();
-
-      // — Reload
-      addItem('Reload', () => { if (wv) wv.reload(); });
-
-      // — Duplicate Tab
-      addItem('Duplicate Tab', () => { if (wv) window.tandem.newTab(wv.src); });
-
-      // — Copy Page Address
-      addItem('Copy Page Address', (itemEl) => {
-        if (wv) {
-          navigator.clipboard.writeText(wv.src);
-          itemEl.textContent = 'Copied!';
-          setTimeout(() => { itemEl.textContent = 'Copy Page Address'; }, 1000);
-        }
-      });
-
-      if (wv && isQuickLinkableUrl(wv.src)) {
-        const quickLinksData = await loadQuickLinksConfig().catch(() => null);
-        const currentQuickLinks = quickLinksData?.general?.quickLinks || [];
-        const currentUrl = normalizeQuickLinkUrl(wv.src);
-        const alreadyQuickLink = currentQuickLinks.some((link) => {
-          try {
-            return normalizeQuickLinkUrl(link?.url) === currentUrl;
-          } catch {
-            return false;
-          }
-        });
-        addItem(alreadyQuickLink ? 'Remove from Quick Links' : 'Add to Quick Links', async () => {
-          try {
-            if (alreadyQuickLink) {
-              await removeQuickLink(currentUrl);
-            } else {
-              await addQuickLink(currentUrl, wv.getTitle() || currentUrl);
-            }
-          } catch {
-            // Ignore save failures for now; the menu just closes.
-          }
-        });
-      }
-
-      addSep();
-
-      // — Move to Workspace (submenu)
-      if (targets.length > 0) {
-        const wsItem = document.createElement('div');
-        wsItem.className = 'tandem-ctx-menu-item';
-        wsItem.innerHTML = '<span>Move to Workspace</span><span class="ctx-arrow">▶</span>';
-
-        const sub = document.createElement('div');
-        sub.className = 'tandem-ctx-submenu';
-        targets.forEach(ws => {
-          const si = document.createElement('div');
-          si.className = 'tandem-ctx-submenu-item';
-          const icon = getIconSvg(ws.icon);
-          si.innerHTML = '<span class="ws-ctx-icon">' + icon + '</span><span>' + ws.name + '</span>';
-          si.addEventListener('click', () => {
-            closeCtxMenu();
-            moveTabToWorkspace(domTabId, ws.id);
-          });
-          sub.appendChild(si);
-        });
-        wsItem.appendChild(sub);
-        menu.appendChild(wsItem);
-
-        addSep();
-      }
-
-      // — Add to Pinboard (submenu)
-      {
-        const pbItem = document.createElement('div');
-        pbItem.className = 'tandem-ctx-menu-item';
-        pbItem.innerHTML = '<span>📌 Add to Pinboard</span><span class="ctx-arrow">▶</span>';
-
-        const pbSub = document.createElement('div');
-        pbSub.className = 'tandem-ctx-submenu';
-
-        if (pbBoards.length === 0) {
-          const empty = document.createElement('div');
-          empty.className = 'tandem-ctx-submenu-item';
-          empty.style.opacity = '0.5';
-          empty.style.cursor = 'default';
-          empty.textContent = 'No boards yet';
-          pbSub.appendChild(empty);
-        } else {
-          pbBoards.forEach(board => {
-            const si = document.createElement('div');
-            si.className = 'tandem-ctx-submenu-item';
-            si.innerHTML = '<span>' + board.emoji + ' ' + board.name + '</span>';
-            si.addEventListener('click', async () => {
-              closeCtxMenu();
-              const tabUrl = wv ? wv.src : '';
-              const tabTitle = wv ? wv.getTitle() : '';
-              await fetch('http://localhost:8765/pinboards/' + board.id + '/items', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${getToken()}` },
-                body: JSON.stringify({ type: 'link', url: tabUrl, title: tabTitle })
-              });
-              // Visual flash feedback on the tab
-              const tabEl = document.querySelector('.tab[data-tab-id="' + domTabId + '"]');
-              if (tabEl) {
-                tabEl.classList.add('pin-flash');
-                setTimeout(() => tabEl.classList.remove('pin-flash'), 700);
-              }
-              // Refresh board if it's currently open (no-op otherwise).
-              refreshPinboardIfOpen(board.id);
-            });
-            pbSub.appendChild(si);
-          });
-        }
-
-        pbItem.appendChild(pbSub);
-        menu.appendChild(pbItem);
-        addSep();
-      }
-
-      // — Mute / Unmute Tab
-      addItem(isMuted ? 'Unmute Tab' : 'Mute Tab', () => {
-        if (wv) wv.audioMuted = !isMuted;
-      });
-
-      // — Set Emoji (submenu)
-      {
-        const emojiItem = document.createElement('div');
-        emojiItem.className = 'tandem-ctx-menu-item';
-        const tabEl = document.querySelector('.tab[data-tab-id="' + domTabId + '"]');
-        const tabEmojiSpan = tabEl ? tabEl.querySelector('.tab-emoji') : null;
-        const currentEmoji = (tabEmojiSpan && tabEmojiSpan.style.display !== 'none') ? tabEmojiSpan.textContent : '';
-        const emojiLabel = document.createElement('span');
-        emojiLabel.textContent = currentEmoji ? ('Emoji: ' + currentEmoji) : 'Set Emoji...';
-        const emojiArrow = document.createElement('span');
-        emojiArrow.className = 'ctx-arrow';
-        emojiArrow.textContent = '▶';
-        emojiItem.appendChild(emojiLabel);
-        emojiItem.appendChild(emojiArrow);
-
-        const emojiSub = document.createElement('div');
-        emojiSub.className = 'tandem-ctx-submenu tandem-emoji-grid';
-
-        if (currentEmoji) {
-          const removeItem = document.createElement('div');
-          removeItem.className = 'tandem-ctx-submenu-item';
-          removeItem.textContent = 'Remove Emoji';
-          removeItem.addEventListener('click', async () => {
-            closeCtxMenu();
-            await fetch('http://localhost:8765/tabs/' + encodeURIComponent(domTabId) + '/emoji', {
-              method: 'DELETE',
-              headers: { Authorization: 'Bearer ' + getToken() }
-            });
-          });
-          emojiSub.appendChild(removeItem);
-          const sep = document.createElement('div');
-          sep.className = 'tandem-ctx-separator';
-          emojiSub.appendChild(sep);
-        }
-
-        const emojis = [
-          '🔥','⭐','💡','🚀','✅','❌','⚠️','🎯','💬','📌',
-          '📚','🧪','🔧','🎨','📊','🔒','👀','💰','🎵','❤️',
-          '🏠','📧','🛒','📝','🗂️','🌍','☁️','📸','🎮','🤖',
-          '🧠','🔍','📅','🎁','🏷️','⏰','🔔','💻','📱','🎬',
-          '🍕','☕','🌟','💎','🦊','🐛','🏗️','📦','🔗','🏆',
-        ];
-        const grid = document.createElement('div');
-        grid.className = 'tandem-emoji-picker';
-        emojis.forEach(emoji => {
-          const btn = document.createElement('span');
-          btn.className = 'tandem-emoji-btn';
-          btn.textContent = emoji;
-          btn.addEventListener('click', async () => {
-            closeCtxMenu();
-            await fetch('http://localhost:8765/tabs/' + encodeURIComponent(domTabId) + '/emoji', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json', Authorization: 'Bearer ' + getToken() },
-              body: JSON.stringify({ emoji: emoji })
-            });
-          });
-          grid.appendChild(btn);
-        });
-        emojiSub.appendChild(grid);
-
-        emojiItem.appendChild(emojiSub);
-        menu.appendChild(emojiItem);
-      }
-
-      addSep();
-
-      // — Close Tab
-      addItem('Close Tab', () => { window.tandem.closeTab(domTabId); });
-
-      // — Close Other Tabs
-      addItem('Close Other Tabs', () => {
-        const allTabs = document.querySelectorAll('#tab-bar .tab[data-tab-id]');
-        allTabs.forEach(t => {
-          const tid = t.dataset.tabId;
-          if (tid && tid !== domTabId) window.tandem.closeTab(tid);
-        });
-      });
-
-      // — Close Tabs to the Right
-      addItem('Close Tabs to the Right', () => {
-        const allTabs = Array.from(document.querySelectorAll('#tab-bar .tab[data-tab-id]'));
-        const idx = allTabs.findIndex(t => t.dataset.tabId === domTabId);
-        if (idx >= 0) {
-          for (let i = idx + 1; i < allTabs.length; i++) {
-            const tid = allTabs[i].dataset.tabId;
-            if (tid) window.tandem.closeTab(tid);
-          }
-        }
-      });
-
-      document.body.appendChild(menu);
-      ctxMenuEl = menu;
-
-      // Auto-flip if menu extends beyond viewport
-      const rect = menu.getBoundingClientRect();
-      if (rect.right > window.innerWidth) menu.style.left = Math.max(0, window.innerWidth - rect.width - 8) + 'px';
-      if (rect.bottom > window.innerHeight) menu.style.top = Math.max(0, window.innerHeight - rect.height - 8) + 'px';
-
-      // Flip submenu left if near right edge
-      requestAnimationFrame(() => {
-        const menuRight = menu.getBoundingClientRect().right;
-        if (menuRight + 180 > window.innerWidth) {
-          const subs = menu.querySelectorAll('.tandem-ctx-submenu');
-          subs.forEach(s => s.classList.add('flip-left'));
-        }
-      });
-
-      // Close on click outside, Escape, scroll
-      const closeHandler = (e) => {
-        if (ctxMenuEl && !ctxMenuEl.contains(e.target)) { closeCtxMenu(); cleanup(); }
-      };
-      const escHandler = (e) => {
-        if (e.key === 'Escape') { closeCtxMenu(); cleanup(); }
-      };
-      const scrollHandler = () => { closeCtxMenu(); cleanup(); };
-      function cleanup() {
-        document.removeEventListener('mousedown', closeHandler);
-        document.removeEventListener('keydown', escHandler);
-        window.removeEventListener('scroll', scrollHandler, true);
-      }
-      setTimeout(() => {
-        document.addEventListener('mousedown', closeHandler);
-        document.addEventListener('keydown', escHandler);
-        window.addEventListener('scroll', scrollHandler, true);
-      }, 0);
-    }
-
-    // Expose globally so main.js can call it
-    window.__tandemShowTabContextMenu = showTabContextMenu;
 
     return { init, loadConfig, activateItem, toggleVisibility };
   })();

--- a/shell/js/sidebar/index.js
+++ b/shell/js/sidebar/index.js
@@ -279,10 +279,9 @@ import { moveTabToWorkspace } from './tab-context-menu.js';
       });
 
       document.getElementById('sidebar-tips').addEventListener('click', () => {
-        const webview = document.querySelector('webview.active');
-        if (webview) {
-          const shellPath = window.location.href.replace(/\/[^/]*$/, '');
-          webview.loadURL(shellPath + '/help.html');
+        const shellPath = window.location.href.replace(/\/[^/]*$/, '');
+        if (window.tandem && window.tandem.newTab) {
+          window.tandem.newTab(shellPath + '/help.html');
         }
       });
 

--- a/shell/js/sidebar/panels/workspaces.js
+++ b/shell/js/sidebar/panels/workspaces.js
@@ -1,0 +1,299 @@
+/**
+ * Sidebar workspaces panel — workspace list, create/edit/delete form, icon
+ * grid, and tab-bar filtering by active workspace.
+ *
+ * All workspace I/O talks to the localhost:8765 HTTP API. Workspace state is
+ * kept in config.js (getWorkspaces/setWorkspaces/getActiveWorkspaceId); this
+ * module is a view over that state plus the tab-bar filter side-effect.
+ *
+ * The sidebar's render() is needed here to refresh the workspace icon strip
+ * after mutations. Since panels/workspaces.js can't import from the index
+ * (circular), index.js injects its render() via setWorkspacesRender() during
+ * init(). Calls before init are no-ops, which is fine — nothing mutates
+ * workspaces before the DOM is ready.
+ *
+ * Loaded from: shell/js/sidebar/index.js
+ * window exports: none
+ */
+
+import { WORKSPACE_ICONS } from '../constants.js';
+import {
+  getToken,
+  getConfig,
+  setSetupPanelOpen,
+  getWorkspaces, setWorkspaces,
+  getActiveWorkspaceId, setActiveWorkspaceId,
+} from '../config.js';
+import { hideWebviews, safeSetPanelHTML } from '../webview.js';
+import { getPanelWidth, setPanelWidth } from '../panel-resize.js';
+
+// The sidebar panel id used when the workspaces panel is open. Not routed
+// through activateItem — index.js's click handler calls openWorkspacePanel
+// directly — but exported so callers have a stable reference.
+export const WORKSPACE_PANEL_ID = '__workspaces';
+
+// Injected by index.js during init() so the workspaces module can re-render
+// the sidebar icon strip after mutations without importing from index.
+let _render = () => {};
+export function setWorkspacesRender(fn) { _render = fn; }
+
+export function getIconSvg(slug) {
+  if (WORKSPACE_ICONS[slug]) return WORKSPACE_ICONS[slug];
+  // If the slug isn't a known icon name, render it directly (supports emoji icons)
+  if (slug && typeof slug === 'string' && slug.trim()) {
+    return `<span class="workspace-emoji-icon">${slug}</span>`;
+  }
+  return WORKSPACE_ICONS.home;
+}
+
+export async function loadWorkspaces() {
+  try {
+    const r = await fetch('http://localhost:8765/workspaces', { headers: { Authorization: `Bearer ${getToken()}` } });
+    const data = await r.json();
+    if (data.ok) {
+      setWorkspaces(data.workspaces);
+      setActiveWorkspaceId(data.activeId);
+      _render();
+      filterTabBar();
+    }
+  } catch (e) { /* workspace API not yet available during startup */ }
+}
+
+async function switchWorkspace(id) {
+  try {
+    const r = await fetch(`http://localhost:8765/workspaces/${id}/switch`, {
+      method: 'POST', headers: { Authorization: `Bearer ${getToken()}` }
+    });
+    const data = await r.json();
+    if (data.ok) {
+      setActiveWorkspaceId(data.workspace.id);
+      // Update the local workspace's tabIds
+      const ws = getWorkspaces().find(w => w.id === id);
+      if (ws) Object.assign(ws, data.workspace);
+      _render();
+      filterTabBar();
+    }
+  } catch (e) { console.error('switchWorkspace failed:', e); }
+}
+
+function getNextWorkspaceName() {
+  const existing = getWorkspaces().map(w => w.name);
+  let n = 1;
+  while (existing.includes(`Workspace ${n}`)) n++;
+  return `Workspace ${n}`;
+}
+
+function renderIconGrid(selectedIcon) {
+  const slugs = Object.keys(WORKSPACE_ICONS);
+  return slugs.map(slug => {
+    const isSelected = slug === selectedIcon;
+    return `<button class="ws-icon-grid-btn ${isSelected ? 'selected' : ''}" data-icon-slug="${slug}" title="${slug}">
+      <span class="ws-icon-grid-svg">${WORKSPACE_ICONS[slug]}</span>
+    </button>`;
+  }).join('');
+}
+
+function showWorkspaceForm(content, mode, existingWs) {
+  const isEdit = mode === 'edit';
+  const title = isEdit ? 'Edit workspace' : 'Create workspace';
+  const btnLabel = isEdit ? 'Save' : 'Create';
+  const defaultIcon = isEdit ? existingWs.icon : Object.keys(WORKSPACE_ICONS)[0];
+  const defaultName = isEdit ? existingWs.name : getNextWorkspaceName();
+
+  safeSetPanelHTML(`
+    <div class="ws-form-sheet">
+      <div class="ws-form-title">${title}</div>
+      <div class="ws-form-section-label">Icon</div>
+      <div class="ws-icon-grid" id="ws-icon-grid">${renderIconGrid(defaultIcon)}</div>
+      <div class="ws-form-section-label">Name</div>
+      <input type="text" class="ws-form-input" id="ws-form-name" value="${defaultName}" placeholder="${getNextWorkspaceName()}" />
+      <div class="ws-form-actions">
+        <button class="ws-form-btn-cancel" id="ws-form-cancel">Cancel</button>
+        <button class="ws-form-btn-primary" id="ws-form-submit">${btnLabel}</button>
+      </div>
+      ${isEdit ? `<button class="ws-form-btn-delete" id="ws-form-delete">Delete workspace</button>` : ''}
+      <div class="ws-form-delete-confirm" id="ws-form-delete-confirm" style="display:none;">
+        <span>Are you sure? Tabs will move to Default.</span>
+        <div class="ws-form-delete-confirm-actions">
+          <button class="ws-form-btn-cancel" id="ws-form-delete-no">No</button>
+          <button class="ws-form-btn-danger" id="ws-form-delete-yes">Yes, delete</button>
+        </div>
+      </div>
+    </div>`);
+
+  let selectedIcon = defaultIcon;
+
+  // Icon grid selection
+  content.querySelectorAll('.ws-icon-grid-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      content.querySelectorAll('.ws-icon-grid-btn').forEach(b => b.classList.remove('selected'));
+      btn.classList.add('selected');
+      selectedIcon = btn.dataset.iconSlug;
+    });
+  });
+
+  // Auto-focus name input
+  const nameInput = content.querySelector('#ws-form-name');
+  nameInput.focus();
+  nameInput.select();
+
+  // Cancel
+  content.querySelector('#ws-form-cancel').addEventListener('click', () => {
+    openWorkspacePanel();
+  });
+
+  // Submit
+  content.querySelector('#ws-form-submit').addEventListener('click', async () => {
+    const name = nameInput.value.trim();
+    if (!name) return;
+    try {
+      if (isEdit) {
+        const r = await fetch(`http://localhost:8765/workspaces/${existingWs.id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${getToken()}` },
+          body: JSON.stringify({ name, icon: selectedIcon })
+        });
+        const data = await r.json();
+        if (data.ok) {
+          const idx = getWorkspaces().findIndex(w => w.id === existingWs.id);
+          if (idx >= 0) getWorkspaces()[idx] = data.workspace;
+          _render();
+        }
+      } else {
+        const r = await fetch('http://localhost:8765/workspaces', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${getToken()}` },
+          body: JSON.stringify({ name, icon: selectedIcon })
+        });
+        const data = await r.json();
+        if (data.ok) {
+          getWorkspaces().push(data.workspace);
+          _render();
+        }
+      }
+    } catch (e) { console.error('workspace form submit failed:', e); }
+    openWorkspacePanel();
+  });
+
+  // Enter key on input submits
+  nameInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') content.querySelector('#ws-form-submit').click();
+    if (e.key === 'Escape') openWorkspacePanel();
+  });
+
+  // Delete (edit mode only)
+  if (isEdit) {
+    content.querySelector('#ws-form-delete').addEventListener('click', () => {
+      content.querySelector('#ws-form-delete').style.display = 'none';
+      content.querySelector('#ws-form-delete-confirm').style.display = '';
+    });
+    content.querySelector('#ws-form-delete-no').addEventListener('click', () => {
+      content.querySelector('#ws-form-delete-confirm').style.display = 'none';
+      content.querySelector('#ws-form-delete').style.display = '';
+    });
+    content.querySelector('#ws-form-delete-yes').addEventListener('click', async () => {
+      try {
+        await fetch(`http://localhost:8765/workspaces/${existingWs.id}`, {
+          method: 'DELETE', headers: { Authorization: `Bearer ${getToken()}` }
+        });
+        await loadWorkspaces();
+      } catch (e) { console.error('workspace delete failed:', e); }
+      openWorkspacePanel();
+    });
+  }
+}
+
+export function filterTabBar() {
+  // Find active workspace
+  const ws = getWorkspaces().find(w => w.id === getActiveWorkspaceId());
+  if (!ws) return;
+  const allowedTabIds = new Set(ws.tabIds);
+
+  // Get all tab elements from the tab bar
+  const tabEls = document.querySelectorAll('#tab-bar .tab[data-tab-id]');
+  const visibleTabIds = [];
+  tabEls.forEach(el => {
+    const tabId = el.dataset.tabId;
+    // Get webContentsId for this tab from the webview
+    const wv = document.querySelector(`webview[data-tab-id="${tabId}"]`);
+    if (!wv) return;
+    const wcId = wv.getWebContentsId ? wv.getWebContentsId() : null;
+    const visible = wcId !== null && allowedTabIds.has(wcId);
+    el.style.display = visible ? '' : 'none';
+    if (visible) {
+      visibleTabIds.push(tabId);
+    } else {
+      wv.classList.remove('active');
+    }
+  });
+
+  if (visibleTabIds.length === 0) return;
+
+  const activeWebview = document.querySelector('webview.active[data-tab-id]');
+  const activeTabId = activeWebview?.dataset?.tabId || null;
+  if (!activeTabId || !visibleTabIds.includes(activeTabId)) {
+    if (window.tandem) {
+      window.tandem.focusTab(visibleTabIds[0]);
+    }
+  }
+}
+
+export async function openWorkspacePanel() {
+  setSetupPanelOpen(false);
+  getConfig().activeItemId = WORKSPACE_PANEL_ID;
+  const panel = document.getElementById('sidebar-panel');
+  const titleEl = document.getElementById('sidebar-panel-title');
+  const content = document.getElementById('sidebar-panel-content');
+
+  titleEl.textContent = 'Workspaces';
+  panel.classList.add('open');
+  setPanelWidth(getPanelWidth(WORKSPACE_PANEL_ID));
+
+  // Hide webviews
+  hideWebviews();
+  content.classList.remove('webview-mode');
+
+  // Refresh workspace data
+  await loadWorkspaces();
+
+  const rows = getWorkspaces().map(ws => {
+    const isActive = ws.id === getActiveWorkspaceId();
+    return `
+      <div class="ws-panel-item ${isActive ? 'active' : ''}" data-ws-panel-id="${ws.id}">
+        <div class="ws-panel-icon-svg">${getIconSvg(ws.icon)}</div>
+        <span class="ws-panel-name">${ws.name}</span>
+        ${isActive ? '<span class="ws-panel-check">✓</span>' : ''}
+        ${!ws.isDefault ? `<button class="ws-panel-edit" data-ws-edit="${ws.id}" title="Edit">···</button>` : ''}
+      </div>`;
+  }).join('');
+
+  safeSetPanelHTML(`
+    <div class="ws-panel">
+      <button class="ws-panel-add" id="ws-panel-add-btn">+ Add workspace</button>
+      ${rows}
+    </div>`);
+
+  // Event handlers
+  content.querySelector('#ws-panel-add-btn')?.addEventListener('click', () => {
+    showWorkspaceForm(content, 'create', null);
+  });
+  content.querySelectorAll('.ws-panel-item').forEach(el => {
+    el.addEventListener('click', async (e) => {
+      if (e.target.closest('.ws-panel-edit')) return;
+      await switchWorkspace(el.dataset.wsPanelId);
+      await openWorkspacePanel();
+    });
+  });
+  content.querySelectorAll('.ws-panel-edit').forEach(btn => {
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const id = btn.dataset.wsEdit;
+      const ws = getWorkspaces().find(w => w.id === id);
+      if (ws) showWorkspaceForm(content, 'edit', ws);
+    });
+  });
+}
+
+// Exposed so index.js's click handler can invoke workspace switching from
+// the sidebar icon strip without going through openWorkspacePanel.
+export { switchWorkspace };

--- a/shell/js/sidebar/panels/workspaces.js
+++ b/shell/js/sidebar/panels/workspaces.js
@@ -106,7 +106,7 @@ function showWorkspaceForm(content, mode, existingWs) {
       <div class="ws-form-section-label">Icon</div>
       <div class="ws-icon-grid" id="ws-icon-grid">${renderIconGrid(defaultIcon)}</div>
       <div class="ws-form-section-label">Name</div>
-      <input type="text" class="ws-form-input" id="ws-form-name" value="${defaultName}" placeholder="${getNextWorkspaceName()}" />
+      <input type="text" class="ws-form-input" id="ws-form-name" placeholder="${getNextWorkspaceName()}" />
       <div class="ws-form-actions">
         <button class="ws-form-btn-cancel" id="ws-form-cancel">Cancel</button>
         <button class="ws-form-btn-primary" id="ws-form-submit">${btnLabel}</button>
@@ -134,6 +134,7 @@ function showWorkspaceForm(content, mode, existingWs) {
 
   // Auto-focus name input
   const nameInput = content.querySelector('#ws-form-name');
+  nameInput.value = defaultName;
   nameInput.focus();
   nameInput.select();
 

--- a/shell/js/sidebar/tab-context-menu.js
+++ b/shell/js/sidebar/tab-context-menu.js
@@ -206,7 +206,13 @@ export async function showTabContextMenu(domTabId, x, y) {
       const si = document.createElement('div');
       si.className = 'tandem-ctx-submenu-item';
       const icon = getIconSvg(ws.icon);
-      si.innerHTML = '<span class="ws-ctx-icon">' + icon + '</span><span>' + ws.name + '</span>';
+      const iconSpan = document.createElement('span');
+      iconSpan.className = 'ws-ctx-icon';
+      iconSpan.innerHTML = icon;
+      const nameSpan = document.createElement('span');
+      nameSpan.textContent = ws.name;
+      si.appendChild(iconSpan);
+      si.appendChild(nameSpan);
       si.addEventListener('click', () => {
         closeCtxMenu();
         moveTabToWorkspace(domTabId, ws.id);
@@ -239,7 +245,9 @@ export async function showTabContextMenu(domTabId, x, y) {
       pbBoards.forEach(board => {
         const si = document.createElement('div');
         si.className = 'tandem-ctx-submenu-item';
-        si.innerHTML = '<span>' + board.emoji + ' ' + board.name + '</span>';
+        const labelSpan = document.createElement('span');
+        labelSpan.textContent = board.emoji + ' ' + board.name;
+        si.appendChild(labelSpan);
         si.addEventListener('click', async () => {
           closeCtxMenu();
           const tabUrl = wv ? wv.src : '';

--- a/shell/js/sidebar/tab-context-menu.js
+++ b/shell/js/sidebar/tab-context-menu.js
@@ -1,0 +1,403 @@
+/**
+ * Tab context menu — custom DOM menu shown on right-click of a tab.
+ *
+ * Not a sidebar "panel" (it's a floating menu, not inside #sidebar-panel), so
+ * lives at the sidebar/ root alongside drag-drop.js rather than under panels/.
+ *
+ * Exposes window.__tandemShowTabContextMenu so main.js can trigger the menu
+ * in response to webContents context-menu events.
+ *
+ * Loaded from: shell/js/sidebar/index.js
+ * window exports: __tandemShowTabContextMenu
+ */
+
+import { getToken, getWorkspaces } from './config.js';
+import { getIconSvg, filterTabBar, loadWorkspaces } from './panels/workspaces.js';
+import { refreshPinboardIfOpen } from './panels/pinboard.js';
+
+let ctxMenuEl = null;
+
+async function loadQuickLinksConfig() {
+  const response = await fetch('http://localhost:8765/config', {
+    headers: { Authorization: `Bearer ${getToken()}` }
+  });
+  if (!response.ok) throw new Error('Failed to load quick links');
+  return response.json();
+}
+
+function isQuickLinkableUrl(url) {
+  return /^https?:\/\//i.test(url || '');
+}
+
+function normalizeQuickLinkUrl(url) {
+  const parsed = new URL(url);
+  parsed.hash = '';
+  return parsed.toString();
+}
+
+async function addQuickLink(url, label) {
+  const data = await loadQuickLinksConfig();
+  const normalizedUrl = normalizeQuickLinkUrl(url);
+  const quickLinks = (data.general?.quickLinks || []).filter((link) => {
+    try {
+      return normalizeQuickLinkUrl(link?.url) !== normalizedUrl;
+    } catch {
+      return true;
+    }
+  });
+  quickLinks.push({ label, url: normalizedUrl });
+  const response = await fetch('http://localhost:8765/config', {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${getToken()}`
+    },
+    body: JSON.stringify({ general: { quickLinks } })
+  });
+  if (!response.ok) throw new Error('Failed to save quick links');
+  return response.json();
+}
+
+async function removeQuickLink(url) {
+  const data = await loadQuickLinksConfig();
+  const normalizedUrl = normalizeQuickLinkUrl(url);
+  const quickLinks = (data.general?.quickLinks || []).filter((link) => {
+    try {
+      return normalizeQuickLinkUrl(link?.url) !== normalizedUrl;
+    } catch {
+      return true;
+    }
+  });
+  const response = await fetch('http://localhost:8765/config', {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${getToken()}`
+    },
+    body: JSON.stringify({ general: { quickLinks } })
+  });
+  if (!response.ok) throw new Error('Failed to save quick links');
+  return response.json();
+}
+
+function getWebContentsIdForTab(domTabId) {
+  const wv = document.querySelector(`webview[data-tab-id="${domTabId}"]`);
+  return wv && wv.getWebContentsId ? wv.getWebContentsId() : null;
+}
+
+function getTabWorkspaceId(domTabId) {
+  const wcId = getWebContentsIdForTab(domTabId);
+  if (wcId === null) return null;
+  const ws = getWorkspaces().find(w => w.tabIds && w.tabIds.includes(wcId));
+  return ws ? ws.id : null;
+}
+
+export async function moveTabToWorkspace(domTabId, targetWsId) {
+  const wcId = getWebContentsIdForTab(domTabId);
+  if (wcId === null) return;
+  try {
+    await fetch(`http://localhost:8765/workspaces/${targetWsId}/move-tab`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${getToken()}` },
+      body: JSON.stringify({ tabId: wcId })
+    });
+    await loadWorkspaces();
+    filterTabBar();
+    const ws = getWorkspaces().find(w => w.id === targetWsId);
+    console.log(`Tab moved to workspace ${ws ? ws.name : targetWsId}`);
+  } catch (e) { console.error('moveTabToWorkspace failed:', e); }
+}
+
+function closeCtxMenu() {
+  if (ctxMenuEl) { ctxMenuEl.remove(); ctxMenuEl = null; }
+}
+
+export async function showTabContextMenu(domTabId, x, y) {
+  closeCtxMenu();
+
+  const wv = document.querySelector('webview[data-tab-id="'+domTabId+'"]');
+  const isMuted = wv ? wv.audioMuted : false;
+  const currentWsId = getTabWorkspaceId(domTabId);
+  const targets = getWorkspaces().filter(ws => ws.id !== currentWsId);
+
+  // Pre-fetch pinboards (fast — same-machine API call)
+  let pbBoards = [];
+  try {
+    const pbRes = await fetch('http://localhost:8765/pinboards', { headers: { Authorization: `Bearer ${getToken()}` } });
+    const pbData = await pbRes.json();
+    pbBoards = pbData.boards || [];
+  } catch { /* Tandem not running or no boards */ }
+
+  const menu = document.createElement('div');
+  menu.className = 'tandem-ctx-menu';
+  menu.style.left = x + 'px';
+  menu.style.top = y + 'px';
+
+  function addItem(label, onClick) {
+    const item = document.createElement('div');
+    item.className = 'tandem-ctx-menu-item';
+    item.textContent = label;
+    item.addEventListener('click', () => { closeCtxMenu(); onClick(item); });
+    menu.appendChild(item);
+    return item;
+  }
+
+  function addSep() {
+    const sep = document.createElement('div');
+    sep.className = 'tandem-ctx-separator';
+    menu.appendChild(sep);
+  }
+
+  // — New Tab
+  addItem('New Tab', () => { window.tandem.newTab(); });
+
+  addSep();
+
+  // — Reload
+  addItem('Reload', () => { if (wv) wv.reload(); });
+
+  // — Duplicate Tab
+  addItem('Duplicate Tab', () => { if (wv) window.tandem.newTab(wv.src); });
+
+  // — Copy Page Address
+  addItem('Copy Page Address', (itemEl) => {
+    if (wv) {
+      navigator.clipboard.writeText(wv.src);
+      itemEl.textContent = 'Copied!';
+      setTimeout(() => { itemEl.textContent = 'Copy Page Address'; }, 1000);
+    }
+  });
+
+  if (wv && isQuickLinkableUrl(wv.src)) {
+    const quickLinksData = await loadQuickLinksConfig().catch(() => null);
+    const currentQuickLinks = quickLinksData?.general?.quickLinks || [];
+    const currentUrl = normalizeQuickLinkUrl(wv.src);
+    const alreadyQuickLink = currentQuickLinks.some((link) => {
+      try {
+        return normalizeQuickLinkUrl(link?.url) === currentUrl;
+      } catch {
+        return false;
+      }
+    });
+    addItem(alreadyQuickLink ? 'Remove from Quick Links' : 'Add to Quick Links', async () => {
+      try {
+        if (alreadyQuickLink) {
+          await removeQuickLink(currentUrl);
+        } else {
+          await addQuickLink(currentUrl, wv.getTitle() || currentUrl);
+        }
+      } catch {
+        // Ignore save failures for now; the menu just closes.
+      }
+    });
+  }
+
+  addSep();
+
+  // — Move to Workspace (submenu)
+  if (targets.length > 0) {
+    const wsItem = document.createElement('div');
+    wsItem.className = 'tandem-ctx-menu-item';
+    wsItem.innerHTML = '<span>Move to Workspace</span><span class="ctx-arrow">▶</span>';
+
+    const sub = document.createElement('div');
+    sub.className = 'tandem-ctx-submenu';
+    targets.forEach(ws => {
+      const si = document.createElement('div');
+      si.className = 'tandem-ctx-submenu-item';
+      const icon = getIconSvg(ws.icon);
+      si.innerHTML = '<span class="ws-ctx-icon">' + icon + '</span><span>' + ws.name + '</span>';
+      si.addEventListener('click', () => {
+        closeCtxMenu();
+        moveTabToWorkspace(domTabId, ws.id);
+      });
+      sub.appendChild(si);
+    });
+    wsItem.appendChild(sub);
+    menu.appendChild(wsItem);
+
+    addSep();
+  }
+
+  // — Add to Pinboard (submenu)
+  {
+    const pbItem = document.createElement('div');
+    pbItem.className = 'tandem-ctx-menu-item';
+    pbItem.innerHTML = '<span>📌 Add to Pinboard</span><span class="ctx-arrow">▶</span>';
+
+    const pbSub = document.createElement('div');
+    pbSub.className = 'tandem-ctx-submenu';
+
+    if (pbBoards.length === 0) {
+      const empty = document.createElement('div');
+      empty.className = 'tandem-ctx-submenu-item';
+      empty.style.opacity = '0.5';
+      empty.style.cursor = 'default';
+      empty.textContent = 'No boards yet';
+      pbSub.appendChild(empty);
+    } else {
+      pbBoards.forEach(board => {
+        const si = document.createElement('div');
+        si.className = 'tandem-ctx-submenu-item';
+        si.innerHTML = '<span>' + board.emoji + ' ' + board.name + '</span>';
+        si.addEventListener('click', async () => {
+          closeCtxMenu();
+          const tabUrl = wv ? wv.src : '';
+          const tabTitle = wv ? wv.getTitle() : '';
+          await fetch('http://localhost:8765/pinboards/' + board.id + '/items', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${getToken()}` },
+            body: JSON.stringify({ type: 'link', url: tabUrl, title: tabTitle })
+          });
+          // Visual flash feedback on the tab
+          const tabEl = document.querySelector('.tab[data-tab-id="' + domTabId + '"]');
+          if (tabEl) {
+            tabEl.classList.add('pin-flash');
+            setTimeout(() => tabEl.classList.remove('pin-flash'), 700);
+          }
+          // Refresh board if it's currently open (no-op otherwise).
+          refreshPinboardIfOpen(board.id);
+        });
+        pbSub.appendChild(si);
+      });
+    }
+
+    pbItem.appendChild(pbSub);
+    menu.appendChild(pbItem);
+    addSep();
+  }
+
+  // — Mute / Unmute Tab
+  addItem(isMuted ? 'Unmute Tab' : 'Mute Tab', () => {
+    if (wv) wv.audioMuted = !isMuted;
+  });
+
+  // — Set Emoji (submenu)
+  {
+    const emojiItem = document.createElement('div');
+    emojiItem.className = 'tandem-ctx-menu-item';
+    const tabEl = document.querySelector('.tab[data-tab-id="' + domTabId + '"]');
+    const tabEmojiSpan = tabEl ? tabEl.querySelector('.tab-emoji') : null;
+    const currentEmoji = (tabEmojiSpan && tabEmojiSpan.style.display !== 'none') ? tabEmojiSpan.textContent : '';
+    const emojiLabel = document.createElement('span');
+    emojiLabel.textContent = currentEmoji ? ('Emoji: ' + currentEmoji) : 'Set Emoji...';
+    const emojiArrow = document.createElement('span');
+    emojiArrow.className = 'ctx-arrow';
+    emojiArrow.textContent = '▶';
+    emojiItem.appendChild(emojiLabel);
+    emojiItem.appendChild(emojiArrow);
+
+    const emojiSub = document.createElement('div');
+    emojiSub.className = 'tandem-ctx-submenu tandem-emoji-grid';
+
+    if (currentEmoji) {
+      const removeItem = document.createElement('div');
+      removeItem.className = 'tandem-ctx-submenu-item';
+      removeItem.textContent = 'Remove Emoji';
+      removeItem.addEventListener('click', async () => {
+        closeCtxMenu();
+        await fetch('http://localhost:8765/tabs/' + encodeURIComponent(domTabId) + '/emoji', {
+          method: 'DELETE',
+          headers: { Authorization: 'Bearer ' + getToken() }
+        });
+      });
+      emojiSub.appendChild(removeItem);
+      const sep = document.createElement('div');
+      sep.className = 'tandem-ctx-separator';
+      emojiSub.appendChild(sep);
+    }
+
+    const emojis = [
+      '🔥','⭐','💡','🚀','✅','❌','⚠️','🎯','💬','📌',
+      '📚','🧪','🔧','🎨','📊','🔒','👀','💰','🎵','❤️',
+      '🏠','📧','🛒','📝','🗂️','🌍','☁️','📸','🎮','🤖',
+      '🧠','🔍','📅','🎁','🏷️','⏰','🔔','💻','📱','🎬',
+      '🍕','☕','🌟','💎','🦊','🐛','🏗️','📦','🔗','🏆',
+    ];
+    const grid = document.createElement('div');
+    grid.className = 'tandem-emoji-picker';
+    emojis.forEach(emoji => {
+      const btn = document.createElement('span');
+      btn.className = 'tandem-emoji-btn';
+      btn.textContent = emoji;
+      btn.addEventListener('click', async () => {
+        closeCtxMenu();
+        await fetch('http://localhost:8765/tabs/' + encodeURIComponent(domTabId) + '/emoji', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: 'Bearer ' + getToken() },
+          body: JSON.stringify({ emoji: emoji })
+        });
+      });
+      grid.appendChild(btn);
+    });
+    emojiSub.appendChild(grid);
+
+    emojiItem.appendChild(emojiSub);
+    menu.appendChild(emojiItem);
+  }
+
+  addSep();
+
+  // — Close Tab
+  addItem('Close Tab', () => { window.tandem.closeTab(domTabId); });
+
+  // — Close Other Tabs
+  addItem('Close Other Tabs', () => {
+    const allTabs = document.querySelectorAll('#tab-bar .tab[data-tab-id]');
+    allTabs.forEach(t => {
+      const tid = t.dataset.tabId;
+      if (tid && tid !== domTabId) window.tandem.closeTab(tid);
+    });
+  });
+
+  // — Close Tabs to the Right
+  addItem('Close Tabs to the Right', () => {
+    const allTabs = Array.from(document.querySelectorAll('#tab-bar .tab[data-tab-id]'));
+    const idx = allTabs.findIndex(t => t.dataset.tabId === domTabId);
+    if (idx >= 0) {
+      for (let i = idx + 1; i < allTabs.length; i++) {
+        const tid = allTabs[i].dataset.tabId;
+        if (tid) window.tandem.closeTab(tid);
+      }
+    }
+  });
+
+  document.body.appendChild(menu);
+  ctxMenuEl = menu;
+
+  // Auto-flip if menu extends beyond viewport
+  const rect = menu.getBoundingClientRect();
+  if (rect.right > window.innerWidth) menu.style.left = Math.max(0, window.innerWidth - rect.width - 8) + 'px';
+  if (rect.bottom > window.innerHeight) menu.style.top = Math.max(0, window.innerHeight - rect.height - 8) + 'px';
+
+  // Flip submenu left if near right edge
+  requestAnimationFrame(() => {
+    const menuRight = menu.getBoundingClientRect().right;
+    if (menuRight + 180 > window.innerWidth) {
+      const subs = menu.querySelectorAll('.tandem-ctx-submenu');
+      subs.forEach(s => s.classList.add('flip-left'));
+    }
+  });
+
+  // Close on click outside, Escape, scroll
+  const closeHandler = (e) => {
+    if (ctxMenuEl && !ctxMenuEl.contains(e.target)) { closeCtxMenu(); cleanup(); }
+  };
+  const escHandler = (e) => {
+    if (e.key === 'Escape') { closeCtxMenu(); cleanup(); }
+  };
+  const scrollHandler = () => { closeCtxMenu(); cleanup(); };
+  function cleanup() {
+    document.removeEventListener('mousedown', closeHandler);
+    document.removeEventListener('keydown', escHandler);
+    window.removeEventListener('scroll', scrollHandler, true);
+  }
+  setTimeout(() => {
+    document.addEventListener('mousedown', closeHandler);
+    document.addEventListener('keydown', escHandler);
+    window.addEventListener('scroll', scrollHandler, true);
+  }, 0);
+}
+
+// Expose globally so main.js can call it
+window.__tandemShowTabContextMenu = showTabContextMenu;

--- a/src/workspaces/manager.ts
+++ b/src/workspaces/manager.ts
@@ -63,6 +63,15 @@ export class WorkspaceManager {
   private activeTabIdResolver: (() => number | null) | null = null;
   private isReconciling = false;
   private selectionPinned = false;
+  /**
+   * Tabs assigned via assignTab() that have not yet been observed in the
+   * runtime's tracked tab list. Reconcile refuses to strip these so we don't
+   * lose newly-assigned tabs to the race between web-contents-created (when
+   * main.ts calls assignTab) and TabManager.tabs.set() (when openTab
+   * finishes). Cleared lazily when the tab appears in validTabIds, or on
+   * explicit removeTab()/resetTabAssignments().
+   */
+  private pendingAssignments = new Set<number>();
 
   // === 2. Constructor ===
 
@@ -157,10 +166,16 @@ export class WorkspaceManager {
       for (const workspace of this.getSortedWorkspaces()) {
         const nextTabIds: number[] = [];
         for (const tabId of workspace.tabIds) {
-          if (!Number.isFinite(tabId) || !validTabIds.has(tabId) || assignedTabIds.has(tabId)) {
+          if (!Number.isFinite(tabId) || assignedTabIds.has(tabId)) {
             changed = true;
             continue;
           }
+          const isTracked = validTabIds.has(tabId);
+          if (!isTracked && !this.pendingAssignments.has(tabId)) {
+            changed = true;
+            continue;
+          }
+          if (isTracked) this.pendingAssignments.delete(tabId);
           assignedTabIds.add(tabId);
           nextTabIds.push(tabId);
         }
@@ -309,6 +324,7 @@ export class WorkspaceManager {
 
   /** Assign a tab (by webContentsId) to the currently active workspace. */
   assignTab(tabId: number): void {
+    this.pendingAssignments.add(tabId);
     const active = this.getActive();
     for (const workspace of this.workspaces.values()) {
       const idx = workspace.tabIds.indexOf(tabId);
@@ -324,6 +340,7 @@ export class WorkspaceManager {
 
   /** Remove a tab from whichever workspace it belongs to. */
   removeTab(tabId: number): void {
+    this.pendingAssignments.delete(tabId);
     for (const ws of this.workspaces.values()) {
       const idx = ws.tabIds.indexOf(tabId);
       if (idx !== -1) {
@@ -359,6 +376,7 @@ export class WorkspaceManager {
 
   /** Clear all tab assignments from every workspace. */
   resetTabAssignments(): void {
+    this.pendingAssignments.clear();
     for (const workspace of this.workspaces.values()) {
       workspace.tabIds = [];
     }

--- a/src/workspaces/tests/workspaces.test.ts
+++ b/src/workspaces/tests/workspaces.test.ts
@@ -208,6 +208,50 @@ describe('WorkspaceManager', () => {
       expect(defaultWs.tabIds).not.toContain(42);
       expect(ws2.tabIds).toContain(42);
     });
+
+    // Repro for the "+ new tab goes to Default instead of active workspace" bug.
+    // Simulates the real-world flow: sidebar click activates a workspace with
+    // tabs by calling focusTab() (without switch(), per activateWorkspace
+    // route), then the user clicks + which creates a new tab. At
+    // web-contents-created time the new webContentsId is NOT yet tracked by
+    // TabManager, so trackedTabIdsResolver() does not include it. The active
+    // tab at that moment is the one that belongs to the just-activated
+    // workspace. The new tab should land in that workspace.
+    it('assigns + new tab to the workspace of the currently-focused tab (regression)', () => {
+      const wm = createManager();
+      const kees = wm.create({ name: 'kees-openclaw' });
+      const defaultWs = wm.list().find(w => w.isDefault)!;
+
+      // Existing tabs: one in default (wcId 100), one in kees (wcId 200).
+      const workspaces = (wm as any).workspaces as Map<string, { tabIds: number[] }>;
+      workspaces.get(defaultWs.id)!.tabIds = [100];
+      workspaces.get(kees.id)!.tabIds = [200];
+
+      // Tracked/active state reflects "user currently viewing tab 200 in kees".
+      let tracked: number[] = [100, 200];
+      let activeWcId: number | null = 200;
+      wm.setTabStateResolvers({
+        listTrackedTabIds: () => tracked,
+        getActiveTabId: () => activeWcId,
+      });
+
+      // Sidebar "switch workspace" click on kees: the activateWorkspace route
+      // focuses a tab in kees and runs the activeTabChangedHandler reconcile
+      // with followFocusedTab:true. It does NOT call switch() because kees
+      // already has tabs to focus.
+      wm.reconcileTabState(tracked, activeWcId, { notify: true, followFocusedTab: true });
+      expect(wm.getActiveId()).toBe(kees.id);
+      expect(wm.getActiveSource()).toBe('focused-tab');
+
+      // User clicks + -> web-contents-created fires in main BEFORE the new
+      // webContentsId is inserted into TabManager.tabs, so the resolvers
+      // still reflect the previous state.
+      wm.assignTab(300);
+
+      // The new tab should be in kees, not default.
+      expect(wm.get(kees.id)!.tabIds).toContain(300);
+      expect(wm.get(defaultWs.id)!.tabIds).not.toContain(300);
+    });
   });
 
   describe('removeTab', () => {

--- a/src/workspaces/tests/workspaces.test.ts
+++ b/src/workspaces/tests/workspaces.test.ts
@@ -228,8 +228,8 @@ describe('WorkspaceManager', () => {
       workspaces.get(kees.id)!.tabIds = [200];
 
       // Tracked/active state reflects "user currently viewing tab 200 in kees".
-      let tracked: number[] = [100, 200];
-      let activeWcId: number | null = 200;
+      const tracked: number[] = [100, 200];
+      const activeWcId: number | null = 200;
       wm.setTabStateResolvers({
         listTrackedTabIds: () => tracked,
         getActiveTabId: () => activeWcId,


### PR DESCRIPTION
## Summary

Final sidebar extraction — moves workspaces code and the tab right-click menu out of `shell/js/sidebar/index.js` into two new ES modules. `index.js` drops from 956 → 332 LOC, closing out the 12-step sidebar ESM-split refactor.

- `shell/js/sidebar/panels/workspaces.js` (new) — workspace CRUD, icon grid, form, tab-bar filtering, panel entry-point
- `shell/js/sidebar/tab-context-menu.js` (new, sibling to `panels/` — it's a floating menu, not a panel) — full tab right-click menu incl. Move to Workspace + Add to Pinboard submenus, quick-link helpers
- `sidebar/index.js` keeps only orchestration: imports, render, activateItem routing, init()
- A `setWorkspacesRender(render)` one-time dependency-injection hook in `workspaces.js` breaks the circular dep (workspaces' mutations re-trigger `render()` from `index.js`) without changing behavior

### Fixed along the way — 3 pre-existing XSS sinks

Same class as the pinboard XSS fixed in #154 — API-sourced `ws.name`, `board.name`, `board.emoji` and workspace edit-form `value` attribute were concatenated into `innerHTML`. They existed in the old `sidebar/index.js` and would have silently carried over, so I patched them in this PR rather than ship a known vulnerability. Commit `9caa788e`.

## Test plan
- [x] CI green
- [x] Right-click a tab → Move to Workspace submenu shows workspaces, clicking moves the tab, webview context filters correctly
- [x] Right-click a tab → Add to Pinboard submenu lists boards, clicking adds a link item and refreshes an open pinboard
- [x] Workspace panel opens from icon strip, create/rename/delete flows work, icon grid selection works
- [x] Switching workspace via icon strip filters the tab bar and keeps the active tab visible
- [x] Drag-and-drop a tab onto a workspace icon moves it (exercises imported `moveTabToWorkspace`)
- [x] Onboarding / pin / reload sidebar paths still function (no behavior change intended)

## Scope note

Pure structural refactor + 3 co-located XSS fixes. No new features, no new tests (matches prior sidebar extraction PRs — the codebase has no shell JS test harness yet).