### PR TITLE
feat(wingman): audio ping + escalation + user-return re-alert on approval-requests

### DIFF
--- a/shell/js/wingman/index.js
+++ b/shell/js/wingman/index.js
@@ -46,8 +46,38 @@
     const openHandoffs = new Map();
     const unacknowledgedHandoffs = new Set();
     const HANDOFF_ATTENTION_ESCALATION_MS = 12_000;
+    // "User was away" threshold: how long the Tandem window has to be out
+    // of focus before a focus-return should re-alert. Short blurs (e.g.
+    // Cmd-Tab to clipboard, quick system menu) shouldn't trigger pings.
+    const USER_RETURN_AWAY_MS = 10_000;
+    // Rate-limit re-alerts so escalation + user-return firing close
+    // together don't stack into a double ping.
+    const RE_ALERT_MIN_INTERVAL_MS = 5_000;
     let handoffAttentionEscalationTimer = null;
     let handoffAttentionEscalated = false;
+    let lastReAlertAt = 0;
+    let lastBlurAt = 0;
+
+    function topUnacknowledgedHandoff() {
+      for (const id of unacknowledgedHandoffs) {
+        const handoff = openHandoffs.get(id);
+        if (handoff) return handoff;
+      }
+      return null;
+    }
+
+    function fireHandoffReAlert() {
+      if (!window.tandem || !window.tandem.requestWingmanReAlert) return;
+      const now = Date.now();
+      if (now - lastReAlertAt < RE_ALERT_MIN_INTERVAL_MS) return;
+      const handoff = topUnacknowledgedHandoff();
+      if (!handoff) return;
+      lastReAlertAt = now;
+      window.tandem.requestWingmanReAlert({
+        title: handoff.title || 'Wingman needs you',
+        body: handoff.body || handoff.reason || 'Agent is waiting for input.',
+      });
+    }
 
     function formatHandoffStatus(status) {
       const labels = {
@@ -197,6 +227,7 @@
       if (remaining <= 0) {
         handoffAttentionEscalated = true;
         updateWingmanAttentionUI();
+        fireHandoffReAlert();
         return;
       }
 
@@ -205,9 +236,24 @@
       handoffAttentionEscalationTimer = setTimeout(() => {
         handoffAttentionEscalated = true;
         updateWingmanAttentionUI();
+        fireHandoffReAlert();
         scheduleHandoffAttentionEscalation();
       }, remaining);
     }
+
+    // User-return detection: if the user was away from Tandem long enough
+    // that they almost certainly didn't see the first alert, fire another
+    // one on return. Short blurs don't count (see USER_RETURN_AWAY_MS).
+    window.addEventListener('blur', () => {
+      lastBlurAt = Date.now();
+    });
+    window.addEventListener('focus', () => {
+      const awayMs = lastBlurAt ? Date.now() - lastBlurAt : 0;
+      lastBlurAt = 0;
+      if (awayMs < USER_RETURN_AWAY_MS) return;
+      if (unacknowledgedHandoffs.size === 0) return;
+      fireHandoffReAlert();
+    });
 
     function acknowledgeVisibleHandoffs() {
       for (const handoffId of openHandoffs.keys()) {

--- a/src/agents/task-handoff-coordinator.ts
+++ b/src/agents/task-handoff-coordinator.ts
@@ -1,5 +1,6 @@
 import type { Handoff, HandoffManager } from '../handoffs/manager';
 import type { TaskManager } from './task-manager';
+import { wingmanAlert } from '../notifications/alert';
 
 function appendHandoffNote(body: string, note: string): string {
   const trimmedBody = body.trim();
@@ -42,12 +43,22 @@ export class TaskHandoffCoordinator {
       tabId: typeof params.tabId === 'string' ? params.tabId : null,
     };
 
+    const isNew = !existing;
     const handoff = existing
       ? this.handoffManager.update(existing.id, payload)
       : this.handoffManager.create(payload);
 
     if (!handoff) {
       return null;
+    }
+
+    // Fire a native-OS notification (which plays the system sound on
+    // macOS) so the user hears the agent stalling for input, even if
+    // they're in a different workspace or away from the keyboard. Only
+    // on the first creation — repeated emits for the same step (e.g.,
+    // a retry) shouldn't spam.
+    if (isNew) {
+      wingmanAlert(handoff.title, handoff.body || handoff.reason);
     }
 
     this.syncHandoffState(handoff);

--- a/src/agents/tests/task-handoff-coordinator.test.ts
+++ b/src/agents/tests/task-handoff-coordinator.test.ts
@@ -1,5 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Intercept the native-notification call so tests don't try to reach Electron.
+vi.mock('../../notifications/alert', () => ({
+  wingmanAlert: vi.fn(),
+}));
+
 import { TaskHandoffCoordinator } from '../task-handoff-coordinator';
+import { wingmanAlert } from '../../notifications/alert';
 
 function createHandoff(overrides: Record<string, unknown> = {}) {
   return {
@@ -67,6 +74,23 @@ describe('TaskHandoffCoordinator', () => {
     }));
     expect(taskManager.pauseTaskForHandoff).toHaveBeenCalledWith('task-1', 'step-1', 'handoff-1', 'approval');
     expect(handoff?.status).toBe('waiting_approval');
+    // Fires the native-OS notification / audio ping on first creation
+    // so the user hears the agent stalling even when away / in another
+    // workspace.
+    expect(wingmanAlert).toHaveBeenCalledTimes(1);
+    const [title, body] = vi.mocked(wingmanAlert).mock.calls[0];
+    expect(title).toBe('Need help');
+    expect(body).toBe('Solve captcha');
+  });
+
+  it('does NOT re-fire wingmanAlert when updating an existing approval handoff', () => {
+    taskManager.getTask.mockReturnValue({ createdBy: 'openclaw', assignedTo: 'claude' });
+    handoffManager.findOpenByTaskStep.mockReturnValue(createHandoff({ id: 'handoff-existing' }));
+    handoffManager.update.mockReturnValue(createHandoff({ id: 'handoff-existing', status: 'waiting_approval' }));
+
+    coordinator.handleApprovalRequest({ taskId: 'task-1', stepId: 'step-1', action: null });
+
+    expect(wingmanAlert).not.toHaveBeenCalled();
   });
 
   it('updates an existing approval handoff instead of creating a duplicate', () => {

--- a/src/ipc/handlers.ts
+++ b/src/ipc/handlers.ts
@@ -29,6 +29,7 @@ import { tandemDir } from '../utils/paths';
 import { createLogger } from '../utils/logger';
 import { IpcChannels } from '../shared/ipc-channels';
 import { buildOwnershipContextForTab, buildOwnershipContextForTabId } from '../tabs/runtime-context';
+import { wingmanAlert } from '../notifications/alert';
 
 const log = createLogger('IpcHandlers');
 
@@ -90,6 +91,7 @@ export function registerIpcHandlers(deps: IpcDeps): void {
     IpcChannels.WINDOW_CLOSE,
     IpcChannels.SHOW_SCREENSHOT_MENU,
     IpcChannels.RECORDING_CHUNK,
+    IpcChannels.WINGMAN_RE_ALERT,
   ];
   for (const channel of ipcChannels) {
     ipcMain.removeAllListeners(channel);
@@ -125,6 +127,19 @@ export function registerIpcHandlers(deps: IpcDeps): void {
   for (const handler of ipcHandlers) {
     try { ipcMain.removeHandler(handler); } catch { /* handler may not exist yet */ }
   }
+
+  // ═══ Wingman re-alert — escalation + user-return ping ═══
+  // Shell calls this when an unacknowledged handoff escalates past its
+  // attention timer, or when the user returns to Tandem after being away
+  // long enough that they almost certainly didn't see the first alert.
+  // Re-emits the native-OS notification (which plays the system sound on
+  // macOS). Deliberately loose — any renderer on the shared preload can
+  // send this; the trust model covers "team-initiated" calls.
+  ipcMain.on(IpcChannels.WINGMAN_RE_ALERT, (_event, data: { title?: unknown; body?: unknown }) => {
+    const title = typeof data?.title === 'string' && data.title.trim() ? data.title : 'Wingman needs you';
+    const body = typeof data?.body === 'string' ? data.body : '';
+    wingmanAlert(title, body);
+  });
 
   // Listen for tab metadata updates from renderer
   ipcMain.on(IpcChannels.TAB_UPDATE, (_event, data: { tabId: string; title?: string; url?: string; favicon?: string }) => {

--- a/src/preload/panel.ts
+++ b/src/preload/panel.ts
@@ -75,6 +75,15 @@ export function createPanelApi() {
       ipcRenderer.on(IpcChannels.APPROVAL_RESPONSE, handler);
       return () => ipcRenderer.removeListener(IpcChannels.APPROVAL_RESPONSE, handler);
     },
+    /**
+     * Ask the main process to re-fire a Wingman native-OS notification
+     * (which plays the system sound on macOS) for an existing
+     * unacknowledged handoff. Used on escalation timeouts and on
+     * user-return. Fire-and-forget.
+     */
+    requestWingmanReAlert: (payload: { title: string; body: string }) => {
+      ipcRenderer.send(IpcChannels.WINGMAN_RE_ALERT, payload);
+    },
     onHandoffUpdated: (callback: (data: { kind: 'created' | 'updated'; handoff: Record<string, unknown> }) => void) => {
       const handler = (_event: Electron.IpcRendererEvent, data: { kind: 'created' | 'updated'; handoff: Record<string, unknown> }) => callback(data);
       ipcRenderer.on(IpcChannels.HANDOFF_UPDATED, handler);

--- a/src/preload/tests/panel.test.ts
+++ b/src/preload/tests/panel.test.ts
@@ -3,6 +3,7 @@ import { IpcChannels } from '../../shared/ipc-channels';
 
 // Minimal ipcRenderer mock — we only care about on/removeListener wiring.
 const ipcListeners = new Map<string, Set<(...args: unknown[]) => void>>();
+const sentMessages: Array<{ channel: string; payload: unknown }> = [];
 
 vi.mock('electron', () => ({
   ipcRenderer: {
@@ -14,7 +15,9 @@ vi.mock('electron', () => ({
       ipcListeners.get(channel)?.delete(handler);
     }),
     invoke: vi.fn(),
-    send: vi.fn(),
+    send: vi.fn((channel: string, payload: unknown) => {
+      sentMessages.push({ channel, payload });
+    }),
   },
 }));
 
@@ -22,6 +25,7 @@ import { createPanelApi } from '../panel';
 
 beforeEach(() => {
   ipcListeners.clear();
+  sentMessages.length = 0;
   vi.clearAllMocks();
 });
 
@@ -57,5 +61,13 @@ describe('createPanelApi()', () => {
 
   it('onApprovalRequest and onApprovalResponse use distinct IPC channels', () => {
     expect(IpcChannels.APPROVAL_REQUEST).not.toBe(IpcChannels.APPROVAL_RESPONSE);
+  });
+
+  it('requestWingmanReAlert sends the payload over the WINGMAN_RE_ALERT channel', () => {
+    const api = createPanelApi();
+    api.requestWingmanReAlert({ title: 'Agent stalling', body: 'Approve or reject' });
+    expect(sentMessages).toEqual([
+      { channel: IpcChannels.WINGMAN_RE_ALERT, payload: { title: 'Agent stalling', body: 'Approve or reject' } },
+    ]);
   });
 });

--- a/src/shared/ipc-channels.ts
+++ b/src/shared/ipc-channels.ts
@@ -121,6 +121,11 @@ export const IpcChannels = {
   // (Wingman Chat card, Activity panel, API route, etc.) so every open UI
   // card for the same requestId can dismiss itself in sync.
   APPROVAL_RESPONSE: 'approval-response',
+  // Shell → Main: re-fire a Wingman native-OS notification/ping for an
+  // already-existing unacknowledged handoff. Used on escalation timeouts
+  // and on user-return (focus returns after a longer absence). Payload:
+  // { title, body }.
+  WINGMAN_RE_ALERT: 'wingman-re-alert',
   TASK_UPDATED: 'task-updated',
   HANDOFF_UPDATED: 'handoff-updated',
 


### PR DESCRIPTION
## Problem — agent stalls silently while user is elsewhere

Tandem already has a visual attention system for open handoffs: the Wingman badge changes color, shows a count, and after 12 s without acknowledgement pulses as "escalated". That's easy to miss when the user is in another workspace or away from the keyboard — and missing it means an agent sits waiting for input without the user knowing.

Per Robin: *"de gebruiker moet dat weten want het is heel belangrijk dat de gebruiker dat weet"*.

## Three layered alerts so the user hears the agent stall

### A. Initial native-OS notification on every new approval-request

In \`TaskHandoffCoordinator.handleApprovalRequest\`, when a *new* handoff is created, fire \`wingmanAlert(title, body)\`. That goes through Electron's \`Notification\` API → macOS system sound + Notification Center toast. Updates to an existing approval handoff don't re-ping (no retry spam).

### B. Re-alert on escalation (unacknowledged past 12 s)

\`scheduleHandoffAttentionEscalation()\` in \`shell/js/wingman/index.js\` already flips \`handoffAttentionEscalated\` after the attention timer. It now also calls \`fireHandoffReAlert()\`, which asks the main process (via new IPC channel \`WINGMAN_RE_ALERT\`) to emit another \`wingmanAlert\` for the top unacknowledged handoff. User hears a second ping if they didn't see the first.

### C. Re-alert on user-return after a longer absence

Shell tracks \`window.blur\` / \`window.focus\` timestamps. When focus comes back after \`>10 s\` away AND unacknowledged handoffs still exist, fires \`fireHandoffReAlert()\`. Short blurs (Cmd-Tab to clipboard, system menu) stay below the threshold and don't ping — we only want to re-alert when the user was actually gone.

A 5-second rate limit on \`fireHandoffReAlert\` keeps escalation + user-return from stacking into a double ping when they fire close together.

## Wiring

- \`src/shared/ipc-channels.ts\` — new \`WINGMAN_RE_ALERT\` channel
- \`src/preload/panel.ts\` — new \`requestWingmanReAlert({title, body})\`
- \`src/ipc/handlers.ts\` — \`ipcMain.on\` handler calls \`wingmanAlert\`; added to the \`removeAllListeners\` cleanup list so macOS reactivation doesn't stack duplicates

## Live-verified in running Tandem

Triggered \`POST /security/injection-override\` with the Wingman panel closed. Robin confirmed all three alerts fire, in order:

| Trigger | Expected | Heard / saw |
|---|---|---|
| Initial approval-request | ping + native notification | ✅ |
| 12 s idle unacknowledged | second ping | ✅ |
| Focus away >10 s, return while unacknowledged | third ping | ✅ |

## Tests

- \`src/agents/tests/task-handoff-coordinator.test.ts\`: mocks \`wingmanAlert\`, asserts it is called once with the handoff title/body on new creation, and **not** called when updating an existing approval handoff.
- \`src/preload/tests/panel.test.ts\`: asserts \`requestWingmanReAlert\` sends \`{title, body}\` over \`IpcChannels.WINGMAN_RE_ALERT\`.

Full verify clean: **2684 passed** (+2 net new; one existing coordinator test updated to expect the new alert call), lint ✓, compile ✓, check-consistency ✓.

## Scope — deliberately left out

- **Periodic re-ping every N minutes while unacknowledged.** Escalation + user-return already cover the "user was away" case; adding a periodic loop risks spamming a user who's in a long-running unrelated task and knows the agent is waiting. Can add later if real usage shows it's needed.
- **Stronger visual on the escalated state.** The current yellow urgent-pulse is already prominent; waiting to see if the new audio layer is enough on its own.

## Breaking-change review

None. Audio is additive — no change to the approval flow itself. Native notifications are behind \`Notification.isSupported()\` so environments without it degrade gracefully. The new IPC channel is additive; existing IPC flow is unchanged.