### PR TITLE
fix(security): gate agent-initiated injection overrides behind user approval (audit #34 Medium #3)

### DIFF
--- a/src/api/routes/misc.ts
+++ b/src/api/routes/misc.ts
@@ -8,6 +8,7 @@ import { getPasswordManager } from '../../passwords/manager';
 import { tandemDir } from '../../utils/paths';
 import { handleRouteError } from '../../utils/errors';
 import { isSafeNavigationUrl } from '../../utils/security';
+import { addInjectionOverride } from '../middleware/injection-scanner';
 import { createRateLimitMiddleware } from '../rate-limit';
 import { getActorContext, normalizeTabSource } from '../../tabs/context';
 import { buildOwnershipContextForTab } from '../../tabs/runtime-context';
@@ -72,15 +73,56 @@ export function registerMiscRoutes(router: Router, ctx: RouteContext): void {
   });
 
   // ═══ Injection Override ═══
-  router.post('/security/injection-override', (req: Request, res: Response) => {
+  // Audit #34 Medium #3: the injection scanner's 5-minute override is a
+  // security-weakening action — it silences the prompt-injection blocker for
+  // a domain. The *shell* already shows a double-confirmation modal before
+  // calling this route (see src/api/middleware/injection-scanner.ts), so
+  // shell-initiated calls pass through unchanged. Any other caller (MCP
+  // tool, agent HTTP client, extension) must go through an interactive user
+  // approval via taskManager.requestApproval — same pattern as the
+  // guardian-mode gate in #161.
+  //
+  // "Shell-initiated" = Origin header starts with file:// or is "null".
+  // Both correspond to the Electron shell's webContents origin (the
+  // injection-scanner's override script runs inside that context). Node.js
+  // fetch (MCP api-client) does not set Origin, so MCP calls never spoof
+  // their way past this gate. A caller that has the API token AND can set
+  // arbitrary headers is already a trusted team member by definition.
+  router.post('/security/injection-override', async (req: Request, res: Response) => {
     try {
       const { domain } = req.body;
       if (!domain || typeof domain !== 'string') {
         res.status(400).json({ error: 'domain required' });
         return;
       }
-      // Import the override map from the middleware
-      const { addInjectionOverride } = require('../middleware/injection-scanner');
+
+      const origin = typeof req.headers.origin === 'string' ? req.headers.origin : '';
+      const isShellInitiated = origin.startsWith('file://') || origin === 'null';
+
+      if (!isShellInitiated) {
+        const description = `Silence prompt-injection scanner for ${domain} for 5 minutes`;
+        const task = ctx.taskManager.createTask(
+          description,
+          'claude',
+          'claude',
+          [{
+            description,
+            action: { type: 'security_weaken', params: { domain } },
+            riskLevel: 'high',
+            requiresApproval: true,
+          }],
+        );
+        const approved = await ctx.taskManager.requestApproval(task, 0);
+        if (!approved) {
+          res.status(403).json({
+            error: 'User rejected injection-override request',
+            rejected: true,
+            domain,
+          });
+          return;
+        }
+      }
+
       addInjectionOverride(domain);
       res.json({ ok: true, domain, expiresIn: '5 minutes' });
     } catch (e) {

--- a/src/api/tests/routes/misc.test.ts
+++ b/src/api/tests/routes/misc.test.ts
@@ -163,6 +163,81 @@ describe('misc routes', () => {
   });
 
   // ═══════════════════════════════════════════════
+  // INJECTION OVERRIDE — audit #34 Medium #3
+  // ═══════════════════════════════════════════════
+
+  describe('POST /security/injection-override', () => {
+    it('returns 400 when domain is missing — no approval task created', async () => {
+      const res = await request(app)
+        .post('/security/injection-override')
+        .send({});
+      expect(res.status).toBe(400);
+      expect(ctx.taskManager.requestApproval).not.toHaveBeenCalled();
+    });
+
+    it('shell-initiated call (Origin: file://...) passes through without approval', async () => {
+      const res = await request(app)
+        .post('/security/injection-override')
+        .set('Origin', 'file:///')
+        .send({ domain: 'example.com' });
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ ok: true, domain: 'example.com' });
+      expect(ctx.taskManager.requestApproval).not.toHaveBeenCalled();
+    });
+
+    it('shell-initiated call with Origin: null also passes through (Electron edge case)', async () => {
+      const res = await request(app)
+        .post('/security/injection-override')
+        .set('Origin', 'null')
+        .send({ domain: 'example.com' });
+      expect(res.status).toBe(200);
+      expect(ctx.taskManager.requestApproval).not.toHaveBeenCalled();
+    });
+
+    it('agent/MCP call (no Origin) requires approval — approved path', async () => {
+      vi.mocked(ctx.taskManager.requestApproval).mockResolvedValue(true);
+      const res = await request(app)
+        .post('/security/injection-override')
+        .send({ domain: 'malicious.example' });
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ ok: true, domain: 'malicious.example' });
+      expect(ctx.taskManager.requestApproval).toHaveBeenCalledTimes(1);
+      expect(ctx.taskManager.createTask).toHaveBeenCalled();
+    });
+
+    it('agent/MCP call (no Origin) — rejected returns 403 and never records the override', async () => {
+      vi.mocked(ctx.taskManager.requestApproval).mockResolvedValue(false);
+      const res = await request(app)
+        .post('/security/injection-override')
+        .send({ domain: 'malicious.example' });
+      expect(res.status).toBe(403);
+      expect(res.body.rejected).toBe(true);
+    });
+
+    it('call with a non-shell Origin (e.g. https://some-site) requires approval', async () => {
+      vi.mocked(ctx.taskManager.requestApproval).mockResolvedValue(true);
+      const res = await request(app)
+        .post('/security/injection-override')
+        .set('Origin', 'https://attacker.example')
+        .send({ domain: 'malicious.example' });
+      expect(res.status).toBe(200);
+      expect(ctx.taskManager.requestApproval).toHaveBeenCalled();
+    });
+
+    it('approval task created for agent calls has riskLevel high and requiresApproval', async () => {
+      vi.mocked(ctx.taskManager.requestApproval).mockResolvedValue(true);
+      await request(app)
+        .post('/security/injection-override')
+        .send({ domain: 'example.com' });
+      expect(ctx.taskManager.createTask).toHaveBeenCalled();
+      const createTaskCall = vi.mocked(ctx.taskManager.createTask).mock.calls[0];
+      const steps = createTaskCall[3] as Array<{ riskLevel: string; requiresApproval: boolean }>;
+      expect(steps[0].riskLevel).toBe('high');
+      expect(steps[0].requiresApproval).toBe(true);
+    });
+  });
+
+  // ═══════════════════════════════════════════════
   // ACTIVE TAB CONTEXT
   // ═══════════════════════════════════════════════
 


### PR DESCRIPTION
Addresses **Medium #3** from @samantha-gb's audit in #34.

## The problem

`POST /security/injection-override` silences the prompt-injection scanner for a domain for 5 minutes. The shell-initiated path already has the correct UX (double-confirmation modal inside the scanner warning). The **agent/MCP path has no gate** — exact same shape as the guardian-mode / trust / whitelist problem that #161 solved.

A prompt-injected AI could disable the scanner for the attacker's own domain:

\`\`\`
Malicious page  →  AI reads injection  →  AI under attacker control
  →  AI calls /security/injection-override for attacker's domain
  →  scanner is silent for 5 minutes  →  attacker extracts whatever
\`\`\`

This is precisely the threat Tandem's 8-layer shield exists to block.

## The fix

Same interactive-approval pattern as #161, scoped carefully to preserve shell UX:

- **Shell-initiated** (\`Origin: file://...\` or \`Origin: null\`) → pass through unchanged. The shell's injection-scanner modal already shows the user an explicit double-confirmation before calling this route; adding another modal would be redundant.
- **Agent/MCP/other** (no Origin, or non-file Origin) → \`taskManager.requestApproval\` with \`riskLevel: 'high'\`. Approved → 200 + override applied. Rejected → 403 \`{ rejected: true }\` and the override is never recorded.

### Why \`Origin\` is the right signal

- MCP's \`api-client\` uses Node.js \`fetch\`, which does **not** auto-set \`Origin\`.
- The shell uses the browser's \`fetch\`, which **does** set \`Origin: file://...\` (or sometimes \`null\` in older Electron code paths).
- Web content trying to reach Tandem (e.g. via sandboxed iframe) would set its own origin, which we gate.
- A caller that has the API token AND can set arbitrary headers is already a trusted team member by Tandem's design (the perimeter is between web content and the team, not between team members).

### Minor cleanup

Replaced a runtime \`require('../middleware/injection-scanner')\` with a static ESM import — the runtime require failed under Vitest path resolution. No behavior change.

## Live verification in running Tandem

- **Shell path** (\`Origin: file://\`): 200 instant, no modal.
- **Agent path** (no Origin): Wingman Activity panel shows an "Approval needed: Silence prompt-injection scanner for <domain> for 5 minutes" handoff with Approve/Reject buttons.
- Clicking **Reject** → \`curl\` returns \`403 { rejected: true }\`, override **not** applied.
- Clicking **Approve** would return 200 with the override applied (covered by unit tests).

## Breaking-change review — AI agent autonomy preserved

The MCP tool \`tandem_injection_override\` still works. The only change is that the user is asked to confirm, just like for \`/security/guardian/mode\` (#161) and \`/execute-js/confirm\`. Per Tandem's design principle ("explicit handoffs when the human needs to step in"), this **is** one of those handoff moments — silencing a defense that exists specifically because the AI can be tricked by web content.

The shell-initiated path (where the user has already explicitly approved in the in-tab modal) is unchanged.

## Tests

7 new unit tests in \`src/api/tests/routes/misc.test.ts\`:
- 400 on missing domain — no approval task created
- shell-initiated \`file://\` → pass-through
- shell-initiated \`null\` origin → pass-through (Electron edge case)
- agent-initiated, approved → 200 with override
- agent-initiated, rejected → 403 \`{ rejected: true }\`
- non-shell \`Origin\` (https://…) → still gated
- approval task shape: \`riskLevel: 'high'\` + \`requiresApproval\`

Full verify clean: **2672 passed** (+7), 39 skipped, 1 pre-existing jsdom env error (unrelated), lint ✓, compile ✓, check-consistency ✓.

## Stealth implication

None — this is internal API logic, not observable by web pages.

## #34 status after this PR

Items addressed so far from @samantha-gb's audit: Critical, High-1..5 (#159, #161, #162, #163), Medium #3 (this PR), SSRF and stealth seed (#159).

Truly-remaining web→team items under further investigation:

- CORS \`null\` origin hardening — needs Electron shell-fetch behavior test
- \`Date.now()\` jitter vs TOTP — low priority

The remaining Medium/Low items from the audit have been re-evaluated against Tandem's trust model (the security perimeter sits between web content and the team, not between team members) and many of them don't apply under that model. Happy to discuss any specific item in a follow-up comment.

---

Credit to @samantha-gb. \`Co-authored-by:\` trailer on the commit.