### PR TITLE
fix(tabs): keep user in current workspace after closing active tab

### DIFF
--- a/src/tabs/manager.ts
+++ b/src/tabs/manager.ts
@@ -274,14 +274,23 @@ export class TabManager {
       log.warn(`removeTab IPC failed for ${tabId}:`, e instanceof Error ? e.message : String(e));
     }
 
+    // Capture the closed tab's workspace BEFORE deleting it from the map so
+    // the successor-picking below can prefer a tab in the same workspace.
+    // Without this, closing the last new tab in the current workspace would
+    // pick whichever tab happens to sit at the end of insertion order —
+    // often from a different workspace — and the activeTabChanged reconcile
+    // would then drag activeId along with it (see reconcileTabState's
+    // followFocusedTab path in WorkspaceManager).
+    const closedWorkspaceId = this.workspaceIdResolver?.(tab.webContentsId) ?? null;
+
     this.tabs.delete(tabId);
 
     // If we closed the active tab, focus another
     if (this.activeTabId === tabId) {
       this.activeTabId = null;
-      const remaining = Array.from(this.tabs.keys());
-      if (remaining.length > 0) {
-        await this.focusTab(remaining[remaining.length - 1]);
+      const successor = this.pickCloseSuccessor(closedWorkspaceId);
+      if (successor) {
+        await this.focusTab(successor.id);
       } else {
         await this.notifyActiveTabChanged(null);
       }
@@ -568,6 +577,34 @@ export class TabManager {
   /** Generate unique tab ID */
   private nextId(): string {
     return `tab-${++this.counter}`;
+  }
+
+  /**
+   * Pick the next tab to focus after closing the active tab.
+   *
+   * Prefers a tab in the same workspace as the closed tab so closing a new
+   * tab doesn't silently move the user to another workspace (the
+   * activeTabChanged reconcile runs followFocusedTab, which would otherwise
+   * switch activeId to whichever workspace the successor belongs to).
+   *
+   * If the closed tab's workspace is unknown or empty, fall back to the
+   * most-recently-inserted remaining tab from any workspace so the user
+   * isn't left on a blank screen.
+   */
+  private pickCloseSuccessor(closedWorkspaceId: string | null): Tab | null {
+    const remaining = Array.from(this.tabs.values());
+    if (remaining.length === 0) return null;
+
+    if (closedWorkspaceId && this.workspaceIdResolver) {
+      const sameWorkspace = remaining.filter(
+        (t) => this.workspaceIdResolver?.(t.webContentsId) === closedWorkspaceId,
+      );
+      if (sameWorkspace.length > 0) {
+        return sameWorkspace[sameWorkspace.length - 1];
+      }
+    }
+
+    return remaining[remaining.length - 1];
   }
 
   private resolveInheritedTab(options?: OpenTabOptions): Tab | null {

--- a/src/tabs/tests/tabs.test.ts
+++ b/src/tabs/tests/tabs.test.ts
@@ -210,6 +210,44 @@ describe('TabManager', () => {
       expect(tm.getActiveTab()?.id).toBe(t1.id);
     });
 
+    // Repro for "closing a new tab jumps me to another workspace". When the
+    // active tab closes, closeTab picks a successor. Without workspace
+    // awareness it picks the most recently inserted of ALL tabs, which may
+    // belong to a different workspace than the one the user was viewing.
+    // The reconcile that follows then drags activeId along with the focus.
+    it('prefers a tab in the same workspace as the closed tab when choosing the next focus', async () => {
+      const tabA = await tm.openTab('https://default-a.com');     // default ws
+      const tabKees = await tm.openTab('https://kees.com');       // kees ws
+      const tabNew = await tm.openTab('https://default-new.com'); // default ws, now active
+
+      // Workspace membership: default = [A, New], kees = [Kees]
+      tm.setWorkspaceIdResolver((wcId) => {
+        if (wcId === tabKees.webContentsId) return 'kees';
+        return 'default';
+      });
+
+      await tm.closeTab(tabNew.id);
+
+      // Should stay in default by focusing tabA, not jump to kees.
+      expect(tm.getActiveTab()?.id).toBe(tabA.id);
+    });
+
+    it('falls back to any remaining tab when the closed tab was the last in its workspace', async () => {
+      const tabKees = await tm.openTab('https://kees.com');
+      const tabDefault = await tm.openTab('https://default.com'); // active
+
+      tm.setWorkspaceIdResolver((wcId) => {
+        if (wcId === tabKees.webContentsId) return 'kees';
+        return 'default';
+      });
+
+      await tm.closeTab(tabDefault.id);
+
+      // Default is empty after closing tabDefault — falling back to kees is
+      // fine (user has no other choice).
+      expect(tm.getActiveTab()?.id).toBe(tabKees.id);
+    });
+
     it('caps closed tabs history at 10', async () => {
       for (let i = 0; i < 12; i++) {
         const tab = await tm.openTab(`https://site${i}.com`);


### PR DESCRIPTION
## Summary

Closing a freshly-opened tab in the Default workspace silently teleported the user to another workspace. Reproduction: be in Default, click `+`, then close that new tab — you end up in whichever workspace had the most recently inserted tab.

## Root cause

`closeTab()` in `src/tabs/manager.ts:282` picks the successor from the full `this.tabs` map using insertion order (`remaining[remaining.length - 1]`). No workspace filtering. If any tab in another workspace happens to sit at the end of that order, it becomes focused. The `activeTabChangedHandler` then runs reconcile with `followFocusedTab:true`, which switches `activeId` to the successor's workspace.

## Fix

Prefer a tab in the **same workspace** as the closed tab when picking the successor. Fall back to the most-recently-inserted remaining tab only when the closed workspace is empty (user has no other choice). Uses the existing `workspaceIdResolver` already wired by `bootstrap/runtime.ts:236` — no new cross-module dependencies.

Extracted the successor pick into a small `pickCloseSuccessor(closedWorkspaceId)` helper so it can be unit-tested in isolation and documented.

## Test plan

- [x] Added regression test: closing a Default tab with a tab in another workspace keeps focus on Default's remaining tab
- [x] Added fallback test: closing the last Default tab falls through to the other workspace's tab (no blank screen)
- [x] All 2555 existing tests pass
- [x] Lint + check-consistency clean
- [x] Manual verify in running Tandem: Default + kees workspace, `+` in Default, close new tab → still in Default