### PR TITLE
fix(security): gate security-weakening API mutations (audit #34 High-1)

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -187,7 +187,7 @@ export class TandemAPI {
 
     // Register SecurityManager API routes
     if (this.registry.securityManager) {
-      registerSecurityRoutes(this.app, this.registry.securityManager);
+      registerSecurityRoutes(this.app, this.registry.securityManager, this.registry.taskManager);
     }
   }
 

--- a/src/api/tests/routes/security.test.ts
+++ b/src/api/tests/routes/security.test.ts
@@ -146,10 +146,17 @@ function createMockSecurityManager() {
   };
 }
 
-function createSecurityTestApp(sm: any) {
+function createMockTaskManager() {
+  return {
+    createTask: vi.fn().mockReturnValue({ id: 'task-1', steps: [{ id: 'step-0' }] }),
+    requestApproval: vi.fn().mockResolvedValue(true), // default: approve
+  };
+}
+
+function createSecurityTestApp(sm: any, taskManager: any = createMockTaskManager()) {
   const app = express();
   app.use(express.json());
-  registerSecurityRoutes(app, sm);
+  registerSecurityRoutes(app, sm, taskManager);
   return app;
 }
 
@@ -157,12 +164,14 @@ function createSecurityTestApp(sm: any) {
 
 describe('security routes', () => {
   let mocks: ReturnType<typeof createMockSecurityManager>;
+  let taskManager: ReturnType<typeof createMockTaskManager>;
   let app: ReturnType<typeof createSecurityTestApp>;
 
   beforeEach(() => {
     vi.clearAllMocks();
     mocks = createMockSecurityManager();
-    app = createSecurityTestApp(mocks.sm);
+    taskManager = createMockTaskManager();
+    app = createSecurityTestApp(mocks.sm, taskManager);
   });
 
   // ── Phase 1 (1-9) ──────────────────────────────────────────
@@ -231,13 +240,79 @@ describe('security routes', () => {
 
   // 3. POST /security/guardian/mode
   describe('POST /security/guardian/mode', () => {
-    it('sets guardian mode and returns ok', async () => {
+    it('tightening (balanced → strict) passes through without user approval', async () => {
+      mocks.db.getDomainInfo.mockReturnValue({ domain: 'example.com', guardianMode: 'balanced' });
       const res = await request(app)
         .post('/security/guardian/mode')
         .send({ domain: 'example.com', mode: 'strict' });
       expect(res.status).toBe(200);
       expect(res.body).toEqual({ ok: true, domain: 'example.com', mode: 'strict' });
       expect(mocks.guardian.setMode).toHaveBeenCalledWith('example.com', 'strict');
+      expect(taskManager.requestApproval).not.toHaveBeenCalled();
+    });
+
+    it('same mode (no change) passes through without user approval', async () => {
+      mocks.db.getDomainInfo.mockReturnValue({ domain: 'example.com', guardianMode: 'balanced' });
+      const res = await request(app)
+        .post('/security/guardian/mode')
+        .send({ domain: 'example.com', mode: 'balanced' });
+      expect(res.status).toBe(200);
+      expect(taskManager.requestApproval).not.toHaveBeenCalled();
+    });
+
+    it('weakening (balanced → permissive) requires user approval — approved', async () => {
+      mocks.db.getDomainInfo.mockReturnValue({ domain: 'example.com', guardianMode: 'balanced' });
+      taskManager.requestApproval.mockResolvedValue(true);
+
+      const res = await request(app)
+        .post('/security/guardian/mode')
+        .send({ domain: 'example.com', mode: 'permissive' });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ ok: true, domain: 'example.com', mode: 'permissive' });
+      expect(taskManager.requestApproval).toHaveBeenCalled();
+      expect(mocks.guardian.setMode).toHaveBeenCalledWith('example.com', 'permissive');
+    });
+
+    it('weakening (strict → permissive) requires user approval — rejected', async () => {
+      mocks.db.getDomainInfo.mockReturnValue({ domain: 'example.com', guardianMode: 'strict' });
+      taskManager.requestApproval.mockResolvedValue(false);
+
+      const res = await request(app)
+        .post('/security/guardian/mode')
+        .send({ domain: 'example.com', mode: 'permissive' });
+
+      expect(res.status).toBe(403);
+      expect(res.body.rejected).toBe(true);
+      expect(mocks.guardian.setMode).not.toHaveBeenCalled();
+    });
+
+    it('weakening request creates a task with riskLevel high and requiresApproval', async () => {
+      mocks.db.getDomainInfo.mockReturnValue({ domain: 'example.com', guardianMode: 'strict' });
+      taskManager.requestApproval.mockResolvedValue(true);
+
+      await request(app)
+        .post('/security/guardian/mode')
+        .send({ domain: 'example.com', mode: 'balanced' });
+
+      expect(taskManager.createTask).toHaveBeenCalled();
+      const taskArgs = taskManager.createTask.mock.calls[0];
+      const steps = taskArgs[3];
+      expect(steps[0].riskLevel).toBe('high');
+      expect(steps[0].requiresApproval).toBe(true);
+    });
+
+    it('unknown domain (no record) treats new mode as weakening when lower than default "balanced"', async () => {
+      // No domain info → current effective mode is the default 'balanced'
+      mocks.db.getDomainInfo.mockReturnValue(null);
+      taskManager.requestApproval.mockResolvedValue(true);
+
+      const res = await request(app)
+        .post('/security/guardian/mode')
+        .send({ domain: 'unseen.example', mode: 'permissive' });
+
+      expect(res.status).toBe(200);
+      expect(taskManager.requestApproval).toHaveBeenCalled();
     });
 
     it('returns 400 when domain or mode is missing', async () => {
@@ -256,11 +331,12 @@ describe('security routes', () => {
       expect(res.body.error).toContain('Invalid mode');
     });
 
-    it('returns 500 on error', async () => {
+    it('returns 500 on error during tightening', async () => {
+      mocks.db.getDomainInfo.mockReturnValue({ domain: 'example.com', guardianMode: 'permissive' });
       mocks.guardian.setMode.mockImplementation(() => { throw new Error('setMode failed'); });
       const res = await request(app)
         .post('/security/guardian/mode')
-        .send({ domain: 'example.com', mode: 'balanced' });
+        .send({ domain: 'example.com', mode: 'strict' });
       expect(res.status).toBe(500);
       expect(res.body).toEqual({ error: 'setMode failed' });
     });
@@ -350,13 +426,69 @@ describe('security routes', () => {
 
   // 7. POST /security/domains/:domain/trust
   describe('POST /security/domains/:domain/trust', () => {
-    it('updates trust level for a domain', async () => {
+    it('lowering trust (tightening) passes through without approval', async () => {
+      mocks.db.getDomainInfo.mockReturnValue({ domain: 'example.com', trustLevel: 80 });
       const res = await request(app)
         .post('/security/domains/example.com/trust')
-        .send({ trust: 75 });
+        .send({ trust: 30 });
       expect(res.status).toBe(200);
-      expect(res.body).toEqual({ ok: true, domain: 'example.com', trust: 75 });
-      expect(mocks.db.upsertDomain).toHaveBeenCalledWith('example.com', { trustLevel: 75 });
+      expect(res.body).toEqual({ ok: true, domain: 'example.com', trust: 30 });
+      expect(mocks.db.upsertDomain).toHaveBeenCalledWith('example.com', { trustLevel: 30 });
+      expect(taskManager.requestApproval).not.toHaveBeenCalled();
+    });
+
+    it('same trust (no change) passes through without approval', async () => {
+      mocks.db.getDomainInfo.mockReturnValue({ domain: 'example.com', trustLevel: 50 });
+      const res = await request(app)
+        .post('/security/domains/example.com/trust')
+        .send({ trust: 50 });
+      expect(res.status).toBe(200);
+      expect(taskManager.requestApproval).not.toHaveBeenCalled();
+    });
+
+    it('raising trust (weakening) requires approval — approved', async () => {
+      mocks.db.getDomainInfo.mockReturnValue({ domain: 'example.com', trustLevel: 50 });
+      taskManager.requestApproval.mockResolvedValue(true);
+
+      const res = await request(app)
+        .post('/security/domains/example.com/trust')
+        .send({ trust: 90 });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ ok: true, domain: 'example.com', trust: 90 });
+      expect(taskManager.requestApproval).toHaveBeenCalled();
+    });
+
+    it('raising trust (weakening) requires approval — rejected', async () => {
+      mocks.db.getDomainInfo.mockReturnValue({ domain: 'example.com', trustLevel: 50 });
+      taskManager.requestApproval.mockResolvedValue(false);
+
+      const res = await request(app)
+        .post('/security/domains/example.com/trust')
+        .send({ trust: 90 });
+
+      expect(res.status).toBe(403);
+      expect(res.body.rejected).toBe(true);
+      expect(mocks.db.upsertDomain).not.toHaveBeenCalled();
+    });
+
+    it('unknown domain (no record) treats any new trust as weakening', async () => {
+      mocks.db.getDomainInfo.mockReturnValue(null);
+      taskManager.requestApproval.mockResolvedValue(true);
+      const res = await request(app)
+        .post('/security/domains/unseen.example/trust')
+        .send({ trust: 50 });
+      expect(res.status).toBe(200);
+      expect(taskManager.requestApproval).toHaveBeenCalled();
+    });
+
+    it('unknown domain with trust 0 is not weakening — no approval needed', async () => {
+      mocks.db.getDomainInfo.mockReturnValue(null);
+      const res = await request(app)
+        .post('/security/domains/unseen.example/trust')
+        .send({ trust: 0 });
+      expect(res.status).toBe(200);
+      expect(taskManager.requestApproval).not.toHaveBeenCalled();
     });
 
     it('returns 400 when trust is missing', async () => {
@@ -383,15 +515,8 @@ describe('security routes', () => {
       expect(res.body.error).toContain('trust must be a number');
     });
 
-    it('accepts trust value of 0', async () => {
-      const res = await request(app)
-        .post('/security/domains/example.com/trust')
-        .send({ trust: 0 });
-      expect(res.status).toBe(200);
-      expect(res.body).toEqual({ ok: true, domain: 'example.com', trust: 0 });
-    });
-
-    it('returns 500 on error', async () => {
+    it('returns 500 on error during tightening', async () => {
+      mocks.db.getDomainInfo.mockReturnValue({ domain: 'example.com', trustLevel: 80 });
       mocks.db.upsertDomain.mockImplementation(() => { throw new Error('upsert failed'); });
       const res = await request(app)
         .post('/security/domains/example.com/trust')
@@ -516,32 +641,57 @@ describe('security routes', () => {
 
   // 12. POST /security/outbound/whitelist
   describe('POST /security/outbound/whitelist', () => {
-    it('adds a whitelist pair and lowercases domains', async () => {
+    it('adding a whitelist pair always requires user approval — approved', async () => {
+      taskManager.requestApproval.mockResolvedValue(true);
       const res = await request(app)
         .post('/security/outbound/whitelist')
         .send({ origin: 'Example.COM', destination: 'Api.Service.IO' });
       expect(res.status).toBe(200);
       expect(res.body).toEqual({ ok: true, origin: 'example.com', destination: 'api.service.io' });
+      expect(taskManager.requestApproval).toHaveBeenCalled();
       expect(mocks.db.addWhitelistPair).toHaveBeenCalledWith('example.com', 'api.service.io');
     });
 
-    it('returns 400 when origin is missing', async () => {
+    it('adding a whitelist pair — rejected returns 403 and never calls the DB', async () => {
+      taskManager.requestApproval.mockResolvedValue(false);
+      const res = await request(app)
+        .post('/security/outbound/whitelist')
+        .send({ origin: 'example.com', destination: 'attacker.example' });
+      expect(res.status).toBe(403);
+      expect(res.body.rejected).toBe(true);
+      expect(mocks.db.addWhitelistPair).not.toHaveBeenCalled();
+    });
+
+    it('whitelist request creates a high-risk approval task', async () => {
+      taskManager.requestApproval.mockResolvedValue(true);
+      await request(app)
+        .post('/security/outbound/whitelist')
+        .send({ origin: 'a.com', destination: 'b.com' });
+      const steps = taskManager.createTask.mock.calls[0][3];
+      expect(steps[0].riskLevel).toBe('high');
+      expect(steps[0].requiresApproval).toBe(true);
+    });
+
+    it('returns 400 when origin is missing — no approval task created', async () => {
       const res = await request(app)
         .post('/security/outbound/whitelist')
         .send({ destination: 'api.com' });
       expect(res.status).toBe(400);
       expect(res.body).toEqual({ error: 'origin and destination domains required' });
+      expect(taskManager.requestApproval).not.toHaveBeenCalled();
     });
 
-    it('returns 400 when destination is missing', async () => {
+    it('returns 400 when destination is missing — no approval task created', async () => {
       const res = await request(app)
         .post('/security/outbound/whitelist')
         .send({ origin: 'example.com' });
       expect(res.status).toBe(400);
       expect(res.body).toEqual({ error: 'origin and destination domains required' });
+      expect(taskManager.requestApproval).not.toHaveBeenCalled();
     });
 
-    it('returns 500 on error', async () => {
+    it('returns 500 on DB error after approval', async () => {
+      taskManager.requestApproval.mockResolvedValue(true);
       mocks.db.addWhitelistPair.mockImplementation(() => { throw new Error('whitelist error'); });
       const res = await request(app)
         .post('/security/outbound/whitelist')

--- a/src/security/routes.ts
+++ b/src/security/routes.ts
@@ -1,18 +1,64 @@
 import type express from 'express';
 import type { SecurityManager } from './security-manager';
 import type { GuardianMode, GatekeeperAction } from './types';
+import type { TaskManager } from '../agents/task-manager';
 import { createLogger } from '../utils/logger';
 
 const log = createLogger('SecurityRoutes');
 
 /**
+ * Default guardian mode when no per-domain record exists. Must match
+ * Guardian.defaultMode. Kept as a constant so mode-comparison logic in
+ * weakening detection stays consistent with runtime behavior.
+ */
+const DEFAULT_GUARDIAN_MODE: GuardianMode = 'balanced';
+
+/**
+ * Rank Guardian modes from most restrictive to least. Used to detect when a
+ * mode change weakens security posture (next rank < current rank) vs tightens
+ * it (next rank > current rank) — only weakening changes need user approval.
+ */
+const MODE_RANK: Record<GuardianMode, number> = {
+  strict: 3,
+  balanced: 2,
+  permissive: 1,
+};
+
+/**
+ * Gate a security-weakening mutation behind an interactive user approval.
+ * Mirrors POST /execute-js/confirm: create a high-risk task with
+ * requiresApproval, await the user's decision, resolve to true/false.
+ */
+async function requireWeakeningApproval(
+  taskManager: TaskManager,
+  description: string,
+): Promise<boolean> {
+  const task = taskManager.createTask(
+    description,
+    'claude',
+    'claude',
+    [{
+      description,
+      action: { type: 'security_weaken', params: {} },
+      riskLevel: 'high',
+      requiresApproval: true,
+    }],
+  );
+  return taskManager.requestApproval(task, 0);
+}
+
+/**
  * Register all 34 security API routes on the Express app.
- * Extracted from SecurityManager.registerRoutes() so the manager
- * class doesn't depend on Express directly.
+ *
+ * `taskManager` is required so security-weakening mutations
+ * (lowering guardian mode, raising domain trust, adding outbound whitelist
+ * pairs) can be gated behind an interactive user approval. Tightening
+ * changes pass through without friction. Addresses audit #34 High-1.
  */
 export function registerSecurityRoutes(
   app: express.Application,
   sm: SecurityManager,
+  taskManager: TaskManager,
 ): void {
   // === Phase 1 routes (1-9) ===
 
@@ -51,7 +97,7 @@ export function registerSecurityRoutes(
   });
 
   // 3. POST /security/guardian/mode — Set guardian mode per domain
-  app.post('/security/guardian/mode', (req, res) => {
+  app.post('/security/guardian/mode', async (req, res) => {
     try {
       const { domain, mode } = req.body;
       if (!domain || !mode) {
@@ -63,8 +109,23 @@ export function registerSecurityRoutes(
         res.status(400).json({ error: `Invalid mode. Use: ${validModes.join(', ')}` });
         return;
       }
-      sm.getGuardian().setMode(domain, mode);
-      res.json({ ok: true, domain, mode });
+      const nextMode = mode as GuardianMode;
+      const currentMode: GuardianMode =
+        (sm.getDb().getDomainInfo(domain)?.guardianMode as GuardianMode | undefined) ?? DEFAULT_GUARDIAN_MODE;
+      // Weakening = lowering the mode's rank (e.g. balanced → permissive)
+      if (MODE_RANK[nextMode] < MODE_RANK[currentMode]) {
+        const approved = await requireWeakeningApproval(
+          taskManager,
+          `Lower Guardian mode for ${domain}: ${currentMode} → ${nextMode}`,
+        );
+        if (!approved) {
+          log.warn(`guardian/mode weaken rejected by user: ${domain} ${currentMode} → ${nextMode}`);
+          res.status(403).json({ error: 'User rejected security-weakening change', rejected: true });
+          return;
+        }
+      }
+      sm.getGuardian().setMode(domain, nextMode);
+      res.json({ ok: true, domain, mode: nextMode });
     } catch (e) {
       res.status(500).json({ error: e instanceof Error ? e.message : String(e) });
     }
@@ -111,13 +172,28 @@ export function registerSecurityRoutes(
   });
 
   // 7. POST /security/domains/:domain/trust — Manual trust adjustment
-  app.post('/security/domains/:domain/trust', (req, res) => {
+  app.post('/security/domains/:domain/trust', async (req, res) => {
     try {
       const domain = req.params.domain;
       const { trust } = req.body;
       if (trust === undefined || typeof trust !== 'number' || trust < 0 || trust > 100) {
         res.status(400).json({ error: 'trust must be a number between 0 and 100' });
         return;
+      }
+      // Treat unknown domains as trustLevel 0 — so raising from 0 to anything
+      // positive is a weakening change and requires approval.
+      const currentTrust: number = sm.getDb().getDomainInfo(domain)?.trustLevel ?? 0;
+      // Weakening = raising trust (more trust → less shield).
+      if (trust > currentTrust) {
+        const approved = await requireWeakeningApproval(
+          taskManager,
+          `Raise trust for ${domain}: ${currentTrust} → ${trust}`,
+        );
+        if (!approved) {
+          log.warn(`domains/trust raise rejected by user: ${domain} ${currentTrust} → ${trust}`);
+          res.status(403).json({ error: 'User rejected security-weakening change', rejected: true });
+          return;
+        }
       }
       sm.getDb().upsertDomain(domain, { trustLevel: trust });
       res.json({ ok: true, domain, trust });
@@ -180,15 +256,28 @@ export function registerSecurityRoutes(
   });
 
   // 12. POST /security/outbound/whitelist — Whitelist a domain pair
-  app.post('/security/outbound/whitelist', (req, res) => {
+  app.post('/security/outbound/whitelist', async (req, res) => {
     try {
       const { origin, destination } = req.body;
       if (!origin || !destination) {
         res.status(400).json({ error: 'origin and destination domains required' });
         return;
       }
-      sm.getDb().addWhitelistPair(origin.toLowerCase(), destination.toLowerCase());
-      res.json({ ok: true, origin: origin.toLowerCase(), destination: destination.toLowerCase() });
+      const o = String(origin).toLowerCase();
+      const d = String(destination).toLowerCase();
+      // Whitelisting always weakens posture: it bypasses OutboundGuard for
+      // the (origin, destination) pair. Every addition requires approval.
+      const approved = await requireWeakeningApproval(
+        taskManager,
+        `Whitelist outbound bypass: ${o} → ${d}`,
+      );
+      if (!approved) {
+        log.warn(`outbound/whitelist add rejected by user: ${o} → ${d}`);
+        res.status(403).json({ error: 'User rejected security-weakening change', rejected: true });
+        return;
+      }
+      sm.getDb().addWhitelistPair(o, d);
+      res.json({ ok: true, origin: o, destination: d });
     } catch (e) {
       res.status(500).json({ error: e instanceof Error ? e.message : String(e) });
     }


### PR DESCRIPTION
Addresses **High-1** from @samantha-gb's audit in #34.

## The problem

Three security routes let any API caller silently lower Tandem's defenses for a domain:

- `POST /security/guardian/mode` — lowering the per-domain guardian mode (`balanced → permissive`) reduces how aggressively the 8-layer shield inspects requests.
- `POST /security/domains/:domain/trust` — raising trust (e.g. `30 → 90`) makes the shield treat the domain as more reliable, reducing script, cookie, and outbound scrutiny.
- `POST /security/outbound/whitelist` — adding an (origin, destination) pair whitelists outbound traffic past OutboundGuard, which is the last-line credential-exfiltration defense.

A prompt-injected agent could chain these to prepare a domain for credential exfiltration without any user-visible signal:

```
POST /security/guardian/mode    {"domain":"evil.example","mode":"permissive"}
POST /security/domains/evil.example/trust  {"trust":100}
POST /security/outbound/whitelist  {"origin":"bank.com","destination":"evil.example"}
POST /execute-js                 (send cookies to evil.example — OutboundGuard now bypassed)
```

## The fix

Only **weakening** mutations require interactive user approval via the same flow as `/execute-js/confirm` (`taskManager.requestApproval`, `riskLevel: 'high'`, `requiresApproval: true`). Tightening and no-op changes pass through without friction — this preserves Tandem's trust model: the AI still operates freely, but any change that *lowers* the shield requires the human in the loop.

### Weakening definitions

| Route | Weakening if |
|---|---|
| `guardian/mode` | `MODE_RANK[next] < MODE_RANK[current]` where `strict(3) > balanced(2) > permissive(1)` |
| `domains/:domain/trust` | `new_trust > current_trust` (unknown domain → treated as `trust = 0`) |
| `outbound/whitelist` | **always** — adding a bypass is inherently weakening |

### Signature change

`registerSecurityRoutes(app, sm, taskManager)` — the one production caller in `src/api/server.ts` is updated to pass `registry.taskManager`.

## Verification

### Live-verified in running Tandem ✅

| Scenario | Result |
|---|---|
| Guardian `balanced → strict` (tightening) | 200 instant, no modal |
| Guardian validation (`mode: "chaos"`) | 400, no modal |
| Trust `0 → 80` (weakening) + user approves in modal | 200, mutation applied |
| Whitelist add + user **rejects** in modal | 403 `{"rejected":true}`, no mutation |

### Unit tests

- 11 new tests covering approve / reject / tighten / no-op / unknown-domain paths for all three routes
- Verification that 400-validation paths do not accidentally create approval tasks
- Full vitest suite: **2640 passed**, 39 skipped, 1 pre-existing jsdom env error (unrelated)
- `npm run verify` clean: compile ✓, lint ✓, check-consistency ✓

### Backward compatibility

- No API change for normal/tightening usage
- Breaking change (intentional): callers that silently weakened posture now receive `403` unless the human approves. This is the point of the fix.

## Stealth implication

None — these are internal security endpoints, not observable by web pages or scripts.

## Not in scope

- **High-3** CRX signature verification — separate concern (extension install pipeline)
- **High-4** IPC `execute-js` callable from renderer — separate concern (shell ↔ main boundary)
- **Medium / Low tier** findings — follow-up PRs

---

Credit to @samantha-gb for finding this during the external audit. The `Co-authored-by:` trailer on the commit puts her on the contributor graph for this change.