### PR TITLE
fix(security): reject CORS Origin: null + fix #164 shell-detection regression (audit #34 Medium #1)

### DIFF
--- a/src/api/middleware/injection-scanner.ts
+++ b/src/api/middleware/injection-scanner.ts
@@ -252,7 +252,16 @@ export function injectionScannerMiddleware(req: Request, res: Response, next: Ne
                         const token = window.__TANDEM_TOKEN__ || '';
                         await fetch('http://localhost:8765/security/injection-override', {
                           method: 'POST',
-                          headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token },
+                          headers: {
+                            'Content-Type': 'application/json',
+                            'Authorization': 'Bearer ' + token,
+                            // Marks this call as originating from the shell's
+                            // post-confirmation "Override" button. The route
+                            // handler trusts this header to skip the second
+                            // approval modal. See src/api/routes/misc.ts —
+                            // audit #34 Medium #3 and the header-based fix.
+                            'X-Tandem-Shell-Initiated': '1',
+                          },
                           body: JSON.stringify({ domain: '${domain}' }),
                         });
                         modal.innerHTML = '<div style="text-align:center;padding:20px;"><span style="font-size:24px;">✅</span><div style="margin-top:8px;">Override granted for 5 minutes.<br>Retry your request.</div></div>';

--- a/src/api/routes/misc.ts
+++ b/src/api/routes/misc.ts
@@ -82,12 +82,18 @@ export function registerMiscRoutes(router: Router, ctx: RouteContext): void {
   // approval via taskManager.requestApproval — same pattern as the
   // guardian-mode gate in #161.
   //
-  // "Shell-initiated" = Origin header starts with file:// or is "null".
-  // Both correspond to the Electron shell's webContents origin (the
-  // injection-scanner's override script runs inside that context). Node.js
-  // fetch (MCP api-client) does not set Origin, so MCP calls never spoof
-  // their way past this gate. A caller that has the API token AND can set
-  // arbitrary headers is already a trusted team member by definition.
+  // Shell-initiated calls mark themselves with `X-Tandem-Shell-Initiated: 1`.
+  // An earlier version of this gate (#164) checked the Origin header, but
+  // live investigation showed that modern Electron strips Origin on
+  // file:// → http://localhost cross-origin fetches, so Origin is absent
+  // for the shell. The dedicated header is explicit and doesn't depend on
+  // Electron version.
+  //
+  // No MCP tool grants agents the ability to set arbitrary HTTP headers,
+  // so a prompt-injected agent cannot spoof this header through the
+  // normal tool surface. Within Tandem's trust model the header is a
+  // sufficient signal — the perimeter sits between web content and the
+  // team, not between team members.
   router.post('/security/injection-override', async (req: Request, res: Response) => {
     try {
       const { domain } = req.body;
@@ -96,8 +102,8 @@ export function registerMiscRoutes(router: Router, ctx: RouteContext): void {
         return;
       }
 
-      const origin = typeof req.headers.origin === 'string' ? req.headers.origin : '';
-      const isShellInitiated = origin.startsWith('file://') || origin === 'null';
+      const shellMarker = req.headers['x-tandem-shell-initiated'];
+      const isShellInitiated = shellMarker === '1' || shellMarker === 'true';
 
       if (!isShellInitiated) {
         const description = `Silence prompt-injection scanner for ${domain} for 5 minutes`;

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -123,19 +123,21 @@ export class TandemAPI {
     this.app = express();
     this.app.use(cors({
       origin: (origin, callback) => {
-        // Allow requests with no origin (curl, server-to-server)
+        // Allow requests with no origin (curl, MCP Node.js fetch, Electron
+        // shell — modern Electron strips Origin on file:// → http://localhost
+        // cross-origin fetches, so this is the shell's normal case).
         if (!origin) return callback(null, true);
-        // Allow file:// protocol (Electron shell + webview pages)
-        // Note: Electron may send 'file://', 'file:///', or 'file:///full/path'
+        // Allow file:// protocol — some Electron versions do send this.
+        // Note: may appear as 'file://', 'file:///', or 'file:///full/path'.
         if (origin.startsWith('file://')) return callback(null, true);
-        // Allow "null" origin — some Electron contexts send this for file:// → http:// fetches
-        if (origin === 'null') return callback(null, true);
         // Allow installed extensions to call their narrow helper routes.
         if (this.isTrustedExtensionOrigin(origin)) return callback(null, true);
-        // Block everything else
+        // Reject everything else. Origin: "null" in particular is the
+        // attacker-reachable case (data: URIs, sandbox=""  iframes) and
+        // must not reach public routes — see audit #34 Medium #1.
         callback(new Error('CORS not allowed'));
       },
-      allowedHeaders: ['Authorization', 'Content-Type', 'X-Session', 'X-Tab-Id', 'X-Tandem-Extension-Id', 'Mcp-Session-Id'],
+      allowedHeaders: ['Authorization', 'Content-Type', 'X-Session', 'X-Tab-Id', 'X-Tandem-Extension-Id', 'X-Tandem-Shell-Initiated', 'Mcp-Session-Id'],
       exposedHeaders: ['Mcp-Session-Id'],
     }));
     this.app.use(express.json({ limit: '50mb' }));

--- a/src/api/tests/routes/misc.test.ts
+++ b/src/api/tests/routes/misc.test.ts
@@ -175,26 +175,26 @@ describe('misc routes', () => {
       expect(ctx.taskManager.requestApproval).not.toHaveBeenCalled();
     });
 
-    it('shell-initiated call (Origin: file://...) passes through without approval', async () => {
+    it('shell-initiated call (X-Tandem-Shell-Initiated: 1) passes through without approval', async () => {
       const res = await request(app)
         .post('/security/injection-override')
-        .set('Origin', 'file:///')
+        .set('X-Tandem-Shell-Initiated', '1')
         .send({ domain: 'example.com' });
       expect(res.status).toBe(200);
       expect(res.body).toMatchObject({ ok: true, domain: 'example.com' });
       expect(ctx.taskManager.requestApproval).not.toHaveBeenCalled();
     });
 
-    it('shell-initiated call with Origin: null also passes through (Electron edge case)', async () => {
+    it('shell-initiated header value "true" also passes through', async () => {
       const res = await request(app)
         .post('/security/injection-override')
-        .set('Origin', 'null')
+        .set('X-Tandem-Shell-Initiated', 'true')
         .send({ domain: 'example.com' });
       expect(res.status).toBe(200);
       expect(ctx.taskManager.requestApproval).not.toHaveBeenCalled();
     });
 
-    it('agent/MCP call (no Origin) requires approval — approved path', async () => {
+    it('call without the shell marker (MCP/agent) requires approval — approved path', async () => {
       vi.mocked(ctx.taskManager.requestApproval).mockResolvedValue(true);
       const res = await request(app)
         .post('/security/injection-override')
@@ -205,7 +205,7 @@ describe('misc routes', () => {
       expect(ctx.taskManager.createTask).toHaveBeenCalled();
     });
 
-    it('agent/MCP call (no Origin) — rejected returns 403 and never records the override', async () => {
+    it('call without the shell marker — rejected returns 403 and never records the override', async () => {
       vi.mocked(ctx.taskManager.requestApproval).mockResolvedValue(false);
       const res = await request(app)
         .post('/security/injection-override')
@@ -214,17 +214,31 @@ describe('misc routes', () => {
       expect(res.body.rejected).toBe(true);
     });
 
-    it('call with a non-shell Origin (e.g. https://some-site) requires approval', async () => {
+    it('Origin header alone no longer bypasses the gate (regression guard for the #164 heuristic)', async () => {
+      // Before the live investigation we keyed the gate off Origin: file:// /
+      // null. Modern Electron strips Origin on file:// → http://localhost
+      // fetches so that heuristic was both unreliable for the real shell
+      // and easy to spoof from a web-side caller setting Origin.
       vi.mocked(ctx.taskManager.requestApproval).mockResolvedValue(true);
       const res = await request(app)
         .post('/security/injection-override')
-        .set('Origin', 'https://attacker.example')
+        .set('Origin', 'file:///')
         .send({ domain: 'malicious.example' });
       expect(res.status).toBe(200);
       expect(ctx.taskManager.requestApproval).toHaveBeenCalled();
     });
 
-    it('approval task created for agent calls has riskLevel high and requiresApproval', async () => {
+    it('arbitrary header values other than 1/true do not count as shell-initiated', async () => {
+      vi.mocked(ctx.taskManager.requestApproval).mockResolvedValue(true);
+      const res = await request(app)
+        .post('/security/injection-override')
+        .set('X-Tandem-Shell-Initiated', 'yes')
+        .send({ domain: 'malicious.example' });
+      expect(res.status).toBe(200);
+      expect(ctx.taskManager.requestApproval).toHaveBeenCalled();
+    });
+
+    it('approval task for agent calls has riskLevel high and requiresApproval', async () => {
       vi.mocked(ctx.taskManager.requestApproval).mockResolvedValue(true);
       await request(app)
         .post('/security/injection-override')

--- a/src/api/tests/server-auth.test.ts
+++ b/src/api/tests/server-auth.test.ts
@@ -137,3 +137,60 @@ describe('TandemAPI extension auth', () => {
     expect(decision.reason).toContain('does not match requested extension');
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────
+// CORS origin policy — audit #34 Medium #1
+// ─────────────────────────────────────────────────────────────────────
+
+describe('TandemAPI CORS policy', () => {
+  function buildApi() {
+    const ctx = createMockContext();
+    const api = new TandemAPI({ win: ctx.win as any, registry: ctx as any });
+    const app = (api as unknown as { app: Application }).app;
+    return { app, ctx };
+  }
+
+  it('allows requests with no Origin header (shell, MCP, curl)', async () => {
+    const { app } = buildApi();
+    // /status is public so we don't need a token.
+    const res = await request(app).get('/status');
+    // CORS error would surface as 500 with "CORS not allowed"; we just need
+    // to see the request got past the CORS middleware and hit the route.
+    expect(res.status).not.toBe(500);
+  });
+
+  it('allows file:// origins (Electron shell)', async () => {
+    const { app } = buildApi();
+    const res = await request(app).get('/status').set('Origin', 'file:///Users/x/shell/index.html');
+    expect(res.status).not.toBe(500);
+  });
+
+  it('rejects Origin: null (sandboxed iframes, data: URIs — audit #34 Medium #1)', async () => {
+    const { app } = buildApi();
+    const res = await request(app).get('/status').set('Origin', 'null');
+    // cors middleware turns the error into a 500. The body varies by express
+    // version; the important contract is "did not get the public /status
+    // payload".
+    expect(res.status).toBe(500);
+    expect(res.body).not.toHaveProperty('ready');
+  });
+
+  it('rejects arbitrary http:// origins from random web pages', async () => {
+    const { app } = buildApi();
+    const res = await request(app).get('/status').set('Origin', 'https://evil.example');
+    expect(res.status).toBe(500);
+    expect(res.body).not.toHaveProperty('ready');
+  });
+
+  it('allows the X-Tandem-Shell-Initiated header in CORS preflight', async () => {
+    const { app } = buildApi();
+    const res = await request(app)
+      .options('/security/injection-override')
+      .set('Origin', 'file:///')
+      .set('Access-Control-Request-Method', 'POST')
+      .set('Access-Control-Request-Headers', 'X-Tandem-Shell-Initiated, Authorization, Content-Type');
+    expect(res.status).toBeLessThan(400);
+    const allowed = String(res.headers['access-control-allow-headers'] || '').toLowerCase();
+    expect(allowed).toContain('x-tandem-shell-initiated');
+  });
+});


### PR DESCRIPTION
Closes **Medium #1** from @samantha-gb's audit in #34, and fixes a regression introduced in #164.

## Two related fixes

They share the same code path and one implies the other, so they go together.

### 1. CORS now rejects Origin: null

The old policy allowed `Origin: null` because the comment said some Electron contexts send it for file:// → http:// fetches. Live investigation (logging every request's Origin header during normal shell use) showed the **opposite**:

- Modern Electron **strips** the Origin header entirely on file:// → http://localhost cross-origin fetches.
- Every real shell fetch arrives with **no Origin** at all, not `Origin: null`.

So the null branch was dead code for legitimate callers — but still reachable for malicious web content. Sandboxed iframes (\`sandbox=""\`) and \`data:\` URIs send \`Origin: null\`. A malicious page rendered in any Tandem tab could \`<iframe sandbox>\`-in a script that fetches \`http://localhost:8765/status\` and read the user's active-tab URL/title — no token needed, \`/status\` is public.

Closing the null-origin hole removes that cross-tab leak. Random \`https://…\` origins are also explicitly rejected now (they already were in practice; the comment makes the policy clear).

### 2. Fix the #164 shell-detection regression

#164 gated \`/security/injection-override\` behind an approval flow, using \`Origin: file://\` / \`Origin: null\` to detect the shell. The live investigation above shows the shell sends **neither** — Origin is stripped. So the real shell's "Override" button was falling through into the approval-required branch, producing a **second modal** (Wingman Activity / Chat) on top of the existing scanner "Are you absolutely sure?" modal. Double-modal UX.

Replace the Origin heuristic with an explicit header: \`X-Tandem-Shell-Initiated: 1\`. The shell's injection-scanner override script now sets this header. The route handler treats \`"1"\` or \`"true"\` as "skip approval, the shell already confirmed"; anything else goes through \`taskManager.requestApproval\` as before.

Under Tandem's trust model (the security perimeter sits between web content and the team, not between team members) the header is a sufficient signal: no MCP tool grants agents the ability to set arbitrary HTTP headers, so a prompt-injected agent cannot spoof it through the normal tool surface. Documented inline so future readers don't re-investigate.

Added \`X-Tandem-Shell-Initiated\` to the \`allowedHeaders\` list so the browser's CORS preflight permits it.

## Live verification in running Tandem

- Shell fetches across sidebar / bookmarks / config / handoffs / workspaces / status: all logged with **no Origin header**, all pass.
- Agent-path call (no marker) → single approval card in Wingman. Clicked "Afwijzen" → HTTP \`403 { rejected: true, domain: "real-agent-path.example" }\`, override not applied.
- \`curl -H "Origin: null" http://127.0.0.1:8765/status\` → "CORS not allowed", public \`/status\` body not served.
- \`curl -H "Origin: https://evil.example" …\` → same rejection.
- \`curl\` with no Origin → \`/status\` body served normally (MCP, shell, local tooling still work).

## Tests

11 new tests total across two suites:

**\`src/api/tests/routes/misc.test.ts\`** (injection-override route):
- Shell marker \`"1"\` / \`"true"\` → pass-through, no approval
- No marker (MCP/agent) → approval required, approved=200 / rejected=403
- Bare \`Origin: file://\` no longer bypasses approval (regression guard for #164)
- Arbitrary shell-marker values (e.g. \`"yes"\`) do not count
- Approval task shape preserved (\`riskLevel: 'high'\`, \`requiresApproval: true\`)

**\`src/api/tests/server-auth.test.ts\`** (CORS integration):
- No-Origin and \`file://\` origins allowed
- \`Origin: null\` rejected
- Arbitrary \`https://…\` origins rejected
- \`X-Tandem-Shell-Initiated\` in the CORS preflight allow-list

Full verify clean: **2678 passed** (+6 net new; some #164 tests were rewritten), 39 skipped, 1 pre-existing jsdom env error (unrelated), lint ✓, compile ✓, check-consistency ✓.

## Breaking-change review — AI agent autonomy preserved

- MCP \`apiCall\` uses Node.js fetch → no Origin set → CORS allows (unchanged).
- Shell fetches → no Origin (Electron strips it) → CORS allows (unchanged).
- Trusted extensions → unchanged.
- Only NEW thing blocked: \`Origin: null\` (sandboxed iframes / data: URIs) and arbitrary http(s):// origins. Neither is a legitimate Tandem caller.

MCP tool \`tandem_injection_override\` still works — it now triggers a single user approval modal, matching how the shell already handles this action.

## Known follow-up (out of scope)

While testing the agent-path I noticed a UX bug: when the user clicks Approve/Reject in one Wingman panel (Activity tab), the other panel (Chat tab) still shows the pending card until the user refreshes. The approval is recorded correctly server-side — only the UI is out of sync. This is pre-existing and unrelated to this PR; tracking it separately.

## #34 status after this PR

Addressed so far: Critical, High-1..5 (#159, #161, #162, #163), Medium #3 (#164), Medium #1 (this PR), SSRF + stealth seed (#159).

Remaining truly-web→team item: \`Date.now()\` jitter vs TOTP (Low #4, low priority). The other Medium/Low items fall on the team-side of Tandem's trust perimeter and are not vulnerabilities under the current threat model.

---

Credit to @samantha-gb. \`Co-authored-by:\` trailer on the commit.