### PR TITLE
fix(theme): pre-paint injection + consolidation (no more startup flash)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "electron-builder": "^26.0.0",
         "esbuild": "^0.28.0",
         "eslint": "^10.0.3",
+        "jsdom": "^29.0.2",
         "supertest": "^7.2.2",
         "typescript": "^5.6.0",
         "typescript-eslint": "^8.56.1",
@@ -43,6 +44,57 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.10.tgz",
+      "integrity": "sha512-KyOb19eytNSELkmdqzZZUXWCU25byIlOld5qVFg0RYdS0T3tt7jeDByxk9hIAC73frclD8GKrHttr0SUjKCCdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
@@ -102,6 +154,159 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@derhuerst/http-basic": {
@@ -1201,6 +1406,24 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@hono/node-server": {
@@ -3492,6 +3715,16 @@
         "node": "20.x || 22.x || 23.x || 24.x || 25.x"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -4197,6 +4430,34 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -4213,6 +4474,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -4804,6 +5072,19 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -5980,6 +6261,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -6227,6 +6521,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -6375,6 +6676,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/json-buffer": {
@@ -6908,6 +7260,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -7551,6 +7910,19 @@
       "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
       "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -8192,6 +8564,19 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -8767,6 +9152,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tar": {
       "version": "7.5.11",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
@@ -8956,6 +9348,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmp": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
@@ -8983,6 +9395,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/truncate-utf8-bytes": {
@@ -9119,6 +9557,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -9397,6 +9845,19 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
@@ -9405,6 +9866,41 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -9513,6 +10009,16 @@
         }
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
@@ -9522,6 +10028,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "electron-builder": "^26.0.0",
     "esbuild": "^0.28.0",
     "eslint": "^10.0.3",
+    "jsdom": "^29.0.2",
     "supertest": "^7.2.2",
     "typescript": "^5.6.0",
     "typescript-eslint": "^8.56.1",

--- a/shell/about.html
+++ b/shell/about.html
@@ -1,6 +1,27 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- Pre-paint theme stamp for webview-loaded shell pages.
+       The main BrowserWindow gets the theme via preload+additionalArguments,
+       but webviews don't inherit that path — so we do a tiny sync XHR here to
+       stamp data-theme before the inline <style> blocks are processed by the
+       parser. Sync XHR is deprecated (console warning), but it's the only way
+       to avoid a dark→light flash. Fails silently if the API isn't up. -->
+  <script>
+    (function () {
+      try {
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', 'http://localhost:8765/config', false);
+        xhr.send();
+        if (xhr.status === 200) {
+          var cfg = JSON.parse(xhr.responseText);
+          var theme = (cfg && cfg.appearance && cfg.appearance.theme) || 'dark';
+          if (theme === 'light') document.documentElement.setAttribute('data-theme', 'light');
+          else if (theme === 'system') document.documentElement.setAttribute('data-theme', 'system');
+        }
+      } catch (e) { /* API not ready; theme.js will apply on load */ }
+    })();
+  </script>
   <meta charset="UTF-8">
   <title>About Tandem</title>
   <script type="module" src="js/theme.js"></script>

--- a/shell/about.html
+++ b/shell/about.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>About Tandem</title>
-  <script src="js/theme.js"></script>
+  <script type="module" src="js/theme.js"></script>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html {

--- a/shell/about.html
+++ b/shell/about.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>About Tandem</title>
+  <script src="js/theme.js"></script>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     html {

--- a/shell/bookmarks.html
+++ b/shell/bookmarks.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Bookmarks</title>
-  <script src="js/theme.js"></script>
+  <script type="module" src="js/theme.js"></script>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
 

--- a/shell/bookmarks.html
+++ b/shell/bookmarks.html
@@ -1,6 +1,27 @@
 <!DOCTYPE html>
 <html lang="nl">
 <head>
+  <!-- Pre-paint theme stamp for webview-loaded shell pages.
+       The main BrowserWindow gets the theme via preload+additionalArguments,
+       but webviews don't inherit that path — so we do a tiny sync XHR here to
+       stamp data-theme before the inline <style> blocks are processed by the
+       parser. Sync XHR is deprecated (console warning), but it's the only way
+       to avoid a dark→light flash. Fails silently if the API isn't up. -->
+  <script>
+    (function () {
+      try {
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', 'http://localhost:8765/config', false);
+        xhr.send();
+        if (xhr.status === 200) {
+          var cfg = JSON.parse(xhr.responseText);
+          var theme = (cfg && cfg.appearance && cfg.appearance.theme) || 'dark';
+          if (theme === 'light') document.documentElement.setAttribute('data-theme', 'light');
+          else if (theme === 'system') document.documentElement.setAttribute('data-theme', 'system');
+        }
+      } catch (e) { /* API not ready; theme.js will apply on load */ }
+    })();
+  </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Bookmarks</title>

--- a/shell/bookmarks.html
+++ b/shell/bookmarks.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Bookmarks</title>
+  <script src="js/theme.js"></script>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
 
@@ -747,19 +748,7 @@
     fetchBookmarks();
     renderBreadcrumb();
 
-    // Theme sync
-    function applyTheme(theme) {
-      if (theme === 'light') document.documentElement.setAttribute('data-theme', 'light');
-      else if (theme === 'system') document.documentElement.setAttribute('data-theme', 'system');
-      else document.documentElement.removeAttribute('data-theme');
-    }
-    fetch('http://localhost:8765/config').then(r => r.json()).then(c => {
-      applyTheme(c.appearance?.theme || c.theme || 'dark');
-    }).catch(() => {});
-    try {
-      const bc = new BroadcastChannel('tandem-theme');
-      bc.onmessage = (e) => { if (e.data?.theme) applyTheme(e.data.theme); };
-    } catch {}
+    // Theme sync is handled by shell/js/theme.js (loaded in <head>).
   </script>
 </body>
 </html>

--- a/shell/css/browser-shell.css
+++ b/shell/css/browser-shell.css
@@ -95,26 +95,6 @@
       --hover-bg-subtle: rgba(255, 255, 255, 0.07);
     }
 
-    /* LGL Dark Mode Tokens */
-    [data-theme="dark"],
-    @media (prefers-color-scheme: dark) {
-      :root {
-        --lgl-tint-dark: rgba(30, 30, 30, 0.55);
-        --lgl-tint: var(--lgl-tint-dark);
-        --lgl-solid-bg: rgba(30, 30, 30, 0.95);
-        --lgl-text-primary: rgba(255, 255, 255, 0.9);
-        --lgl-text-secondary: rgba(255, 255, 255, 0.6);
-        --lgl-text-tertiary: rgba(255, 255, 255, 0.4);
-        --lgl-border: rgba(255, 255, 255, 0.1);
-        --lgl-border-subtle: rgba(255, 255, 255, 0.05);
-        --lgl-contrast-border: rgba(255, 255, 255, 0.2);
-        --lgl-edge-color: rgba(255, 255, 255, 0.10);
-        --lgl-focus-ring: rgba(10, 132, 255, 0.6);
-        --lgl-shadow-opacity: 0.18;
-        --lgl-shadow-opacity-text: 0.25;
-      }
-    }
-
     /* Light theme */
     [data-theme="light"] {
       --bg: #f8fafc;

--- a/shell/help.html
+++ b/shell/help.html
@@ -1,6 +1,27 @@
 <!DOCTYPE html>
 <html lang="nl">
 <head>
+  <!-- Pre-paint theme stamp for webview-loaded shell pages.
+       The main BrowserWindow gets the theme via preload+additionalArguments,
+       but webviews don't inherit that path — so we do a tiny sync XHR here to
+       stamp data-theme before the inline <style> blocks are processed by the
+       parser. Sync XHR is deprecated (console warning), but it's the only way
+       to avoid a dark→light flash. Fails silently if the API isn't up. -->
+  <script>
+    (function () {
+      try {
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', 'http://localhost:8765/config', false);
+        xhr.send();
+        if (xhr.status === 200) {
+          var cfg = JSON.parse(xhr.responseText);
+          var theme = (cfg && cfg.appearance && cfg.appearance.theme) || 'dark';
+          if (theme === 'light') document.documentElement.setAttribute('data-theme', 'light');
+          else if (theme === 'system') document.documentElement.setAttribute('data-theme', 'system');
+        }
+      } catch (e) { /* API not ready; theme.js will apply on load */ }
+    })();
+  </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tandem — Help & Features</title>

--- a/shell/help.html
+++ b/shell/help.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tandem — Help & Features</title>
+  <script src="js/theme.js"></script>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     
@@ -604,25 +605,7 @@
       }
     });
 
-    // Theme sync
-    function applyTheme(theme) {
-      if (theme === 'light') {
-        document.documentElement.setAttribute('data-theme', 'light');
-      } else if (theme === 'system') {
-        document.documentElement.setAttribute('data-theme', 'system');
-      } else {
-        document.documentElement.removeAttribute('data-theme');
-      }
-    }
-
-    fetch('http://localhost:8765/config').then(r => r.json()).then(c => {
-      applyTheme(c.appearance?.theme || c.theme || 'dark');
-    }).catch(() => {});
-
-    try {
-      const bc = new BroadcastChannel('tandem-theme');
-      bc.onmessage = (e) => { if (e.data?.theme) applyTheme(e.data.theme); };
-    } catch {}
+    // Theme sync is handled by shell/js/theme.js (loaded in <head>).
   </script>
 </body>
 </html>

--- a/shell/help.html
+++ b/shell/help.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tandem — Help & Features</title>
-  <script src="js/theme.js"></script>
+  <script type="module" src="js/theme.js"></script>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     

--- a/shell/index.html
+++ b/shell/index.html
@@ -5,6 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tandem Browser</title>
+  <script src="js/theme.js"></script>
   <link rel="stylesheet" href="css/main.css">
 </head>
 

--- a/shell/index.html
+++ b/shell/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tandem Browser</title>
-  <script src="js/theme.js"></script>
+  <script type="module" src="js/theme.js"></script>
   <link rel="stylesheet" href="css/main.css">
 </head>
 

--- a/shell/js/shortcuts.js
+++ b/shell/js/shortcuts.js
@@ -250,7 +250,7 @@
     setTimeout(checkOnboarding, 2000);
 
     // Theme management lives in shell/js/theme.js and is loaded before this file
-    // via <script src="js/theme.js"></script> in the shell HTML files.
+    // via <script type="module" src="js/theme.js"></script> in the shell HTML files.
 
     // ═══════════════════════════════════════════════
     // Password Vault UI Logic

--- a/shell/js/shortcuts.js
+++ b/shell/js/shortcuts.js
@@ -249,43 +249,8 @@
     // Start onboarding check
     setTimeout(checkOnboarding, 2000);
 
-    // ═══════════════════════════════════════════════
-    // Theme management
-    // ═══════════════════════════════════════════════
-
-    async function loadThemeFromConfig() {
-      try {
-        const response = await fetch('http://localhost:8765/config');
-        if (response.ok) {
-          const config = await response.json();
-          const theme = config.theme || 'dark';
-          applyTheme(theme);
-        }
-      } catch (error) {
-        // Default dark theme used (config load failed)
-      }
-    }
-
-    function applyTheme(theme) {
-      if (theme === 'light') {
-        document.documentElement.setAttribute('data-theme', 'light');
-      } else if (theme === 'system') {
-        document.documentElement.setAttribute('data-theme', 'system');
-      } else {
-        document.documentElement.removeAttribute('data-theme'); // Default dark
-      }
-    }
-
-    // Load theme on startup
-    setTimeout(loadThemeFromConfig, 100);
-
-    // Listen for theme changes broadcast from settings window (BroadcastChannel works cross-window in Electron)
-    try {
-      const themeBc = new BroadcastChannel('tandem-theme');
-      themeBc.onmessage = (e) => {
-        if (e.data && e.data.theme) applyTheme(e.data.theme);
-      };
-    } catch {}
+    // Theme management lives in shell/js/theme.js and is loaded before this file
+    // via <script src="js/theme.js"></script> in the shell HTML files.
 
     // ═══════════════════════════════════════════════
     // Password Vault UI Logic

--- a/shell/js/theme.js
+++ b/shell/js/theme.js
@@ -1,0 +1,75 @@
+// Shared theme management for all Tandem shell HTML documents.
+// Load via: <script src="js/theme.js"></script>
+//
+// Responsibilities:
+//   - applyTheme(theme): set document.documentElement[data-theme] correctly
+//   - readInitialTheme(): read the pre-paint hint the preload stamped onto <html>
+//   - loadThemeFromConfig(): fetch /config and apply (uses correct config.appearance.theme path)
+//   - subscribe to the 'tandem-theme' BroadcastChannel for live updates
+//
+// Works both as a classic <script> (exposes window.TandemTheme)
+// and as an ES module (exports for vitest tests).
+
+const VALID_THEMES = new Set(['dark', 'light', 'system']);
+const INITIAL_ATTR = 'data-tandem-initial-theme';
+const CONFIG_URL = 'http://localhost:8765/config';
+const BC_NAME = 'tandem-theme';
+
+export function applyTheme(theme) {
+  if (!VALID_THEMES.has(theme)) return;
+  const html = document.documentElement;
+  if (theme === 'light') html.setAttribute('data-theme', 'light');
+  else if (theme === 'system') html.setAttribute('data-theme', 'system');
+  else html.removeAttribute('data-theme'); // dark is the CSS default
+}
+
+export function readInitialTheme() {
+  const v = document.documentElement.getAttribute(INITIAL_ATTR);
+  return VALID_THEMES.has(v) ? v : null;
+}
+
+export async function loadThemeFromConfig() {
+  try {
+    const res = await fetch(CONFIG_URL);
+    if (!res.ok) return;
+    const config = await res.json();
+    const theme = config?.appearance?.theme || config?.theme || 'dark';
+    applyTheme(theme);
+  } catch {
+    // API not ready — leave whatever the preload stamped in place.
+  }
+}
+
+export function subscribeToBroadcasts() {
+  try {
+    const bc = new BroadcastChannel(BC_NAME);
+    bc.onmessage = (e) => {
+      if (e?.data?.theme) applyTheme(e.data.theme);
+    };
+    return bc;
+  } catch {
+    return null;
+  }
+}
+
+export function init() {
+  // Preload has already stamped <html data-theme="..."> for no-flash paint.
+  // We still call loadThemeFromConfig() after load to catch any drift
+  // (e.g. user changed setting in another window and this page was reopened).
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => void loadThemeFromConfig());
+  } else {
+    void loadThemeFromConfig();
+  }
+  subscribeToBroadcasts();
+}
+
+// Expose as a global for classic <script> loads.
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+  const api = { applyTheme, readInitialTheme, loadThemeFromConfig, subscribeToBroadcasts, init };
+  window.TandemTheme = api;
+  // Auto-init in browser context (not in vitest, where fetch is mocked per test).
+  if (!window.__TANDEM_THEME_SUPPRESS_AUTOINIT__) {
+    try { init(); } catch { /* ignore */ }
+  }
+}

--- a/shell/js/theme.js
+++ b/shell/js/theme.js
@@ -1,5 +1,5 @@
 // Shared theme management for all Tandem shell HTML documents.
-// Load via: <script src="js/theme.js"></script>
+// Load via: <script type="module" src="js/theme.js"></script>
 //
 // Responsibilities:
 //   - applyTheme(theme): set document.documentElement[data-theme] correctly
@@ -7,8 +7,13 @@
 //   - loadThemeFromConfig(): fetch /config and apply (uses correct config.appearance.theme path)
 //   - subscribe to the 'tandem-theme' BroadcastChannel for live updates
 //
-// Works both as a classic <script> (exposes window.TandemTheme)
-// and as an ES module (exports for vitest tests).
+// This file uses ES module `export` syntax, so HTML must load it with
+// type="module" (otherwise Chromium reports a SyntaxError and the whole
+// script fails to parse). It also assigns window.TandemTheme for inline
+// script consumers. Module scripts are deferred by default — they run
+// after HTML parsing but before DOMContentLoaded, which is early enough
+// for any consumer that awaits before use. Pre-paint theme is stamped
+// by the preload (src/preload/theme.ts), not by this module.
 
 const VALID_THEMES = new Set(['dark', 'light', 'system']);
 const INITIAL_ATTR = 'data-tandem-initial-theme';

--- a/shell/newtab.html
+++ b/shell/newtab.html
@@ -1,6 +1,27 @@
 <!DOCTYPE html>
 <html lang="nl">
 <head>
+  <!-- Pre-paint theme stamp for webview-loaded shell pages.
+       The main BrowserWindow gets the theme via preload+additionalArguments,
+       but webviews don't inherit that path — so we do a tiny sync XHR here to
+       stamp data-theme before the inline <style> blocks are processed by the
+       parser. Sync XHR is deprecated (console warning), but it's the only way
+       to avoid a dark→light flash. Fails silently if the API isn't up. -->
+  <script>
+    (function () {
+      try {
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', 'http://localhost:8765/config', false);
+        xhr.send();
+        if (xhr.status === 200) {
+          var cfg = JSON.parse(xhr.responseText);
+          var theme = (cfg && cfg.appearance && cfg.appearance.theme) || 'dark';
+          if (theme === 'light') document.documentElement.setAttribute('data-theme', 'light');
+          else if (theme === 'system') document.documentElement.setAttribute('data-theme', 'system');
+        }
+      } catch (e) { /* API not ready; theme.js will apply on load */ }
+    })();
+  </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>New Tab</title>

--- a/shell/newtab.html
+++ b/shell/newtab.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>New Tab</title>
+  <script src="js/theme.js"></script>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
 
@@ -516,33 +517,7 @@
     loadQuickLinks();
     loadRecentTabs();
 
-    // Theme sync — load from config + listen for changes
-    function applyTheme(theme) {
-      if (theme === 'light') {
-        document.documentElement.setAttribute('data-theme', 'light');
-      } else if (theme === 'system') {
-        document.documentElement.setAttribute('data-theme', 'system');
-      } else {
-        document.documentElement.removeAttribute('data-theme');
-      }
-    }
-
-    async function loadTheme() {
-      try {
-        const res = await fetch(`${API}/config`);
-        if (res.ok) {
-          const config = await res.json();
-          applyTheme(config.appearance?.theme || config.theme || 'dark');
-        }
-      } catch {}
-    }
-
-    loadTheme();
-
-    try {
-      const themeBc = new BroadcastChannel('tandem-theme');
-      themeBc.onmessage = (e) => { if (e.data?.theme) applyTheme(e.data.theme); };
-    } catch {}
+    // Theme sync is handled by shell/js/theme.js (loaded in <head>).
   </script>
 </body>
 </html>

--- a/shell/newtab.html
+++ b/shell/newtab.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>New Tab</title>
-  <script src="js/theme.js"></script>
+  <script type="module" src="js/theme.js"></script>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
 

--- a/shell/settings.html
+++ b/shell/settings.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tandem — Settings</title>
+  <script src="js/theme.js"></script>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     
@@ -1138,7 +1139,7 @@
 
       // Appearance/Theme
       setVal('cfg-theme', a.theme || 'dark');
-      applyTheme(a.theme || 'dark');
+      window.TandemTheme.applyTheme(a.theme || 'dark');
       setVal('cfg-language', g.language || 'nl-BE');
       setVal('cfg-wingmanPanelPosition', g.wingmanPanelPosition || 'right');
       setChecked('cfg-wingmanPanelDefaultOpen', !!g.wingmanPanelDefaultOpen);
@@ -1619,26 +1620,19 @@
       window.open('help.html', '_blank');
     }
 
-    // Handle theme changes
+    // Handle theme changes — apply locally via the shared module, then
+    // broadcast to all other renderer windows so they update too.
+    // Settings.html is the single broadcaster; all other windows only subscribe
+    // (the subscription is installed by shell/js/theme.js).
     document.getElementById('cfg-theme').addEventListener('change', (e) => {
-      applyTheme(e.target.value);
-    });
-
-    function applyTheme(theme) {
-      if (theme === 'light') {
-        document.documentElement.setAttribute('data-theme', 'light');
-      } else if (theme === 'system') {
-        document.documentElement.setAttribute('data-theme', 'system');
-      } else {
-        document.documentElement.removeAttribute('data-theme'); // Default dark
-      }
-      // Broadcast to all other renderer windows via BroadcastChannel
+      const theme = e.target.value;
+      window.TandemTheme.applyTheme(theme);
       try {
         const bc = new BroadcastChannel('tandem-theme');
         bc.postMessage({ theme });
         bc.close();
       } catch {}
-    }
+    });
 
     // ═══ Chrome sync ═══
     // Show/hide profile selector when sync toggled

--- a/shell/settings.html
+++ b/shell/settings.html
@@ -1,6 +1,27 @@
 <!DOCTYPE html>
 <html lang="nl">
 <head>
+  <!-- Pre-paint theme stamp for webview-loaded shell pages.
+       The main BrowserWindow gets the theme via preload+additionalArguments,
+       but webviews don't inherit that path — so we do a tiny sync XHR here to
+       stamp data-theme before the inline <style> blocks are processed by the
+       parser. Sync XHR is deprecated (console warning), but it's the only way
+       to avoid a dark→light flash. Fails silently if the API isn't up. -->
+  <script>
+    (function () {
+      try {
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', 'http://localhost:8765/config', false);
+        xhr.send();
+        if (xhr.status === 200) {
+          var cfg = JSON.parse(xhr.responseText);
+          var theme = (cfg && cfg.appearance && cfg.appearance.theme) || 'dark';
+          if (theme === 'light') document.documentElement.setAttribute('data-theme', 'light');
+          else if (theme === 'system') document.documentElement.setAttribute('data-theme', 'system');
+        }
+      } catch (e) { /* API not ready; theme.js will apply on load */ }
+    })();
+  </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tandem — Settings</title>

--- a/shell/settings.html
+++ b/shell/settings.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tandem — Settings</title>
-  <script src="js/theme.js"></script>
+  <script type="module" src="js/theme.js"></script>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     

--- a/shell/tests/theme.test.js
+++ b/shell/tests/theme.test.js
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+// Suppress auto-init in tests — we invoke APIs manually.
+globalThis.__TANDEM_THEME_SUPPRESS_AUTOINIT__ = true;
+if (typeof window !== 'undefined') window.__TANDEM_THEME_SUPPRESS_AUTOINIT__ = true;
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+async function loadFresh() {
+  // Reset data-theme only — callers set data-tandem-initial-theme before loading
+  // when they need it, and we must not clobber that setup here.
+  document.documentElement.removeAttribute('data-theme');
+  vi.resetModules();
+  return await import('../js/theme.js');
+}
+
+describe('shell theme module', () => {
+  beforeEach(() => {
+    document.documentElement.removeAttribute('data-theme');
+    document.documentElement.removeAttribute('data-tandem-initial-theme');
+  });
+
+  it('applyTheme("light") sets data-theme=light', async () => {
+    const { applyTheme } = await loadFresh();
+    applyTheme('light');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('applyTheme("system") sets data-theme=system', async () => {
+    const { applyTheme } = await loadFresh();
+    applyTheme('system');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('system');
+  });
+
+  it('applyTheme("dark") removes data-theme (dark is CSS default)', async () => {
+    const { applyTheme } = await loadFresh();
+    document.documentElement.setAttribute('data-theme', 'light');
+    applyTheme('dark');
+    expect(document.documentElement.hasAttribute('data-theme')).toBe(false);
+  });
+
+  it('applyTheme ignores unknown values', async () => {
+    const { applyTheme } = await loadFresh();
+    applyTheme('hotpink');
+    expect(document.documentElement.hasAttribute('data-theme')).toBe(false);
+  });
+
+  it('readInitialTheme reads from <html data-tandem-initial-theme>', async () => {
+    document.documentElement.setAttribute('data-tandem-initial-theme', 'light');
+    const { readInitialTheme } = await loadFresh();
+    expect(readInitialTheme()).toBe('light');
+  });
+
+  it('loadThemeFromConfig prefers appearance.theme over legacy config.theme', async () => {
+    const { loadThemeFromConfig } = await loadFresh();
+    const fakeFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ theme: 'light', appearance: { theme: 'dark' } }),
+    });
+    globalThis.fetch = fakeFetch;
+    await loadThemeFromConfig();
+    // dark = no attribute (CSS default is dark)
+    expect(document.documentElement.hasAttribute('data-theme')).toBe(false);
+  });
+
+  it('loadThemeFromConfig falls back to legacy config.theme if appearance missing', async () => {
+    const { loadThemeFromConfig } = await loadFresh();
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ theme: 'light' }),
+    });
+    await loadThemeFromConfig();
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+});

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1,0 +1,35 @@
+// src/config/io.ts
+// Sync file reader for the persisted config. Used during main-process startup
+// BEFORE ConfigManager is initialized (e.g. to resolve the pre-paint theme
+// for webPreferences.additionalArguments).
+
+import fs from 'fs';
+import path from 'path';
+import { tandemDir } from '../utils/paths';
+
+/**
+ * Shape we care about during pre-window startup. The full config type is
+ * larger (see `src/config/manager.ts`); we only type the fields we read here.
+ */
+export interface PreStartupConfig {
+  appearance?: {
+    theme?: 'dark' | 'light' | 'system';
+  };
+}
+
+/**
+ * Read ~/.tandem/config.json synchronously. Returns `null` if the file
+ * is missing or unreadable (e.g. first launch). Never throws.
+ */
+export function readConfigFileSync(): PreStartupConfig | null {
+  try {
+    const p = path.join(tandemDir(), 'config.json');
+    if (!fs.existsSync(p)) return null;
+    const raw = fs.readFileSync(p, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') return parsed as PreStartupConfig;
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/src/config/tests/io.test.ts
+++ b/src/config/tests/io.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+// We mock the paths module so tests don't touch a real home dir.
+vi.mock('../../utils/paths', () => ({
+  tandemDir: () => '/tmp/tandem-io-test',
+}));
+
+import { readConfigFileSync } from '../io';
+
+const DIR = '/tmp/tandem-io-test';
+const FILE = path.join(DIR, 'config.json');
+
+describe('readConfigFileSync', () => {
+  beforeEach(() => {
+    try { fs.rmSync(DIR, { recursive: true, force: true }); } catch { /* ignore */ }
+    fs.mkdirSync(DIR, { recursive: true });
+  });
+
+  afterEach(() => {
+    try { fs.rmSync(DIR, { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  it('returns null when config.json is missing', () => {
+    expect(readConfigFileSync()).toBe(null);
+  });
+
+  it('returns parsed config when file exists', () => {
+    fs.writeFileSync(FILE, JSON.stringify({ appearance: { theme: 'light' } }));
+    const cfg = readConfigFileSync();
+    expect(cfg?.appearance?.theme).toBe('light');
+  });
+
+  it('returns null on invalid JSON', () => {
+    fs.writeFileSync(FILE, 'not json');
+    expect(readConfigFileSync()).toBe(null);
+  });
+
+  it('returns null on non-object JSON', () => {
+    fs.writeFileSync(FILE, '42');
+    expect(readConfigFileSync()).toBe(null);
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,6 +44,8 @@ import { registerInitialTabLifecycle } from './bootstrap/tab-session';
 import { IpcChannels } from './shared/ipc-channels';
 import type { PendingTabRegister, RuntimeManagers } from './bootstrap/types';
 import { isGoogleAuthUrl, shouldSkipStealth, pathnameMatchesPrefix, tryParseUrl, urlHasProtocol, hostnameMatches } from './utils/security';
+import { readConfigFileSync } from './config/io';
+import { resolveInitialTheme, buildThemeAdditionalArg, type ResolvedTheme } from './theme/resolver';
 
 const log = createLogger('Main');
 
@@ -463,6 +465,18 @@ async function createWindow(): Promise<BrowserWindow> {
       }
     : {};
 
+  // Pre-paint theme resolution — eliminates dark→light flash.
+  // We read the file directly because ConfigManager is not yet initialized.
+  let initialTheme: ResolvedTheme = 'dark';
+  try {
+    const cfg = readConfigFileSync();
+    const setting = cfg?.appearance?.theme ?? 'dark';
+    initialTheme = resolveInitialTheme(setting, nativeTheme);
+    log.info(`[Theme] Pre-paint resolved theme: ${initialTheme} (setting=${setting})`);
+  } catch (err) {
+    log.warn('[Theme] Could not resolve initial theme, defaulting to dark', err);
+  }
+
   mainWindow = new BrowserWindow({
     width: 1400,
     height: 900,
@@ -475,6 +489,7 @@ async function createWindow(): Promise<BrowserWindow> {
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: true,
+      additionalArguments: [buildThemeAdditionalArg(initialTheme)],
     },
   });
   setMainWindow(mainWindow);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,5 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron';
 import { IpcChannels } from '../shared/ipc-channels';
+import { applyInitialTheme } from './theme';
 import { createNavigationApi } from './navigation';
 import { createContentApi } from './content';
 import { createTabsApi } from './tabs';
@@ -12,6 +13,9 @@ import { createBookmarksApi } from './bookmarks';
 import { createExtensionsApi } from './extensions';
 import { createWorkspacesApi } from './workspaces';
 import { createWindowApi } from './window';
+
+// Stamp the pre-paint theme on <html> before the shell document renders.
+applyInitialTheme();
 
 contextBridge.exposeInMainWorld('__TANDEM_TOKEN__', '');
 contextBridge.exposeInMainWorld('__TANDEM_VERSION__', process.env.npm_package_version || '');

--- a/src/preload/tests/theme.test.ts
+++ b/src/preload/tests/theme.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { parseThemeArg } from '../theme';
+
+describe('parseThemeArg', () => {
+  it('extracts theme from --tandem-theme=light', () => {
+    expect(parseThemeArg(['--tandem-theme=light'])).toBe('light');
+  });
+
+  it('extracts theme from --tandem-theme=dark with other args', () => {
+    expect(parseThemeArg(['--foo', '--tandem-theme=dark', '--bar'])).toBe('dark');
+  });
+
+  it('returns null if no matching arg', () => {
+    expect(parseThemeArg(['--other=1'])).toBe(null);
+  });
+
+  it('rejects unknown theme values', () => {
+    expect(parseThemeArg(['--tandem-theme=neon'])).toBe(null);
+  });
+
+  it('handles empty argv', () => {
+    expect(parseThemeArg([])).toBe(null);
+  });
+});

--- a/src/preload/theme.ts
+++ b/src/preload/theme.ts
@@ -1,0 +1,50 @@
+/**
+ * Read --tandem-theme=<theme> from process.argv (passed via
+ * webPreferences.additionalArguments) and stamp it onto <html> before paint.
+ *
+ * This runs in the preload's isolated world at document-start. At that point
+ * <html> exists but <body>/children may not — setAttribute on documentElement
+ * is safe and is exactly what we need to make CSS variable overrides apply
+ * before the first paint.
+ */
+
+// The preload tsconfig does not include the DOM lib (node-style target), but
+// this module runs in a renderer preload where `document` is available. We
+// declare just the shape we use rather than pulling in the whole DOM lib,
+// which would conflict with node types (Buffer/fetch) in main-process code.
+interface ThemeDocumentElement {
+  setAttribute(name: string, value: string): void;
+}
+interface ThemeDocument {
+  documentElement: ThemeDocumentElement | null;
+}
+declare const document: ThemeDocument | undefined;
+
+const VALID = new Set(['dark', 'light']);
+
+export function parseThemeArg(argv: readonly string[]): 'dark' | 'light' | null {
+  const prefix = '--tandem-theme=';
+  for (const a of argv) {
+    if (a.startsWith(prefix)) {
+      const v = a.slice(prefix.length);
+      if (VALID.has(v)) return v as 'dark' | 'light';
+      return null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Called from the preload entry. Stamps two attributes on <html>:
+ *   - data-theme="light"            when resolved theme is light (no attribute for dark, since dark is CSS default)
+ *   - data-tandem-initial-theme=... always, so shell code can read what we decided
+ */
+export function applyInitialTheme(): void {
+  if (typeof document === 'undefined' || !document || !document.documentElement) return;
+  const theme = parseThemeArg(process.argv);
+  if (!theme) return;
+  if (theme === 'light') {
+    document.documentElement.setAttribute('data-theme', 'light');
+  }
+  document.documentElement.setAttribute('data-tandem-initial-theme', theme);
+}

--- a/src/theme/resolver.ts
+++ b/src/theme/resolver.ts
@@ -18,3 +18,7 @@ export function resolveInitialTheme(
   if (setting === 'system') return nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
   return 'dark';
 }
+
+export function buildThemeAdditionalArg(theme: ResolvedTheme): string {
+  return `--tandem-theme=${theme}`;
+}

--- a/src/theme/resolver.ts
+++ b/src/theme/resolver.ts
@@ -1,0 +1,20 @@
+export type ThemeSetting = 'dark' | 'light' | 'system';
+export type ResolvedTheme = 'dark' | 'light';
+
+export interface NativeThemeLike {
+  readonly shouldUseDarkColors: boolean;
+}
+
+/**
+ * Convert the user's theme setting into a concrete palette (`dark` | `light`).
+ * Used at startup to pick a pre-paint theme for the preload.
+ */
+export function resolveInitialTheme(
+  setting: ThemeSetting,
+  nativeTheme: NativeThemeLike,
+): ResolvedTheme {
+  if (setting === 'light') return 'light';
+  if (setting === 'dark') return 'dark';
+  if (setting === 'system') return nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
+  return 'dark';
+}

--- a/src/theme/tests/additional-args.test.ts
+++ b/src/theme/tests/additional-args.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { buildThemeAdditionalArg } from '../resolver';
+
+describe('buildThemeAdditionalArg', () => {
+  it('returns --tandem-theme=light for light', () => {
+    expect(buildThemeAdditionalArg('light')).toBe('--tandem-theme=light');
+  });
+  it('returns --tandem-theme=dark for dark', () => {
+    expect(buildThemeAdditionalArg('dark')).toBe('--tandem-theme=dark');
+  });
+});

--- a/src/theme/tests/resolver.test.ts
+++ b/src/theme/tests/resolver.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { resolveInitialTheme } from '../resolver';
+
+describe('resolveInitialTheme', () => {
+  it('returns "dark" when config is dark', () => {
+    expect(resolveInitialTheme('dark', { shouldUseDarkColors: false })).toBe('dark');
+  });
+
+  it('returns "light" when config is light', () => {
+    expect(resolveInitialTheme('light', { shouldUseDarkColors: true })).toBe('light');
+  });
+
+  it('returns "dark" when config is system and OS prefers dark', () => {
+    expect(resolveInitialTheme('system', { shouldUseDarkColors: true })).toBe('dark');
+  });
+
+  it('returns "light" when config is system and OS prefers light', () => {
+    expect(resolveInitialTheme('system', { shouldUseDarkColors: false })).toBe('light');
+  });
+
+  it('falls back to "dark" for unknown values', () => {
+    // @ts-expect-error testing runtime fallback
+    expect(resolveInitialTheme('magenta', { shouldUseDarkColors: false })).toBe('dark');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     include: [
       'src/**/tests/**/*.test.ts',
+      'shell/tests/**/*.test.js',
     ],
     setupFiles: [
       'src/api/tests/setup.ts',


### PR DESCRIPTION
## Summary

Fixes the theme-system bug where Tandem opens in dark theme and switches to the configured theme ~1s later (flash), even for `appearance.theme=light`.

### Root cause
- CSS `:root` defaults to dark values.
- `<html data-theme>` was only applied after JS ran — and JS ran behind a 100ms `setTimeout` + async fetch.
- `shell/js/shortcuts.js` read `config.theme` instead of `config.appearance.theme` (silent bug — the fetch succeeded but the key was wrong).
- 5 copy-pasted theme implementations across shell HTML files, one of which (`about.html`) was missing entirely.

### Fix (8 commits)
1. **Pure resolver** (`src/theme/resolver.ts`) — `resolveInitialTheme(setting, nativeTheme)` converts `'system'` to a concrete `'dark'|'light'` using `nativeTheme.shouldUseDarkColors`.
2. **Shared shell module** (`shell/js/theme.js`) — single source of truth for `applyTheme`, `loadThemeFromConfig`, BroadcastChannel subscriber. Uses the correct `appearance.theme` config path with legacy fallback.
3. **Preload pre-paint injection** (`src/preload/theme.ts`) — reads `--tandem-theme=<theme>` from `process.argv` and stamps `<html data-theme=...>` before first paint in the main BrowserWindow.
4. **Main wires it up** (`src/main.ts`) — reads `~/.tandem/config.json` sync before `createWindow`, resolves the theme, passes it via `webPreferences.additionalArguments`.
5. **Shell HTML consolidated** — all 6 shell pages load `theme.js` as an ES module; 111 lines of duplicated theme code removed.
6. **Webview pre-paint stamp** — webviews don't inherit `additionalArguments`, so a small inline sync-XHR snippet in `newtab.html`/`bookmarks.html`/`help.html`/`about.html`/`settings.html` stamps `data-theme` before any `<style>` computes. Fixes the secondary flash on new-tab.
7. **CSS cleanup** — removed invalid `[data-theme="dark"], @media(...)` selector list that had been silently dead since it was written.

### Not in this PR (deferred to PR B)
- `nativeTheme.themeSource` syncing with config (macOS traffic lights etc.)
- Per-workspace theme override hook

## Test plan

- [x] `npm run verify` passes (compile, lint, 2578 tests, consistency)
- [x] App opens with configured theme immediately — no flash (dark/light/system)
- [x] Opening a new tab in light theme shows `newtab.html` light immediately (was the primary remaining bug during local testing)
- [x] Changing theme in settings updates all open shell pages live via BroadcastChannel
- [x] about, bookmarks, help, settings all respect the theme