### PR TITLE
fix(security): verify CRX3 RSA signatures before installing (audit #34 High-3)

### DIFF
--- a/src/extensions/crx-downloader.ts
+++ b/src/extensions/crx-downloader.ts
@@ -139,11 +139,8 @@ export class CrxDownloader {
     log.info(`🧩 CRX format verified: ${verification.format}, downloadedFromGoogle=${verification.downloadedFromGoogle}`);
 
     // Audit #34 High-3: cryptographic signature verification.
-    // CRX2 has been deprecated since 2018 and the Chrome Web Store no longer
-    // serves it. Receiving a CRX2 here means either a very old cached copy
-    // or something attempting to bypass the newer signature scheme — refuse
-    // in either case.
-    if (verification.format === 'crx2') {
+    const sigGate = this.gateCrxForInstall(downloadResult.buffer, extensionId, verification.format);
+    if (!sigGate.ok) {
       return {
         success: false,
         extensionId,
@@ -151,21 +148,7 @@ export class CrxDownloader {
         version: '',
         installPath: '',
         signatureVerified: false,
-        error: 'CRX2 format is deprecated and not accepted (no cryptographic verification possible)',
-      };
-    }
-
-    // CRX3: verify the RSA signature and bind to the requested extension ID.
-    const sigResult = verifyCrx3Signature(downloadResult.buffer, extensionId);
-    if (!sigResult.valid) {
-      return {
-        success: false,
-        extensionId,
-        name: '',
-        version: '',
-        installPath: '',
-        signatureVerified: false,
-        error: `CRX3 signature verification failed: ${sigResult.error}`,
+        error: sigGate.error,
       };
     }
     log.info(`🧩 CRX3 signature verified for ${extensionId}`);
@@ -245,6 +228,37 @@ export class CrxDownloader {
       contentScriptPatterns,
       warning,
     };
+  }
+
+  /**
+   * Audit #34 High-3 gate: decide whether a downloaded CRX buffer may be
+   * installed. CRX2 is always rejected (deprecated since 2018, no signatures
+   * we trust). CRX3 must pass RSA signature verification, and its signing key
+   * must derive to the expected extension ID.
+   *
+   * Returns `{ ok: true }` when install should proceed, otherwise
+   * `{ ok: false, error }`. Factored out of `installExtension` so it can be
+   * unit-tested without running the real network download.
+   */
+  gateCrxForInstall(
+    buffer: Buffer,
+    extensionId: string,
+    format: 'crx2' | 'crx3',
+  ): { ok: true } | { ok: false; error: string } {
+    if (format === 'crx2') {
+      return {
+        ok: false,
+        error: 'CRX2 format is deprecated and not accepted (no cryptographic verification possible)',
+      };
+    }
+    const sig = verifyCrx3Signature(buffer, extensionId);
+    if (!sig.valid) {
+      return {
+        ok: false,
+        error: `CRX3 signature verification failed: ${sig.error}`,
+      };
+    }
+    return { ok: true };
   }
 
   /**

--- a/src/extensions/crx-downloader.ts
+++ b/src/extensions/crx-downloader.ts
@@ -5,6 +5,7 @@ import AdmZip from 'adm-zip';
 import { tandemDir, ensureDir } from '../utils/paths';
 import { createLogger } from '../utils/logger';
 import { assertChromeExtensionId, resolvePathWithinRoot } from '../utils/security';
+import { verifyCrx3Signature } from './crx-verifier';
 
 const log = createLogger('CrxDownloader');
 
@@ -137,6 +138,38 @@ export class CrxDownloader {
 
     log.info(`🧩 CRX format verified: ${verification.format}, downloadedFromGoogle=${verification.downloadedFromGoogle}`);
 
+    // Audit #34 High-3: cryptographic signature verification.
+    // CRX2 has been deprecated since 2018 and the Chrome Web Store no longer
+    // serves it. Receiving a CRX2 here means either a very old cached copy
+    // or something attempting to bypass the newer signature scheme — refuse
+    // in either case.
+    if (verification.format === 'crx2') {
+      return {
+        success: false,
+        extensionId,
+        name: '',
+        version: '',
+        installPath: '',
+        signatureVerified: false,
+        error: 'CRX2 format is deprecated and not accepted (no cryptographic verification possible)',
+      };
+    }
+
+    // CRX3: verify the RSA signature and bind to the requested extension ID.
+    const sigResult = verifyCrx3Signature(downloadResult.buffer, extensionId);
+    if (!sigResult.valid) {
+      return {
+        success: false,
+        extensionId,
+        name: '',
+        version: '',
+        installPath: '',
+        signatureVerified: false,
+        error: `CRX3 signature verification failed: ${sigResult.error}`,
+      };
+    }
+    log.info(`🧩 CRX3 signature verified for ${extensionId}`);
+
     // Extract CRX to extension directory
     let installPath: string;
     try {
@@ -202,18 +235,15 @@ export class CrxDownloader {
 
     log.info(`🧩 Extension ${extensionId} installed: ${manifestName} v${manifestVersion}`);
 
-    // CRX3 RSA signature verification not yet implemented — warn user
-    log.warn(`⚠️ Extension ${extensionId} installed WITHOUT cryptographic signature verification. Only install extensions from trusted sources (Chrome Web Store).`);
-
     return {
       success: true,
       extensionId,
       name: manifestName,
       version: manifestVersion,
       installPath,
-      signatureVerified: false,
+      signatureVerified: true,
       contentScriptPatterns,
-      warning: warning || 'Extension signature not verified — installed from Google CDN only',
+      warning,
     };
   }
 

--- a/src/extensions/crx-verifier.ts
+++ b/src/extensions/crx-verifier.ts
@@ -1,0 +1,337 @@
+/**
+ * CRX3 signature verification — addresses audit #34 High-3.
+ *
+ * Downloaded CRX files previously only checked magic bytes ("Cr24") and that
+ * every host in the redirect chain was under *.google.com. That is not a
+ * cryptographic guarantee: a CA compromise, BGP hijack, or CDN compromise
+ * could still deliver a tampered extension under a legitimate certificate.
+ * This module verifies the CRX3 RSA-SHA256 signature embedded in the file
+ * header, and binds the signing public key back to the expected extension ID.
+ *
+ * CRX3 file layout (see Chromium's crx_file.proto for reference):
+ *
+ *   [0..4)   magic bytes "Cr24"
+ *   [4..8)   version = 3 (uint32 LE)
+ *   [8..12)  header_size (uint32 LE) — length of the protobuf header
+ *   [12..12+header_size)
+ *            CrxFileHeader (protobuf, wire format)
+ *              field 2 repeated AsymmetricKeyProof sha256_with_rsa
+ *              field 3 repeated AsymmetricKeyProof sha256_with_ecdsa  (not used here)
+ *              field 10000 bytes signed_header_data (itself a SignedData
+ *                                                    protobuf with field 1 = crx_id)
+ *   [rest]   ZIP payload
+ *
+ * AsymmetricKeyProof { field 1 bytes public_key; field 2 bytes signature }
+ * SignedData         { field 1 bytes crx_id (16 bytes) }
+ *
+ * For each sha256_with_rsa proof, the signed message is:
+ *   "CRX3 SignedData\0" || uint32_le(len(signed_header_data)) ||
+ *   signed_header_data || zip_payload
+ *
+ * Verification requirements to pass:
+ *   1. At least one RSA proof is present.
+ *   2. The first RSA proof's public key (SHA-256, first 16 bytes, a-p alphabet)
+ *      equals the expected extension ID — this binds the CRX to the extension
+ *      we actually asked for.
+ *   3. That same proof's signature verifies over the signed message above.
+ *   4. signed_header_data's crx_id equals the expected extension ID bytes —
+ *      defends against an attacker swapping signed_header_data to point at
+ *      a different extension.
+ *
+ * ECDSA support is intentionally deferred: Google's Chrome Web Store serves
+ * RSA signatures as the primary proof, and adding ECDSA would expand the
+ * trusted-crypto surface without clear benefit. A future PR can extend this
+ * if needed.
+ */
+
+import crypto from 'crypto';
+
+// ─── Types ───────────────────────────────────────────────────────────────
+
+export interface AsymmetricKeyProof {
+  publicKey: Buffer;
+  signature: Buffer;
+}
+
+export interface Crx3Header {
+  rsaProofs: AsymmetricKeyProof[];
+  ecdsaProofs: AsymmetricKeyProof[];
+  signedHeaderData: Buffer;
+}
+
+export interface Crx3VerificationResult {
+  valid: boolean;
+  error?: string;
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────
+
+const CRX3_MAGIC = Buffer.from('Cr24');
+const CRX3_VERSION = 3;
+const CRX3_SIGNED_DATA_PREFIX = Buffer.from('CRX3 SignedData\0', 'binary');
+const CRX_ID_LENGTH = 16;
+
+const FIELD_SHA256_WITH_RSA = 2;
+const FIELD_SHA256_WITH_ECDSA = 3;
+const FIELD_SIGNED_HEADER_DATA = 10000;
+
+const KEY_PROOF_FIELD_PUBLIC_KEY = 1;
+const KEY_PROOF_FIELD_SIGNATURE = 2;
+
+const SIGNED_DATA_FIELD_CRX_ID = 1;
+
+// ─── Protobuf minimal decoder ────────────────────────────────────────────
+
+function readVarint(buf: Buffer, offset: number): { value: number; next: number } {
+  let value = 0;
+  let shift = 0;
+  let idx = offset;
+  // Limit varint length to 10 bytes (max for a 64-bit number). In practice we
+  // never need more than 5 bytes here — field 10000 is the largest tag.
+  while (idx < buf.length && idx < offset + 10) {
+    const byte = buf[idx];
+    value += (byte & 0x7f) * Math.pow(2, shift);
+    idx++;
+    if ((byte & 0x80) === 0) {
+      return { value, next: idx };
+    }
+    shift += 7;
+  }
+  throw new Error('Truncated or oversized varint');
+}
+
+/** Decode a wire-type-2 (length-delimited) field starting at `offset` (after the tag). */
+function readLengthDelimited(buf: Buffer, offset: number): { value: Buffer; next: number } {
+  const { value: len, next: after } = readVarint(buf, offset);
+  if (after + len > buf.length) {
+    throw new Error('Length-delimited field exceeds buffer');
+  }
+  return { value: buf.subarray(after, after + len), next: after + len };
+}
+
+/** Iterate top-level fields in a protobuf message. Only handles wire type 2. */
+function* iterFields(buf: Buffer): Generator<{ fieldNumber: number; value: Buffer }> {
+  let offset = 0;
+  while (offset < buf.length) {
+    const tagRead = readVarint(buf, offset);
+    const tag = tagRead.value;
+    const wireType = tag & 0x7;
+    const fieldNumber = Math.floor(tag / 8);
+    offset = tagRead.next;
+
+    if (wireType !== 2) {
+      // We only care about length-delimited fields. Skip other wire types
+      // defensively — if a future Chrome release adds a new field with a
+      // different wire type, we should not blow up.
+      if (wireType === 0) {
+        // varint
+        offset = readVarint(buf, offset).next;
+      } else if (wireType === 1) {
+        offset += 8; // 64-bit fixed
+      } else if (wireType === 5) {
+        offset += 4; // 32-bit fixed
+      } else {
+        throw new Error(`Unsupported wire type ${wireType}`);
+      }
+      continue;
+    }
+
+    const { value, next } = readLengthDelimited(buf, offset);
+    offset = next;
+    yield { fieldNumber, value };
+  }
+}
+
+function parseKeyProof(buf: Buffer): AsymmetricKeyProof {
+  let publicKey: Buffer | null = null;
+  let signature: Buffer | null = null;
+  for (const { fieldNumber, value } of iterFields(buf)) {
+    if (fieldNumber === KEY_PROOF_FIELD_PUBLIC_KEY) publicKey = Buffer.from(value);
+    else if (fieldNumber === KEY_PROOF_FIELD_SIGNATURE) signature = Buffer.from(value);
+  }
+  if (!publicKey || !signature) {
+    throw new Error('AsymmetricKeyProof missing public_key or signature');
+  }
+  return { publicKey, signature };
+}
+
+function parseCrxId(signedHeaderData: Buffer): Buffer | null {
+  for (const { fieldNumber, value } of iterFields(signedHeaderData)) {
+    if (fieldNumber === SIGNED_DATA_FIELD_CRX_ID) {
+      return Buffer.from(value);
+    }
+  }
+  return null;
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────
+
+/**
+ * Parse the CRX3 envelope. Returns the decoded header and the offset where
+ * the ZIP payload begins. Throws if the buffer is too short, has the wrong
+ * magic, or is not a CRX3.
+ */
+export function parseCrx3Header(buffer: Buffer): { header: Crx3Header; zipStart: number } {
+  if (buffer.length < 12) {
+    throw new Error('CRX too short to contain a header');
+  }
+  if (!buffer.subarray(0, 4).equals(CRX3_MAGIC)) {
+    throw new Error('Invalid CRX magic bytes');
+  }
+  const version = buffer.readUInt32LE(4);
+  if (version !== CRX3_VERSION) {
+    throw new Error(`Unsupported CRX version ${version} — only CRX3 is accepted`);
+  }
+  const headerSize = buffer.readUInt32LE(8);
+  const headerEnd = 12 + headerSize;
+  if (headerEnd > buffer.length) {
+    throw new Error('CRX header_size exceeds buffer length');
+  }
+  const headerBytes = buffer.subarray(12, headerEnd);
+
+  const rsaProofs: AsymmetricKeyProof[] = [];
+  const ecdsaProofs: AsymmetricKeyProof[] = [];
+  let signedHeaderData: Buffer = Buffer.alloc(0);
+
+  for (const { fieldNumber, value } of iterFields(headerBytes)) {
+    if (fieldNumber === FIELD_SHA256_WITH_RSA) {
+      rsaProofs.push(parseKeyProof(value));
+    } else if (fieldNumber === FIELD_SHA256_WITH_ECDSA) {
+      ecdsaProofs.push(parseKeyProof(value));
+    } else if (fieldNumber === FIELD_SIGNED_HEADER_DATA) {
+      signedHeaderData = Buffer.from(value);
+    }
+    // Any other fields are ignored — forwards-compatible.
+  }
+
+  return {
+    header: { rsaProofs, ecdsaProofs, signedHeaderData },
+    zipStart: headerEnd,
+  };
+}
+
+/**
+ * Derive a Chrome-style extension ID from a SPKI-DER public key.
+ * Chrome computes SHA-256 of the public key, takes the first 16 bytes,
+ * and maps each nibble (0-15) to a-p. The result is a 32-character
+ * string in [a-p].
+ */
+export function deriveExtensionIdFromPublicKey(publicKeyDer: Buffer): string {
+  const digest = crypto.createHash('sha256').update(publicKeyDer).digest();
+  const out: string[] = [];
+  for (let i = 0; i < CRX_ID_LENGTH; i++) {
+    const byte = digest[i];
+    out.push(String.fromCharCode(97 + ((byte >> 4) & 0xf)));
+    out.push(String.fromCharCode(97 + (byte & 0xf)));
+  }
+  return out.join('');
+}
+
+function extensionIdToCrxIdBytes(extensionId: string): Buffer {
+  if (extensionId.length !== 32 || !/^[a-p]{32}$/.test(extensionId)) {
+    throw new Error(`Invalid Chrome extension ID: ${extensionId}`);
+  }
+  const out = Buffer.alloc(CRX_ID_LENGTH);
+  for (let i = 0; i < CRX_ID_LENGTH; i++) {
+    const hi = extensionId.charCodeAt(i * 2) - 97;
+    const lo = extensionId.charCodeAt(i * 2 + 1) - 97;
+    out[i] = (hi << 4) | lo;
+  }
+  return out;
+}
+
+function verifyRsaProofSignature(
+  proof: AsymmetricKeyProof,
+  signedHeaderData: Buffer,
+  zipPayload: Buffer,
+): boolean {
+  let publicKeyObject: crypto.KeyObject;
+  try {
+    publicKeyObject = crypto.createPublicKey({
+      key: proof.publicKey,
+      format: 'der',
+      type: 'spki',
+    });
+  } catch {
+    return false;
+  }
+
+  const verifier = crypto.createVerify('sha256');
+  const lenBuf = Buffer.alloc(4);
+  lenBuf.writeUInt32LE(signedHeaderData.length, 0);
+  verifier.update(CRX3_SIGNED_DATA_PREFIX);
+  verifier.update(lenBuf);
+  verifier.update(signedHeaderData);
+  verifier.update(zipPayload);
+  try {
+    return verifier.verify(publicKeyObject, proof.signature);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Verify that `crxBuffer` is a well-formed CRX3 whose RSA signature is
+ * valid and whose signing key corresponds to `expectedExtensionId`. Returns
+ * `{ valid: true }` on success, or `{ valid: false, error }` with a short
+ * diagnostic on any failure.
+ *
+ * This function never throws — parse errors are surfaced as `valid: false`.
+ */
+export function verifyCrx3Signature(
+  crxBuffer: Buffer,
+  expectedExtensionId: string,
+): Crx3VerificationResult {
+  let parsed: ReturnType<typeof parseCrx3Header>;
+  try {
+    parsed = parseCrx3Header(crxBuffer);
+  } catch (err) {
+    return { valid: false, error: err instanceof Error ? err.message : String(err) };
+  }
+  const { header, zipStart } = parsed;
+
+  if (header.rsaProofs.length === 0) {
+    return { valid: false, error: 'CRX3 has no sha256_with_rsa proofs' };
+  }
+
+  // Use the first RSA proof. Chrome's crx_verifier requires additional
+  // proofs (e.g. a Chrome publisher key) for some policies; that hardening
+  // is out of scope for this pass.
+  const proof = header.rsaProofs[0];
+
+  // 1. Derive ID from key and compare with expected — this is what binds
+  //    the download to the extension ID the caller asked for.
+  let derivedId: string;
+  try {
+    derivedId = deriveExtensionIdFromPublicKey(proof.publicKey);
+  } catch (err) {
+    return { valid: false, error: `Failed to derive extension ID: ${err instanceof Error ? err.message : String(err)}` };
+  }
+  if (derivedId !== expectedExtensionId) {
+    return {
+      valid: false,
+      error: `Extension ID mismatch: key yields ${derivedId}, expected ${expectedExtensionId}`,
+    };
+  }
+
+  // 2. Verify the RSA signature over "CRX3 SignedData\0" || len ||
+  //    signed_header_data || zip.
+  const zipPayload = crxBuffer.subarray(zipStart);
+  if (!verifyRsaProofSignature(proof, header.signedHeaderData, zipPayload)) {
+    return { valid: false, error: 'CRX3 RSA signature verification failed' };
+  }
+
+  // 3. Cross-check crx_id inside signed_header_data. A valid signature over
+  //    a SignedData pointing at a different extension ID is still an attack
+  //    (attacker reuses a legit signed blob under a different key claim).
+  const signedCrxId = parseCrxId(header.signedHeaderData);
+  if (!signedCrxId) {
+    return { valid: false, error: 'signed_header_data missing crx_id' };
+  }
+  const expectedCrxIdBytes = extensionIdToCrxIdBytes(expectedExtensionId);
+  if (!signedCrxId.equals(expectedCrxIdBytes)) {
+    return { valid: false, error: 'signed_header_data crx_id does not match expected extension ID' };
+  }
+
+  return { valid: true };
+}

--- a/src/extensions/tests/crx-verifier.test.ts
+++ b/src/extensions/tests/crx-verifier.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import crypto from 'crypto';
+import {
+  parseCrx3Header,
+  deriveExtensionIdFromPublicKey,
+  verifyCrx3Signature,
+} from '../crx-verifier';
+
+// ─── Protobuf wire-format encoder (test helper only) ──────────────────────
+
+function encodeVarint(value: number): Buffer {
+  const bytes: number[] = [];
+  let v = value;
+  while (v > 0x7f) {
+    bytes.push((v & 0x7f) | 0x80);
+    v = Math.floor(v / 128);
+  }
+  bytes.push(v & 0x7f);
+  return Buffer.from(bytes);
+}
+
+function encodeTag(fieldNumber: number, wireType: number): Buffer {
+  return encodeVarint((fieldNumber << 3) | wireType);
+}
+
+function encodeLengthDelimited(fieldNumber: number, payload: Buffer): Buffer {
+  return Buffer.concat([encodeTag(fieldNumber, 2), encodeVarint(payload.length), payload]);
+}
+
+// AsymmetricKeyProof { 1: public_key, 2: signature }
+function encodeKeyProof(publicKey: Buffer, signature: Buffer): Buffer {
+  return Buffer.concat([
+    encodeLengthDelimited(1, publicKey),
+    encodeLengthDelimited(2, signature),
+  ]);
+}
+
+// SignedData { 1: crx_id }
+function encodeSignedData(crxId: Buffer): Buffer {
+  return encodeLengthDelimited(1, crxId);
+}
+
+// ─── CRX3 builder (test helper) ──────────────────────────────────────────
+
+interface BuildOpts {
+  zipPayload: Buffer;
+  crxId: Buffer;              // 16 bytes — derived from first public key
+  privateKey: crypto.KeyObject;
+  publicKeyDer: Buffer;       // SPKI DER encoding
+}
+
+const CRX3_MAGIC = Buffer.from('Cr24');
+const CRX3_VERSION = 3;
+const CRX3_SIGNED_DATA_PREFIX = Buffer.from('CRX3 SignedData\0', 'binary');
+
+function signOver(privateKey: crypto.KeyObject, signedHeaderData: Buffer, zip: Buffer): Buffer {
+  const signer = crypto.createSign('sha256');
+  const lenBuf = Buffer.alloc(4);
+  lenBuf.writeUInt32LE(signedHeaderData.length, 0);
+  signer.update(CRX3_SIGNED_DATA_PREFIX);
+  signer.update(lenBuf);
+  signer.update(signedHeaderData);
+  signer.update(zip);
+  return signer.sign(privateKey);
+}
+
+function buildCrx3(opts: BuildOpts): Buffer {
+  const signedHeaderData = encodeSignedData(opts.crxId);
+  const signature = signOver(opts.privateKey, signedHeaderData, opts.zipPayload);
+  const rsaProof = encodeKeyProof(opts.publicKeyDer, signature);
+  const header = Buffer.concat([
+    encodeLengthDelimited(2, rsaProof),            // field 2: sha256_with_rsa[]
+    encodeLengthDelimited(10000, signedHeaderData), // field 10000: signed_header_data
+  ]);
+
+  const lenBuf = Buffer.alloc(4);
+  lenBuf.writeUInt32LE(header.length, 0);
+  const versionBuf = Buffer.alloc(4);
+  versionBuf.writeUInt32LE(CRX3_VERSION, 0);
+
+  return Buffer.concat([CRX3_MAGIC, versionBuf, lenBuf, header, opts.zipPayload]);
+}
+
+// ─── Fixtures (generated once per file) ──────────────────────────────────
+
+let keyPair: crypto.KeyPairKeyObjectResult;
+let publicKeyDer: Buffer;
+let expectedExtensionId: string;
+const zipPayload = Buffer.from('PK\x03\x04fake-zip-content-for-signing-test', 'binary');
+
+beforeAll(() => {
+  keyPair = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+  publicKeyDer = keyPair.publicKey.export({ type: 'spki', format: 'der' }) as Buffer;
+  // CRX extension ID: sha256 of SPKI public key, take first 16 bytes, map
+  // each nibble (0-15) through the a-p alphabet.
+  const digest = crypto.createHash('sha256').update(publicKeyDer).digest();
+  const first16 = digest.subarray(0, 16);
+  expectedExtensionId = Array.from(first16)
+    .map((b) => {
+      const hi = (b >> 4) & 0xf;
+      const lo = b & 0xf;
+      return String.fromCharCode(97 + hi) + String.fromCharCode(97 + lo);
+    })
+    .join('');
+});
+
+function crxIdBytesFor(extensionId: string): Buffer {
+  // Reverse of the a-p mapping: each character's code - 97 is a nibble.
+  const buf = Buffer.alloc(16);
+  for (let i = 0; i < 16; i++) {
+    const hi = extensionId.charCodeAt(i * 2) - 97;
+    const lo = extensionId.charCodeAt(i * 2 + 1) - 97;
+    buf[i] = (hi << 4) | lo;
+  }
+  return buf;
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────
+
+describe('deriveExtensionIdFromPublicKey()', () => {
+  it('maps a SPKI DER public key to a 32-char a-p extension ID', () => {
+    const id = deriveExtensionIdFromPublicKey(publicKeyDer);
+    expect(id).toBe(expectedExtensionId);
+    expect(id).toMatch(/^[a-p]{32}$/);
+  });
+
+  it('is stable for the same input', () => {
+    const a = deriveExtensionIdFromPublicKey(publicKeyDer);
+    const b = deriveExtensionIdFromPublicKey(publicKeyDer);
+    expect(a).toBe(b);
+  });
+
+  it('differs for different public keys', () => {
+    const other = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const otherDer = other.publicKey.export({ type: 'spki', format: 'der' }) as Buffer;
+    expect(deriveExtensionIdFromPublicKey(publicKeyDer)).not.toBe(deriveExtensionIdFromPublicKey(otherDer));
+  });
+});
+
+describe('parseCrx3Header()', () => {
+  it('extracts RSA proofs and signed_header_data from a well-formed CRX3', () => {
+    const crx = buildCrx3({
+      zipPayload,
+      crxId: crxIdBytesFor(expectedExtensionId),
+      privateKey: keyPair.privateKey,
+      publicKeyDer,
+    });
+
+    const { header, zipStart } = parseCrx3Header(crx);
+
+    expect(header.rsaProofs).toHaveLength(1);
+    expect(header.rsaProofs[0].publicKey.equals(publicKeyDer)).toBe(true);
+    expect(header.signedHeaderData.length).toBeGreaterThan(0);
+    expect(crx.subarray(zipStart).equals(zipPayload)).toBe(true);
+  });
+
+  it('throws on truncated buffer', () => {
+    expect(() => parseCrx3Header(Buffer.alloc(8))).toThrow();
+  });
+
+  it('throws on wrong magic', () => {
+    const buf = Buffer.alloc(100);
+    Buffer.from('XXXX').copy(buf, 0);
+    expect(() => parseCrx3Header(buf)).toThrow(/magic/i);
+  });
+
+  it('throws on non-3 version', () => {
+    const buf = Buffer.alloc(100);
+    CRX3_MAGIC.copy(buf, 0);
+    buf.writeUInt32LE(2, 4); // CRX2
+    buf.writeUInt32LE(0, 8);
+    expect(() => parseCrx3Header(buf)).toThrow(/version/i);
+  });
+});
+
+describe('verifyCrx3Signature()', () => {
+  it('returns valid=true for a correctly-signed CRX that matches the expected ID', () => {
+    const crx = buildCrx3({
+      zipPayload,
+      crxId: crxIdBytesFor(expectedExtensionId),
+      privateKey: keyPair.privateKey,
+      publicKeyDer,
+    });
+
+    const result = verifyCrx3Signature(crx, expectedExtensionId);
+    expect(result).toEqual({ valid: true });
+  });
+
+  it('returns valid=false if the zip payload is tampered after signing', () => {
+    const crx = buildCrx3({
+      zipPayload,
+      crxId: crxIdBytesFor(expectedExtensionId),
+      privateKey: keyPair.privateKey,
+      publicKeyDer,
+    });
+    // Flip one byte deep in the zip region (past the header)
+    const tampered = Buffer.from(crx);
+    tampered[tampered.length - 5] ^= 0xff;
+
+    const result = verifyCrx3Signature(tampered, expectedExtensionId);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/signature/i);
+  });
+
+  it('returns valid=false if the signature bytes are tampered', () => {
+    const crx = buildCrx3({
+      zipPayload,
+      crxId: crxIdBytesFor(expectedExtensionId),
+      privateKey: keyPair.privateKey,
+      publicKeyDer,
+    });
+    // Flip a byte somewhere in the header (where the signature lives)
+    const tampered = Buffer.from(crx);
+    tampered[200] ^= 0xff;
+
+    const result = verifyCrx3Signature(tampered, expectedExtensionId);
+    expect(result.valid).toBe(false);
+  });
+
+  it('returns valid=false when expectedExtensionId does not match key-derived ID', () => {
+    const crx = buildCrx3({
+      zipPayload,
+      crxId: crxIdBytesFor(expectedExtensionId),
+      privateKey: keyPair.privateKey,
+      publicKeyDer,
+    });
+
+    const wrongId = 'a'.repeat(32);
+    const result = verifyCrx3Signature(crx, wrongId);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/extension id/i);
+  });
+
+  it('returns valid=false when signed_header_data crx_id does not match expectedExtensionId', () => {
+    // Key is correct, but SignedData claims a different crx_id. This catches
+    // an attacker substituting the signed header to point at another extension.
+    const wrongCrxId = Buffer.alloc(16, 0xaa);
+    const crx = buildCrx3({
+      zipPayload,
+      crxId: wrongCrxId,
+      privateKey: keyPair.privateKey,
+      publicKeyDer,
+    });
+
+    const result = verifyCrx3Signature(crx, expectedExtensionId);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/crx_id|signed header/i);
+  });
+
+  it('returns valid=false when no RSA proof is present', () => {
+    // Header with only signed_header_data, no sha256_with_rsa list.
+    const signedHeaderData = encodeSignedData(crxIdBytesFor(expectedExtensionId));
+    const header = encodeLengthDelimited(10000, signedHeaderData);
+    const versionBuf = Buffer.alloc(4);
+    versionBuf.writeUInt32LE(CRX3_VERSION, 0);
+    const lenBuf = Buffer.alloc(4);
+    lenBuf.writeUInt32LE(header.length, 0);
+    const crx = Buffer.concat([CRX3_MAGIC, versionBuf, lenBuf, header, zipPayload]);
+
+    const result = verifyCrx3Signature(crx, expectedExtensionId);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/no sha256_with_rsa|no rsa|no signature/i);
+  });
+});

--- a/src/extensions/tests/crx-verifier.test.ts
+++ b/src/extensions/tests/crx-verifier.test.ts
@@ -261,4 +261,119 @@ describe('verifyCrx3Signature()', () => {
     expect(result.valid).toBe(false);
     expect(result.error).toMatch(/no sha256_with_rsa|no rsa|no signature/i);
   });
+
+  it('returns valid=false when signed_header_data is missing entirely', () => {
+    // Header with an RSA proof but no signed_header_data field. parseCrxId
+    // then returns null → verification fails with "missing crx_id".
+    const fakeProof = encodeKeyProof(publicKeyDer, Buffer.alloc(256));
+    const header = encodeLengthDelimited(2, fakeProof);
+    const versionBuf = Buffer.alloc(4);
+    versionBuf.writeUInt32LE(CRX3_VERSION, 0);
+    const lenBuf = Buffer.alloc(4);
+    lenBuf.writeUInt32LE(header.length, 0);
+    const crx = Buffer.concat([CRX3_MAGIC, versionBuf, lenBuf, header, zipPayload]);
+
+    const result = verifyCrx3Signature(crx, expectedExtensionId);
+    expect(result.valid).toBe(false);
+    // Fails earlier (at the sig check), but in any case: not valid.
+  });
+
+  it('returns valid=false — public key is not a valid SPKI DER', () => {
+    // Build a CRX3 whose "public_key" bytes are garbage. createPublicKey
+    // throws inside verifyRsaProofSignature, which should be caught and
+    // turned into { valid: false }.
+    const signedHeaderData = encodeSignedData(crxIdBytesFor(expectedExtensionId));
+    const fakeSignature = Buffer.alloc(256, 1);
+    // derive the "expected id" from the garbage key so the ID-binding check
+    // passes and we actually exercise the signature-verify path
+    const garbageKey = Buffer.from('not a DER key');
+    const garbageId = deriveExtensionIdFromPublicKey(garbageKey);
+    const proof = encodeKeyProof(garbageKey, fakeSignature);
+    const header = Buffer.concat([
+      encodeLengthDelimited(2, proof),
+      encodeLengthDelimited(10000, signedHeaderData),
+    ]);
+    const versionBuf = Buffer.alloc(4);
+    versionBuf.writeUInt32LE(CRX3_VERSION, 0);
+    const lenBuf = Buffer.alloc(4);
+    lenBuf.writeUInt32LE(header.length, 0);
+    const crx = Buffer.concat([CRX3_MAGIC, versionBuf, lenBuf, header, zipPayload]);
+
+    const result = verifyCrx3Signature(crx, garbageId);
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/signature/i);
+  });
+
+  it('handles (skips) ECDSA proofs in field 3 without breaking parsing', () => {
+    // A real Chrome publisher key would use ECDSA; we just need to confirm
+    // the decoder's ECDSA branch doesn't trip over a field-3 entry.
+    const ecdsaProof = encodeKeyProof(Buffer.from('fake-ecdsa-key'), Buffer.from('fake-sig'));
+    const signedHeaderData = encodeSignedData(crxIdBytesFor(expectedExtensionId));
+    const signature = signOver(keyPair.privateKey, signedHeaderData, zipPayload);
+    const rsaProof = encodeKeyProof(publicKeyDer, signature);
+    const header = Buffer.concat([
+      encodeLengthDelimited(2, rsaProof),
+      encodeLengthDelimited(3, ecdsaProof), // field 3 = sha256_with_ecdsa
+      encodeLengthDelimited(10000, signedHeaderData),
+    ]);
+    const versionBuf = Buffer.alloc(4);
+    versionBuf.writeUInt32LE(CRX3_VERSION, 0);
+    const lenBuf = Buffer.alloc(4);
+    lenBuf.writeUInt32LE(header.length, 0);
+    const crx = Buffer.concat([CRX3_MAGIC, versionBuf, lenBuf, header, zipPayload]);
+
+    const { header: parsed } = parseCrx3Header(crx);
+    expect(parsed.rsaProofs).toHaveLength(1);
+    expect(parsed.ecdsaProofs).toHaveLength(1);
+
+    // End-to-end verify still passes because we only check RSA.
+    const result = verifyCrx3Signature(crx, expectedExtensionId);
+    expect(result.valid).toBe(true);
+  });
+
+  it('parseCrx3Header skips forwards-compatible fields of other wire types', () => {
+    // Add a varint field (wire type 0) and a 32-bit fixed field (wire type 5)
+    // with field numbers we don't care about. Parser should skip them.
+    const rsaProof = encodeKeyProof(publicKeyDer, Buffer.alloc(256));
+    const signedHeaderData = encodeSignedData(crxIdBytesFor(expectedExtensionId));
+
+    // Tag for field 42 wire type 0 (varint) = (42<<3)|0 = 336
+    // 336 as varint: 0xd0 0x02
+    const varintField = Buffer.from([0xd0, 0x02, 0x2a]); // field 42 varint = 42
+    // Tag for field 43 wire type 5 (fixed32) = (43<<3)|5 = 349
+    // 349 as varint: 0xdd 0x02
+    const fixed32Field = Buffer.from([0xdd, 0x02, 0x01, 0x02, 0x03, 0x04]);
+
+    const header = Buffer.concat([
+      varintField,
+      encodeLengthDelimited(2, rsaProof),
+      fixed32Field,
+      encodeLengthDelimited(10000, signedHeaderData),
+    ]);
+    const versionBuf = Buffer.alloc(4);
+    versionBuf.writeUInt32LE(CRX3_VERSION, 0);
+    const lenBuf = Buffer.alloc(4);
+    lenBuf.writeUInt32LE(header.length, 0);
+    const crx = Buffer.concat([CRX3_MAGIC, versionBuf, lenBuf, header, zipPayload]);
+
+    const { header: parsed } = parseCrx3Header(crx);
+    expect(parsed.rsaProofs).toHaveLength(1);
+    expect(parsed.signedHeaderData.length).toBeGreaterThan(0);
+  });
+
+  it('throws when CRX header_size claims more bytes than the file contains', () => {
+    const versionBuf = Buffer.alloc(4);
+    versionBuf.writeUInt32LE(CRX3_VERSION, 0);
+    const lenBuf = Buffer.alloc(4);
+    lenBuf.writeUInt32LE(1_000_000, 0); // absurd header size
+    const crx = Buffer.concat([CRX3_MAGIC, versionBuf, lenBuf, Buffer.alloc(10)]);
+    expect(() => parseCrx3Header(crx)).toThrow(/header_size/i);
+  });
+
+  it('verifyCrx3Signature surfaces a parse error as valid=false (never throws)', () => {
+    const tooShort = Buffer.alloc(8);
+    const result = verifyCrx3Signature(tooShort, expectedExtensionId);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
 });

--- a/src/extensions/tests/extensions.test.ts
+++ b/src/extensions/tests/extensions.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterAll, beforeEach, afterEach } from 'vitest';
+import type { KeyObject } from 'crypto';
 import { CrxDownloader } from '../crx-downloader';
 import { ChromeExtensionImporter } from '../chrome-importer';
 import { GALLERY_DEFAULTS } from '../gallery-defaults';
@@ -238,6 +239,116 @@ describe('CRX Header Parsing', () => {
     const result = verifyCrxFormat(crx, false);
     expect(result.valid).toBe(false);
     expect(result.error).toContain('outside Google domains');
+  });
+});
+
+// ─── CRX Install Gate Tests (audit #34 High-3) ───────────────────────────────
+
+describe('CrxDownloader.gateCrxForInstall', () => {
+  const downloader = new CrxDownloader();
+
+  // Build a locally-signed CRX3 using the same helpers as the verifier tests.
+  function encodeVarint(value: number): Buffer {
+    const bytes: number[] = [];
+    let v = value;
+    while (v > 0x7f) { bytes.push((v & 0x7f) | 0x80); v = Math.floor(v / 128); }
+    bytes.push(v & 0x7f);
+    return Buffer.from(bytes);
+  }
+  function encodeTag(fieldNumber: number, wireType: number): Buffer {
+    return encodeVarint((fieldNumber << 3) | wireType);
+  }
+  function encodeLengthDelimited(fieldNumber: number, payload: Buffer): Buffer {
+    return Buffer.concat([encodeTag(fieldNumber, 2), encodeVarint(payload.length), payload]);
+  }
+  function deriveIdFromKey(keyDer: Buffer): string {
+    const crypto = require('crypto');
+    const digest = crypto.createHash('sha256').update(keyDer).digest();
+    const out: string[] = [];
+    for (let i = 0; i < 16; i++) {
+      out.push(String.fromCharCode(97 + ((digest[i] >> 4) & 0xf)));
+      out.push(String.fromCharCode(97 + (digest[i] & 0xf)));
+    }
+    return out.join('');
+  }
+  function crxIdBytes(extensionId: string): Buffer {
+    const out = Buffer.alloc(16);
+    for (let i = 0; i < 16; i++) {
+      out[i] = ((extensionId.charCodeAt(i * 2) - 97) << 4) | (extensionId.charCodeAt(i * 2 + 1) - 97);
+    }
+    return out;
+  }
+  function buildSignedCrx3(extensionId: string, zip: Buffer, privateKey: KeyObject, publicKeyDer: Buffer): Buffer {
+    const crypto = require('crypto');
+    const signedHeaderData = encodeLengthDelimited(1, crxIdBytes(extensionId));
+    const lenBuf = Buffer.alloc(4); lenBuf.writeUInt32LE(signedHeaderData.length, 0);
+    const signer = crypto.createSign('sha256');
+    signer.update(Buffer.from('CRX3 SignedData\0', 'binary'));
+    signer.update(lenBuf);
+    signer.update(signedHeaderData);
+    signer.update(zip);
+    const signature = signer.sign(privateKey);
+    const rsaProof = Buffer.concat([
+      encodeLengthDelimited(1, publicKeyDer),
+      encodeLengthDelimited(2, signature),
+    ]);
+    const header = Buffer.concat([
+      encodeLengthDelimited(2, rsaProof),
+      encodeLengthDelimited(10000, signedHeaderData),
+    ]);
+    const magic = Buffer.from('Cr24');
+    const ver = Buffer.alloc(4); ver.writeUInt32LE(3, 0);
+    const headerLen = Buffer.alloc(4); headerLen.writeUInt32LE(header.length, 0);
+    return Buffer.concat([magic, ver, headerLen, header, zip]);
+  }
+
+  it('rejects CRX2 outright regardless of buffer content', () => {
+    const crx2 = buildCrx2(createTestZip({ name: 'X', version: '1.0' }));
+    const result = downloader.gateCrxForInstall(crx2, 'a'.repeat(32), 'crx2');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/crx2/i);
+      expect(result.error).toMatch(/deprecated/i);
+    }
+  });
+
+  it('rejects CRX3 with an invalid signature', () => {
+    const zip = createTestZip({ name: 'X', version: '1.0' });
+    const crx3WithoutSig = buildCrx3(zip); // fake header, no real signatures
+    const result = downloader.gateCrxForInstall(crx3WithoutSig, 'a'.repeat(32), 'crx3');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/signature verification failed/i);
+    }
+  });
+
+  it('accepts a correctly-signed CRX3 whose key-derived ID matches', () => {
+    const crypto = require('crypto');
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const publicKeyDer = publicKey.export({ type: 'spki', format: 'der' }) as Buffer;
+    const expectedId = deriveIdFromKey(publicKeyDer);
+
+    const zip = createTestZip({ name: 'X', version: '1.0' });
+    const signedCrx = buildSignedCrx3(expectedId, zip, privateKey, publicKeyDer);
+
+    const result = downloader.gateCrxForInstall(signedCrx, expectedId, 'crx3');
+    expect(result.ok).toBe(true);
+  });
+
+  it('rejects a signed CRX3 when expectedExtensionId does not match key', () => {
+    const crypto = require('crypto');
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+    const publicKeyDer = publicKey.export({ type: 'spki', format: 'der' }) as Buffer;
+    const actualId = deriveIdFromKey(publicKeyDer);
+    const zip = createTestZip({ name: 'X', version: '1.0' });
+    const signedCrx = buildSignedCrx3(actualId, zip, privateKey, publicKeyDer);
+
+    const wrongId = 'a'.repeat(32);
+    const result = downloader.gateCrxForInstall(signedCrx, wrongId, 'crx3');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toMatch(/extension id/i);
+    }
   });
 });
 


### PR DESCRIPTION
Addresses **High-3** from @samantha-gb's audit in #34 — the last High-tier item.

## The problem

`src/extensions/crx-downloader.ts` verified downloads by:

1. Magic bytes `Cr24`
2. CRX version (2 or 3)
3. Every host in the redirect chain under `*.google.com` / `*.googleapis.com`

None of that is a cryptographic guarantee. A CA compromise, BGP hijack, or compromised Google CDN could deliver a tampered extension under a valid certificate and Tandem would install it. Line 206 of the old code explicitly logged a warning that RSA verification was *"not yet implemented"*. This PR implements it.

## The fix

### New module — `src/extensions/crx-verifier.ts`

- `parseCrx3Header(buffer)` — minimal hand-rolled protobuf wire-format decoder for the CRX3 envelope (`sha256_with_rsa`, `sha256_with_ecdsa`, `signed_header_data`). ~80 LOC, no new dependency.
- `deriveExtensionIdFromPublicKey(pubkey)` — `SHA256(SPKI DER)[:16]` → a-p alphabet (same mapping Chrome uses internally).
- `verifyCrx3Signature(buffer, expectedId)` — parses, verifies, returns `{ valid, error? }`. Never throws.

The signed message is the well-specified:
```
"CRX3 SignedData\0" || uint32_le(len(signed_header_data)) || signed_header_data || zip_payload
```

### Verification passes only if all four hold

1. At least one `sha256_with_rsa` proof is present
2. The first proof's public key hashes to the **expected extension ID** (binds the download to the extension the caller asked for)
3. That proof's signature verifies against the signed message via Node's `crypto.createVerify('sha256')`
4. `signed_header_data.crx_id` matches the expected extension ID bytes — defends against an attacker swapping `SignedData` to point at another extension

### Integration — `src/extensions/crx-downloader.ts`

- **CRX2 is now rejected outright.** Chrome Web Store hasn't served CRX2 since 2018; receiving one is stale or suspicious, and we have no signature mechanism for it.
- **CRX3 runs through `verifyCrx3Signature`** after the format check. Failure aborts install with a clear error.
- `InstallResult.signatureVerified` is now `true` on success (was hardcoded `false`). The fallback warning about "installed WITHOUT cryptographic signature verification" is removed.

## Scope / not in scope

**In:**
- RSA-SHA256 signature verification
- Key → extension ID binding
- `crx_id` cross-check in signed header
- CRX2 reject

**Out (deferred):**
- ECDSA proofs — Chrome Web Store signs with RSA as the primary proof; adding ECDSA expands the trusted-crypto surface without current benefit
- Chromium's `REQUIRE_PUBLISHER_KEY` hardening (verifying a well-known Chrome publisher key) — separate PR

## Tests

**13 new unit tests** in `src/extensions/tests/crx-verifier.test.ts`:

- `deriveExtensionIdFromPublicKey`: stable, differs per key, correct `[a-p]{32}` shape
- `parseCrx3Header`: happy path; rejects truncated buffer, wrong magic, non-3 version
- `verifyCrx3Signature`:
  - ✅ happy path — valid signed CRX + matching expected ID
  - ❌ zip tampered after signing
  - ❌ signature byte flipped
  - ❌ expectedExtensionId doesn't match key-derived ID
  - ❌ `signed_header_data.crx_id` swapped to a different extension
  - ❌ no RSA proof present

Fixtures generate a real 2048-bit RSA key (`crypto.generateKeyPairSync`), encode a valid CRX3 buffer via a local protobuf encoder, and exercise both positive and negative paths through the real `crypto.verify` path — no mocks in the crypto layer.

## Verification

- `npm run verify`: compile ✓, lint ✓, check-consistency ✓
- **2655 tests passed** (+13), 39 skipped, 1 pre-existing jsdom env error (unrelated)
- Local Tandem boot from this branch: clean, navigate sanity passes, no CRX-related errors in startup logs

## Backward compatibility

- Existing installed extensions at `~/.tandem/extensions/` are loaded by `ExtensionLoader` (separate code path) — **not affected**
- New installs via `installFromCws` / `installExtension` now require a valid signature. This is intentional; the old silent path was the bug
- If a CRX2 arrives (shouldn't happen from CWS anymore) install refuses with a clear error

## Stealth implication

None — extension install pipeline is not observable by web pages.

## #34 status after this PR

All **five** High-tier findings addressed (High-1 #161, High-2 #159, High-3 here, High-4 #162, High-5 #159). Remaining: Medium tier (7 items) and Low tier (3 items) — follow-up PRs.

---

Credit to @samantha-gb for the original audit. `Co-authored-by:` trailer on the commit adds her to the contributor graph for this change.