### PR TITLE
fix(wingman): sync approval cards across Activity and Chat panels

### DIFF
--- a/shell/js/wingman/index.js
+++ b/shell/js/wingman/index.js
@@ -598,6 +598,27 @@
         });
       }
 
+      // Mirror: when the approval is resolved via ANY other path (Activity
+      // panel approve/reject, API route auto-resolve, etc.), the inline
+      // Chat card for the same requestId must dismiss itself so the two
+      // Wingman surfaces stay in sync. Without this, a user rejecting via
+      // Activity still saw the "Wingman wants to perform an action" card
+      // in Chat until they clicked it there too.
+      if (window.tandem && window.tandem.onApprovalResponse) {
+        window.tandem.onApprovalResponse((data) => {
+          if (!approvalContainer || !data || !data.requestId) return;
+          const card = approvalContainer.querySelector(
+            `.approval-card[data-request-id="${data.requestId}"]`,
+          );
+          if (card) {
+            card.remove();
+            if (approvalContainer.children.length === 0) {
+              approvalContainer.style.display = 'none';
+            }
+          }
+        });
+      }
+
       function showApprovalCard(data) {
         if (!approvalContainer) return;
         approvalContainer.style.display = 'block';

--- a/src/bootstrap/runtime.ts
+++ b/src/bootstrap/runtime.ts
@@ -90,6 +90,16 @@ function wireTaskManagerEvents(win: BrowserWindow, taskManager: TaskManager, can
       win.webContents.send(IpcChannels.APPROVAL_REQUEST, data);
     }
   });
+  // Broadcast every approval resolution to the shell so any UI surface
+  // showing a card for the same requestId (Wingman Chat, Activity, etc.)
+  // can dismiss or update itself — regardless of which surface actually
+  // triggered the response. Without this, the Chat inline card stayed
+  // visible after the user rejected via the Activity panel.
+  taskManager.on('approval-response', (data: { requestId: string; approved: boolean }) => {
+    if (canUseWindow(win)) {
+      win.webContents.send(IpcChannels.APPROVAL_RESPONSE, data);
+    }
+  });
   taskManager.on('task-updated', (task: Record<string, unknown>) => {
     if (canUseWindow(win)) {
       win.webContents.send(IpcChannels.TASK_UPDATED, task);

--- a/src/preload/panel.ts
+++ b/src/preload/panel.ts
@@ -65,6 +65,16 @@ export function createPanelApi() {
       ipcRenderer.on(IpcChannels.APPROVAL_REQUEST, handler);
       return () => ipcRenderer.removeListener(IpcChannels.APPROVAL_REQUEST, handler);
     },
+    /**
+     * Mirror of onApprovalRequest. Fired whenever any path resolves the
+     * approval (Wingman Chat card, Activity panel, API route, etc.) so every
+     * open UI card for the same requestId can dismiss itself in sync.
+     */
+    onApprovalResponse: (callback: (data: { requestId: string; approved: boolean }) => void) => {
+      const handler = (_event: Electron.IpcRendererEvent, data: { requestId: string; approved: boolean }) => callback(data);
+      ipcRenderer.on(IpcChannels.APPROVAL_RESPONSE, handler);
+      return () => ipcRenderer.removeListener(IpcChannels.APPROVAL_RESPONSE, handler);
+    },
     onHandoffUpdated: (callback: (data: { kind: 'created' | 'updated'; handoff: Record<string, unknown> }) => void) => {
       const handler = (_event: Electron.IpcRendererEvent, data: { kind: 'created' | 'updated'; handoff: Record<string, unknown> }) => callback(data);
       ipcRenderer.on(IpcChannels.HANDOFF_UPDATED, handler);

--- a/src/preload/tests/panel.test.ts
+++ b/src/preload/tests/panel.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { IpcChannels } from '../../shared/ipc-channels';
+
+// Minimal ipcRenderer mock — we only care about on/removeListener wiring.
+const ipcListeners = new Map<string, Set<(...args: unknown[]) => void>>();
+
+vi.mock('electron', () => ({
+  ipcRenderer: {
+    on: vi.fn((channel: string, handler: (...args: unknown[]) => void) => {
+      if (!ipcListeners.has(channel)) ipcListeners.set(channel, new Set());
+      ipcListeners.get(channel)!.add(handler);
+    }),
+    removeListener: vi.fn((channel: string, handler: (...args: unknown[]) => void) => {
+      ipcListeners.get(channel)?.delete(handler);
+    }),
+    invoke: vi.fn(),
+    send: vi.fn(),
+  },
+}));
+
+import { createPanelApi } from '../panel';
+
+beforeEach(() => {
+  ipcListeners.clear();
+  vi.clearAllMocks();
+});
+
+describe('createPanelApi()', () => {
+  it('exposes onApprovalResponse paired with onApprovalRequest (audit #34 follow-up, dual-panel sync)', () => {
+    const api = createPanelApi() as Record<string, unknown>;
+    expect(typeof api.onApprovalRequest).toBe('function');
+    expect(typeof api.onApprovalResponse).toBe('function');
+  });
+
+  it('onApprovalResponse subscribes to the APPROVAL_RESPONSE IPC channel and forwards data', () => {
+    const api = createPanelApi();
+    const received: Array<{ requestId: string; approved: boolean }> = [];
+    api.onApprovalResponse((data) => received.push(data));
+
+    const handlers = ipcListeners.get(IpcChannels.APPROVAL_RESPONSE);
+    expect(handlers).toBeDefined();
+    expect(handlers!.size).toBe(1);
+
+    // Simulate the main process broadcasting a response
+    const payload = { requestId: 'task-1:step-0', approved: false };
+    for (const h of handlers!) h({}, payload);
+    expect(received).toEqual([payload]);
+  });
+
+  it('onApprovalResponse returns an unsubscribe function that removes the listener', () => {
+    const api = createPanelApi();
+    const unsubscribe = api.onApprovalResponse(() => { /* no-op */ });
+    expect(ipcListeners.get(IpcChannels.APPROVAL_RESPONSE)!.size).toBe(1);
+    unsubscribe();
+    expect(ipcListeners.get(IpcChannels.APPROVAL_RESPONSE)!.size).toBe(0);
+  });
+
+  it('onApprovalRequest and onApprovalResponse use distinct IPC channels', () => {
+    expect(IpcChannels.APPROVAL_REQUEST).not.toBe(IpcChannels.APPROVAL_RESPONSE);
+  });
+});

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -117,6 +117,10 @@ export const IpcChannels = {
   // Agents / Tasks
   EMERGENCY_STOP: 'emergency-stop',
   APPROVAL_REQUEST: 'approval-request',
+  // Mirror of APPROVAL_REQUEST: fired when ANY path resolves the approval
+  // (Wingman Chat card, Activity panel, API route, etc.) so every open UI
+  // card for the same requestId can dismiss itself in sync.
+  APPROVAL_RESPONSE: 'approval-response',
   TASK_UPDATED: 'task-updated',
   HANDOFF_UPDATED: 'handoff-updated',
 


### PR DESCRIPTION
## The problem

The Wingman panel has two surfaces that both render a card for each TaskManager approval-request:

- **Activity tab**: handoff cards, fetched via HandoffManager, resolved via \`/handoffs/:id/approve|reject\`
- **Chat tab**: inline "Wingman wants to perform an action" card, posted via \`taskManager.respondToApproval\` through \`/tasks/:taskId/approve|reject\`

Both cards show up for the **same underlying approval**. Resolving one did not dismiss the other — most visibly: rejecting in Activity left the Chat card sitting there until the user clicked its buttons too. Noticed during live testing of #164 / #165.

## Root cause

\`taskManager\` emits both \`'approval-request'\` and \`'approval-response'\`, but \`src/bootstrap/runtime.ts\` only forwards the **request** to the shell via IPC. The response was consumed by \`TaskHandoffCoordinator\` internally (which is why the Chat → Activity direction happened to work, via \`handoff-updated\`) and never reached the Chat card's listener.

## Fix — mirror the existing APPROVAL_REQUEST wiring, four small edits

1. **\`src/shared/ipc-channels.ts\`** — new \`APPROVAL_RESPONSE\` constant, paired with \`APPROVAL_REQUEST\`.
2. **\`src/bootstrap/runtime.ts\`** (\`wireTaskManagerEvents\`) — second listener that forwards every \`approval-response\` to the shell via \`IpcChannels.APPROVAL_RESPONSE\`, same pattern as the request.
3. **\`src/preload/panel.ts\`** — new \`onApprovalResponse(cb)\` parallel to \`onApprovalRequest\`. Returns an unsubscribe function the same way.
4. **\`shell/js/wingman/index.js\`** — subscribe to \`onApprovalResponse\`. When it fires, find the Chat card with matching \`data-request-id\` and remove it; hide the container if empty.

No security surface change — purely UI state synchronisation. The server-side approval flow is unchanged; both paths call \`taskManager.respondToApproval\` as before.

## Live-verified in running Tandem

Triggered a real approval by calling \`POST /security/injection-override\` from curl with no shell marker (same setup that produces the double card today):

- ✅ **Reject via Activity tab** → Chat card dismisses automatically
- ✅ **Afwijzen via Chat card** → Activity card dismisses automatically

Both confirmed by Robin on his Tandem.

## Tests

4 new unit tests in \`src/preload/tests/panel.test.ts\`:

- Preload exposes \`onApprovalResponse\` paired with \`onApprovalRequest\`
- It subscribes to the \`APPROVAL_RESPONSE\` IPC channel and forwards the payload
- It returns a working unsubscribe function
- \`APPROVAL_REQUEST\` and \`APPROVAL_RESPONSE\` are distinct channel names

Full verify clean: **2682 passed** (+4), 39 skipped, 1 pre-existing jsdom env error (unrelated), lint ✓, compile ✓, check-consistency ✓.

## Breaking-change review

None. The new IPC channel is additive; the preload API is additive; the Chat-card rendering only adds a dismiss path when an external response arrives for the same \`requestId\`. No behaviour change for callers that don't trigger an approval-response event.

## Not in scope

The approval-card UX itself (look, risk labels, language) is unchanged. Only the cross-panel sync.