### PR TITLE
docs(security): acknowledge @samantha-gb for audit #34

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,3 +40,15 @@ Strong reports usually include:
 ## Disclosure
 
 Please allow time for triage and a fix before public disclosure.
+
+## Acknowledgments
+
+Tandem Browser is grateful to the security researchers who have responsibly
+reported issues and helped strengthen the project. If you would like to be
+listed here after reporting, say so in your report.
+
+- **[@samantha-gb](https://github.com/samantha-gb)** — external security audit
+  covering ungated JS execution, URL-scheme validation in the agent-facing API,
+  credential-file permissions, and fingerprint-seed determinism
+  ([#34](https://github.com/hydro13/tandem-browser/issues/34)). Findings are
+  being addressed across several releases starting with [#159](https://github.com/hydro13/tandem-browser/pull/159).


### PR DESCRIPTION
External security audits are a real gift to an open-source project — they deserve visible, permanent credit in the repo, not only a mention in issue threads.

Adds an **Acknowledgments** section to SECURITY.md and credits @samantha-gb for the careful audit opened as #34. Her findings drove the fixes in #159, with follow-ups planned for the remaining High/Medium/Low tier items.

Also adds a standing invitation for future researchers to ask to be listed.

## Why a separate PR

Credit doesn't belong buried in a security-fix PR — it's a repo-level policy statement and should be visible on its own. Also, this PR has a `Co-authored-by:` trailer so @samantha-gb shows up on the contributor graph, which couldn't be retroactively added to the already-merged #159.