### PR TITLE
fix(security): remove unused EXECUTE_JS IPC channel (audit #34 High-4)

### DIFF
--- a/src/devtools/manager.ts
+++ b/src/devtools/manager.ts
@@ -273,7 +273,7 @@ export class DevToolsManager {
 
   // ── Evaluate ──
 
-  /** Evaluate JavaScript in the page context via CDP (more powerful than executeJS) */
+  /** Evaluate JavaScript in the page context via CDP (more powerful than wc.executeJavaScript) */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Runtime.evaluate returns arbitrary page values
   async evaluate(expression: string, opts?: { returnByValue?: boolean; awaitPromise?: boolean }): Promise<any> {
     const wc = await this.ensureAttached();

--- a/src/ipc/handlers.ts
+++ b/src/ipc/handlers.ts
@@ -116,7 +116,6 @@ export function registerIpcHandlers(deps: IpcDeps): void {
     IpcChannels.RELOAD,
     IpcChannels.GET_PAGE_CONTENT,
     IpcChannels.GET_PAGE_STATUS,
-    IpcChannels.EXECUTE_JS,
     IpcChannels.GET_API_TOKEN,
     IpcChannels.IS_WINDOW_MAXIMIZED,
     IpcChannels.START_RECORDING,
@@ -645,18 +644,11 @@ export function registerIpcHandlers(deps: IpcDeps): void {
     }
   });
 
-  ipcMain.handle(IpcChannels.EXECUTE_JS, async (_event, code: string) => {
-    const wc = await tabManager.getActiveWebContents();
-    if (!wc) return { success: false, error: 'No active tab' };
-
-    try {
-      const result = await wc.executeJavaScript(code);
-      return { success: true, result };
-    } catch (error) {
-      return { success: false, error: String(error) };
-    }
-  });
-
+  // EXECUTE_JS handler removed in audit #34 High-4 — the channel let any
+  // renderer call wc.executeJavaScript in the active tab, with no sender check
+  // and no approval gate. If a feature later needs agent-driven JS execution
+  // from a trusted surface, prefer the HTTP routes /execute-js/confirm (gated
+  // via taskManager.requestApproval) or /execute-js (scanner-protected).
   ipcMain.handle(IpcChannels.GET_API_TOKEN, async () => {
     try {
       return fs.readFileSync(tandemDir('api-token'), 'utf-8').trim();

--- a/src/preload/content.ts
+++ b/src/preload/content.ts
@@ -5,6 +5,10 @@ export function createContentApi() {
   return {
     getPageContent: () => ipcRenderer.invoke(IpcChannels.GET_PAGE_CONTENT),
     getPageStatus: () => ipcRenderer.invoke(IpcChannels.GET_PAGE_STATUS),
-    executeJS: (code: string) => ipcRenderer.invoke(IpcChannels.EXECUTE_JS, code),
+    // executeJS was removed in audit #34 High-4 — the IPC channel gave any
+    // renderer that could reach window.tandem (e.g. via shell XSS) the ability
+    // to run arbitrary JS in the active webview. The channel is gone; agents
+    // should use the HTTP API routes (/execute-js/confirm, gated; or /execute-js,
+    // scanner-protected), not renderer IPC.
   };
 }

--- a/src/preload/tests/content.test.ts
+++ b/src/preload/tests/content.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// ipcRenderer is only available inside the Electron renderer. For this unit
+// test we mock the minimal surface so the preload module can be imported.
+vi.mock('electron', () => ({
+  ipcRenderer: {
+    invoke: vi.fn(),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+  },
+}));
+
+import { createContentApi } from '../content';
+
+describe('createContentApi()', () => {
+  it('does NOT expose executeJS — per audit #34 High-4 the IPC channel was removed', () => {
+    // Regression guard: if someone re-adds executeJS to the preload without
+    // re-adding a proper gate (scheme block + approval flow), this test flips
+    // red so the review catches it.
+    const api = createContentApi() as Record<string, unknown>;
+    expect(api).not.toHaveProperty('executeJS');
+  });
+
+  it('still exposes the read-only page-state helpers', () => {
+    const api = createContentApi() as Record<string, unknown>;
+    expect(typeof api.getPageContent).toBe('function');
+    expect(typeof api.getPageStatus).toBe('function');
+  });
+});

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -17,7 +17,10 @@ export const IpcChannels = {
   // Page content
   GET_PAGE_CONTENT: 'get-page-content',
   GET_PAGE_STATUS: 'get-page-status',
-  EXECUTE_JS: 'execute-js',
+  // EXECUTE_JS removed in audit #34 High-4: the channel let any renderer
+  // reachable via window.tandem run arbitrary JS in the active webview,
+  // which is an unnecessary XSS amplifier. Use the HTTP /execute-js(/confirm)
+  // routes — they're gated by the injection scanner and user approval.
 
   // Tab management
   TAB_NEW: 'tab-new',


### PR DESCRIPTION
Addresses **High-4** from @samantha-gb's audit in #34.

## The problem

`src/ipc/handlers.ts:648` registered an `EXECUTE_JS` IPC handler that called `wc.executeJavaScript(code)` in the active tab — with no sender check and no approval gate. It was exposed to the shell renderer as `window.tandem.executeJS()` via `src/preload/content.ts:8`.

The audit flagged this as an XSS amplifier: if any HTML rendered in the shell (e.g. a crafted Wingman chat message) ever smuggled script into the shell origin, that script could reach `window.tandem.executeJS` and run arbitrary JS in whatever tab the user happened to be viewing at that moment.

## Why remove instead of gate

A full grep across `src/` and `shell/` shows **zero callers** of the channel. There is nothing to preserve, so the cleanest fix is removal:

- One fewer reachable sink for any future XSS
- Smaller diff, nothing to misconfigure later
- Agent-driven JS execution already has two proper HTTP surfaces:
  - `POST /execute-js/confirm` — user-approval gate via `taskManager.requestApproval`
  - `POST /execute-js` — `injectionScannerMiddleware` protected (covered under audit's Critical; see #159 discussion)

If a future feature genuinely needs renderer-initiated JS execution, it should come back as a new, properly-gated channel — not a resurrection of the silent one.

## Changes

**Removed:**
- `IpcChannels.EXECUTE_JS` in `src/shared/ipc-channels.ts` (replaced with an inline comment explaining the history so the next person who considers re-adding reads it)
- `ipcMain.handle(IpcChannels.EXECUTE_JS, ...)` in `src/ipc/handlers.ts` plus its entry in the `removeHandler` cleanup list
- `executeJS` export in `src/preload/content.ts`

**Added:**
- `src/preload/tests/content.test.ts` — regression guard that flips red if someone re-adds `executeJS` to the preload without re-adding a gate. Also pins the two legitimate read-only helpers (`getPageContent`, `getPageStatus`) so future churn doesn't accidentally drop them.

**Housekeeping:**
- Updated a stale comment in `src/devtools/manager.ts` that referenced the old `executeJS` name

## Verification

### Live-verified in running Tandem ✅

- Shell loads cleanly, no errors about the removed handler in logs
- `POST /navigate` still works (sanity check that shell + API wiring survives)

### Test suite

- Full `npm run verify` clean: compile ✓, lint ✓, check-consistency ✓
- **2642 tests passed**, 39 skipped, 1 pre-existing jsdom env error (unrelated to this change)

## Stealth implication

None — this is an internal IPC channel, not observable by web pages.

## Not in scope

Remaining audit #34 items: **High-3** (CRX signatures), Medium tier (7 items), Low tier (3 items). Separate PRs.

---

Credit to @samantha-gb for finding this. Co-authored on the commit so she's on the contributor graph.