### PR TITLE
Theme: sync nativeTheme with config + workspace scope hook (PR B)

### DIFF
--- a/shell/js/theme.js
+++ b/shell/js/theme.js
@@ -20,12 +20,17 @@ const INITIAL_ATTR = 'data-tandem-initial-theme';
 const CONFIG_URL = 'http://localhost:8765/config';
 const BC_NAME = 'tandem-theme';
 
-export function applyTheme(theme) {
+// opts.scope: optional Element to receive the data-theme attribute instead of
+// <html>. Used by per-workspace theme scoping so workspace-specific views can
+// opt out of the document-wide theme without affecting the rest of the shell.
+// When omitted, behavior is unchanged — the attribute is written to
+// document.documentElement.
+export function applyTheme(theme, opts) {
   if (!VALID_THEMES.has(theme)) return;
-  const html = document.documentElement;
-  if (theme === 'light') html.setAttribute('data-theme', 'light');
-  else if (theme === 'system') html.setAttribute('data-theme', 'system');
-  else html.removeAttribute('data-theme'); // dark is the CSS default
+  const target = (opts && opts.scope) || document.documentElement;
+  if (theme === 'light') target.setAttribute('data-theme', 'light');
+  else if (theme === 'system') target.setAttribute('data-theme', 'system');
+  else target.removeAttribute('data-theme'); // dark is the CSS default
 }
 
 export function readInitialTheme() {

--- a/shell/tests/theme.test.js
+++ b/shell/tests/theme.test.js
@@ -72,3 +72,54 @@ describe('shell theme module', () => {
     expect(document.documentElement.getAttribute('data-theme')).toBe('light');
   });
 });
+
+describe('applyTheme scope option', () => {
+  beforeEach(() => {
+    document.documentElement.removeAttribute('data-theme');
+    document.documentElement.removeAttribute('data-tandem-initial-theme');
+    document.body.innerHTML = '';
+  });
+
+  it('applies data-theme to a scope element when provided, leaving document root untouched', async () => {
+    const { applyTheme } = await loadFresh();
+    const scope = document.createElement('div');
+    document.body.appendChild(scope);
+    document.documentElement.removeAttribute('data-theme');
+
+    applyTheme('light', { scope });
+
+    expect(scope.getAttribute('data-theme')).toBe('light');
+    expect(document.documentElement.hasAttribute('data-theme')).toBe(false);
+  });
+
+  it('removes data-theme from scope element when setting dark', async () => {
+    const { applyTheme } = await loadFresh();
+    const scope = document.createElement('div');
+    scope.setAttribute('data-theme', 'light');
+    document.body.appendChild(scope);
+
+    applyTheme('dark', { scope });
+
+    expect(scope.hasAttribute('data-theme')).toBe(false);
+  });
+
+  it('without scope still targets document root (regression)', async () => {
+    const { applyTheme } = await loadFresh();
+    document.documentElement.removeAttribute('data-theme');
+
+    applyTheme('light');
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('ignores invalid theme values even when scope is provided', async () => {
+    const { applyTheme } = await loadFresh();
+    const scope = document.createElement('div');
+    scope.setAttribute('data-theme', 'light');
+    document.body.appendChild(scope);
+
+    applyTheme('bogus', { scope });
+
+    expect(scope.getAttribute('data-theme')).toBe('light');
+  });
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,7 +29,6 @@ app.commandLine.appendSwitch('enable-precise-memory-info');
 //   preventing Google auth cookies during youtube.com → accounts.google.com redirects
 app.commandLine.appendSwitch('disable-features',
   'WebContentsForceDark,ThirdPartyStoragePartitioning,TrackingProtection3pcd');
-nativeTheme.themeSource = 'system';
 import path from 'path';
 import { TandemAPI } from './api/server';
 import { StealthManager } from './stealth/manager';
@@ -45,7 +44,7 @@ import { IpcChannels } from './shared/ipc-channels';
 import type { PendingTabRegister, RuntimeManagers } from './bootstrap/types';
 import { isGoogleAuthUrl, shouldSkipStealth, pathnameMatchesPrefix, tryParseUrl, urlHasProtocol, hostnameMatches } from './utils/security';
 import { readConfigFileSync } from './config/io';
-import { resolveInitialTheme, buildThemeAdditionalArg, type ResolvedTheme } from './theme/resolver';
+import { resolveInitialTheme, buildThemeAdditionalArg, toNativeThemeSource, type ResolvedTheme } from './theme/resolver';
 
 const log = createLogger('Main');
 
@@ -471,8 +470,9 @@ async function createWindow(): Promise<BrowserWindow> {
   try {
     const cfg = readConfigFileSync();
     const setting = cfg?.appearance?.theme ?? 'dark';
+    nativeTheme.themeSource = toNativeThemeSource(setting);
     initialTheme = resolveInitialTheme(setting, nativeTheme);
-    log.info(`[Theme] Pre-paint resolved theme: ${initialTheme} (setting=${setting})`);
+    log.info(`[Theme] Pre-paint resolved theme: ${initialTheme} (setting=${setting}, nativeSource=${nativeTheme.themeSource})`);
   } catch (err) {
     log.warn('[Theme] Could not resolve initial theme, defaulting to dark', err);
   }
@@ -521,6 +521,18 @@ async function startAPI(win: BrowserWindow): Promise<void> {
     canUseWindow,
     log,
   });
+
+  // Keep nativeTheme.themeSource in sync with user config — so macOS traffic
+  // lights, titlebar, and form controls update live when the user changes
+  // theme in settings without requiring a restart.
+  runtime.configManager.onChange((_config, changed) => {
+    const newTheme = changed?.appearance?.theme;
+    if (newTheme === 'dark' || newTheme === 'light' || newTheme === 'system') {
+      nativeTheme.themeSource = toNativeThemeSource(newTheme);
+      log.info(`[Theme] nativeTheme.themeSource synced to '${nativeTheme.themeSource}' after config change`);
+    }
+  });
+
   const registry = createManagerRegistry(runtime);
   api = new TandemAPI({ win, port: API_PORT, registry });
   await api.start();

--- a/src/theme/resolver.ts
+++ b/src/theme/resolver.ts
@@ -22,3 +22,17 @@ export function resolveInitialTheme(
 export function buildThemeAdditionalArg(theme: ResolvedTheme): string {
   return `--tandem-theme=${theme}`;
 }
+
+export type NativeThemeSource = 'system' | 'light' | 'dark';
+
+/**
+ * Maps a theme setting to Electron's `nativeTheme.themeSource`.
+ * Used to sync the native chrome (traffic lights, form controls) with the
+ * user's configured theme. `system` means Electron follows the OS preference.
+ */
+export function toNativeThemeSource(setting: ThemeSetting): NativeThemeSource {
+  if (setting === 'light') return 'light';
+  if (setting === 'dark') return 'dark';
+  if (setting === 'system') return 'system';
+  return 'system';
+}

--- a/src/theme/tests/native-sync.test.ts
+++ b/src/theme/tests/native-sync.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { toNativeThemeSource } from '../resolver';
+
+describe('toNativeThemeSource', () => {
+  it('maps dark → dark', () => expect(toNativeThemeSource('dark')).toBe('dark'));
+  it('maps light → light', () => expect(toNativeThemeSource('light')).toBe('light'));
+  it('maps system → system', () => expect(toNativeThemeSource('system')).toBe('system'));
+  it('maps unknown → system as safe fallback', () => {
+    // @ts-expect-error runtime fallback
+    expect(toNativeThemeSource('neon')).toBe('system');
+  });
+});


### PR DESCRIPTION
## Summary

Second half of the theme system rework. PR A (merged) killed the pre-paint flash and consolidated the six copy-pasted theme implementations. PR B follows up with the native-chrome sync and a small hook for future per-workspace themes.

- **Sync `nativeTheme.themeSource` with user config** — the native Electron chrome (traffic lights, scrollbars, native dialogs) now follows the configured `appearance.theme` instead of being hardcoded to `'system'`. Set on window creation and kept in sync via a `configManager.onChange` subscription, so toggling the theme in Settings updates native chrome immediately without a relaunch.
- **Optional `{ scope }` param on `applyTheme`** — purely additive hook. `applyTheme(theme)` still targets `document.documentElement` exactly as before; passing `{ scope: element }` redirects the `data-theme` write to a specific element. Prep for per-workspace themes; no caller changes in this PR.

No user-visible change for anyone not using a non-`system` theme setting. No schema or config changes.

## Test plan

- [x] `npm run verify` — 2586 passed, 39 skipped, lint clean, compile clean, consistency clean
- [x] 4 new tests for `toNativeThemeSource` (system/light/dark mapping)
- [x] 4 new tests for `applyTheme` scope option (scope write, scope remove-on-dark, no-scope regression, invalid-theme guard)
- [x] Manual: launch Tandem with `appearance.theme = 'light'`, confirm native window chrome is light (not dark)
- [x] Manual: toggle theme in Settings, confirm native chrome updates without restart
- [x] Manual: toggle theme with `'system'` and flip OS theme, confirm native chrome follows