### PR TITLE
feat(behavior): real BehaviorCompiler — real per-user typing rhythm

### DIFF
--- a/src/api/routes/misc.ts
+++ b/src/api/routes/misc.ts
@@ -9,6 +9,8 @@ import { tandemDir } from '../../utils/paths';
 import { handleRouteError } from '../../utils/errors';
 import { isSafeNavigationUrl } from '../../utils/security';
 import { addInjectionOverride } from '../middleware/injection-scanner';
+import { behaviorCompiler } from '../../behavior/compiler';
+import { behaviorReplay } from '../../behavior/replay';
 import { createRateLimitMiddleware } from '../rate-limit';
 import { getActorContext, normalizeTabSource } from '../../tabs/context';
 import { buildOwnershipContextForTab } from '../../tabs/runtime-context';
@@ -448,6 +450,25 @@ export function registerMiscRoutes(router: Router, ctx: RouteContext): void {
         }
       }
       res.json({ ok: true, cleared: true });
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+
+  // Force a fresh compile of the behavioural profile from the current
+  // raw JSONL stream and hand the agent the new numbers immediately.
+  // Useful after a long typing session when the user wants the agent
+  // to incorporate the new rhythm without restarting Tandem.
+  router.post('/behavior/recompile', createRateLimitMiddleware({
+    bucket: 'misc-behavior-recompile',
+    windowMs: 60_000,
+    max: 10,
+    message: 'Too many behavior recompile requests. Retry shortly.',
+  }), (_req: Request, res: Response) => {
+    try {
+      const profile = behaviorCompiler.compile();
+      behaviorReplay.refreshProfile();
+      res.json({ ok: true, profile });
     } catch (e) {
       handleRouteError(res, e);
     }

--- a/src/api/tests/routes/misc.test.ts
+++ b/src/api/tests/routes/misc.test.ts
@@ -770,6 +770,28 @@ describe('misc routes', () => {
     });
   });
 
+  describe('POST /behavior/recompile', () => {
+    it('recompiles the behaviour profile and returns it', async () => {
+      // With the mocked fs returning false for existsSync, compile() hits
+      // the raw-dir-missing path and returns the default profile.
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+
+      const res = await request(app).post('/behavior/recompile');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.profile).toBeDefined();
+      expect(res.body.profile.typingSpeed).toBeDefined();
+      expect(res.body.profile.source).toBeDefined();
+    });
+
+    it('returns the resulting profile source so callers can introspect', async () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      const res = await request(app).post('/behavior/recompile');
+      expect(['default', 'default-insufficient', 'compiled']).toContain(res.body.profile.source);
+    });
+  });
+
   // ═══════════════════════════════════════════════
   // SITE MEMORY
   // ═══════════════════════════════════════════════

--- a/src/behavior/compiler.ts
+++ b/src/behavior/compiler.ts
@@ -1,97 +1,271 @@
 import * as fs from 'fs';
+import * as path from 'path';
 import { tandemDir } from '../utils/paths';
 
 /**
- * Basic Types for Behavioral Data
+ * BehaviorCompiler — turns the BehaviorObserver's raw JSONL stream into
+ * a per-user behavioural profile that BehaviorReplay can sample to mimic
+ * this human's typing rhythm (and, later, mouse behaviour) when the agent
+ * acts on a page.
+ *
+ * Historically this file was a stub: compile() ignored the raw data and
+ * always wrote a hardcoded 85-WPM / ease-in-out / 1.2 px/ms profile, so
+ * every install ended up with the same "average typist" fingerprint. That
+ * defeats the purpose of observing the user. This version reads the raw
+ * JSONL and computes real statistics; mouse-trajectory learning is still
+ * on defaults and will be implemented in a later pass (design notes in
+ * docs/superpowers/behavior-compiler-design.md, phase 2).
  */
-export interface TypeEvent {
-    key: string;
-    timestamp: number;
-}
 
-export interface MouseEvent {
-    x: number;
-    y: number;
-    timestamp: number;
-}
+// ─── Public tuning constants (exported for tests) ──────────────────
+
+/** Drop intervals below this — paste-bursts or key-repeat noise. */
+export const OUTLIER_MIN_MS = 30;
+/** Drop intervals above this — thinking pauses, not typing rhythm. */
+export const OUTLIER_MAX_MS = 2000;
+/** Minimum number of sane intervals before we trust the compiled stats. */
+export const SAMPLE_FLOOR = 100;
+/** Sanity check: reject compiled means that imply an impossible human rate. */
+export const SANE_WPM_MIN = 20;
+export const SANE_WPM_MAX = 150;
+/** Fraction trimmed from the top and bottom before mean/stddev. */
+const PERCENTILE_TRIM_FRACTION = 0.05;
+
+// ─── Types ──────────────────────────────────────────────────────────
+
+export type BehaviorProfileSource = 'default' | 'default-insufficient' | 'compiled';
 
 export interface BehavioralProfile {
-    typingSpeed: {
-        meanWpm: number;
-        variance: number;
-    };
-    mouseMovement: {
-        curveBias: 'linear' | 'ease-in-out' | 'ease-out';
-        averageSpeedPxPerMs: number;
-    };
+  typingSpeed: {
+    meanWpm: number;
+    variance: number;
+  };
+  mouseMovement: {
+    curveBias: 'linear' | 'ease-in-out' | 'ease-out';
+    averageSpeedPxPerMs: number;
+  };
+  // Observability fields — additive, BehaviorReplay does not read them.
+  source?: BehaviorProfileSource;
+  samples?: number;
+  lastCompiledAt?: number;
+}
+
+interface KeypressEvent {
+  type: 'keypress';
+  ts: number;
+  data?: { interval?: number };
+}
+
+// ─── Pure helpers (exported for unit tests) ────────────────────────
+
+/**
+ * Drop intervals outside the band of plausibly-typed keystrokes. Paste
+ * bursts come in as near-zero intervals, thinking pauses come in as
+ * multi-second ones; neither represents the user's actual rhythm.
+ */
+export function filterOutliers(intervals: number[]): number[] {
+  return intervals.filter((i) => i >= OUTLIER_MIN_MS && i <= OUTLIER_MAX_MS);
 }
 
 /**
- * The Compiler is responsible for scanning the raw input events 
- * recorded by the BehaviorObserver and turning them into statistical 
- * distributions that the Replay engine can sample from to mimic
- * realistic human input.
+ * Trim 5% off the top and bottom of a sorted ascending array so a few
+ * remaining stragglers don't skew mean/variance. Returns the middle 90%.
+ * Returns the input unchanged for very small arrays where trimming would
+ * leave us with nothing.
  */
+export function percentileTrim(sorted: number[]): number[] {
+  if (sorted.length < 20) return sorted.slice();
+  const n = sorted.length;
+  const cut = Math.floor(n * PERCENTILE_TRIM_FRACTION);
+  return sorted.slice(cut, n - cut);
+}
+
+/**
+ * Turn a list of keypress intervals (ms between consecutive keys) into
+ * summary statistics. meanWpm follows the 5-chars-per-word convention;
+ * variance is the stddev of the intervals in ms, matching the field
+ * BehaviorReplay.getTypingDelay uses as additive noise amplitude.
+ *
+ * The caller is expected to have already dropped outliers and percentile-
+ * trimmed; this helper just crunches numbers.
+ */
+export function computeStatsFromIntervals(intervals: number[]): {
+  meanWpm: number;
+  variance: number;
+  samples: number;
+} {
+  const samples = intervals.length;
+  if (samples === 0) return { meanWpm: 0, variance: 0, samples: 0 };
+
+  const sum = intervals.reduce((a, b) => a + b, 0);
+  const meanMsPerKey = sum / samples;
+  const cpm = 60_000 / meanMsPerKey;
+  const meanWpm = cpm / 5;
+
+  let variance = 0;
+  if (samples > 1) {
+    let sqSum = 0;
+    for (const v of intervals) {
+      const d = v - meanMsPerKey;
+      sqSum += d * d;
+    }
+    variance = Math.sqrt(sqSum / samples);
+  }
+
+  return {
+    meanWpm: Math.round(meanWpm * 10) / 10,
+    variance: Math.round(variance * 10) / 10,
+    samples,
+  };
+}
+
+/**
+ * Extract only valid keypress intervals from a JSONL blob. Tolerates
+ * malformed lines and ignores every other event type. Keypress events
+ * whose interval is missing or non-positive are skipped — those come
+ * from either the first-press-of-session (no previous timestamp) or
+ * events that pre-date the #168 observer fix.
+ */
+export function extractIntervalsFromJsonl(text: string): number[] {
+  const out: number[] = [];
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!parsed || typeof parsed !== 'object') continue;
+    const event = parsed as KeypressEvent;
+    if (event.type !== 'keypress') continue;
+    const interval = event.data?.interval;
+    if (typeof interval !== 'number' || !Number.isFinite(interval) || interval <= 0) continue;
+    out.push(interval);
+  }
+  return out;
+}
+
+// ─── Defaults ──────────────────────────────────────────────────────
+
+function getDefaultProfile(source: BehaviorProfileSource = 'default', samples = 0): BehavioralProfile {
+  return {
+    typingSpeed: { meanWpm: 60, variance: 15 },
+    mouseMovement: { curveBias: 'ease-in-out', averageSpeedPxPerMs: 1.2 },
+    source,
+    samples,
+    lastCompiledAt: Date.now(),
+  };
+}
+
+// ─── Manager ───────────────────────────────────────────────────────
+
 export class BehaviorCompiler {
-    private rawDir: string;
-    private profileDir: string;
+  private readonly rawDir: string;
+  private readonly profilePath: string;
 
-    constructor() {
-        this.rawDir = tandemDir('behavior', 'raw');
-        this.profileDir = tandemDir('behavior', 'profile.json');
+  constructor() {
+    this.rawDir = tandemDir('behavior', 'raw');
+    this.profilePath = tandemDir('behavior', 'profile.json');
+  }
 
-        if (!fs.existsSync(this.rawDir)) {
-            fs.mkdirSync(this.rawDir, { recursive: true });
+  /**
+   * Read every ~/.tandem/behavior/raw/ *.jsonl file, extract keypress
+   * intervals, filter+trim, compute stats, persist and return the
+   * compiled profile. Safe to call repeatedly — idempotent within a
+   * single snapshot of raw data.
+   */
+  compile(): BehavioralProfile {
+    const intervals = this.collectIntervals();
+    const filtered = filterOutliers(intervals);
+    const sorted = filtered.slice().sort((a, b) => a - b);
+    const trimmed = percentileTrim(sorted);
+
+    if (trimmed.length < SAMPLE_FLOOR) {
+      const source: BehaviorProfileSource = trimmed.length === 0 ? 'default' : 'default-insufficient';
+      return this.persist(getDefaultProfile(source, trimmed.length));
+    }
+
+    const stats = computeStatsFromIntervals(trimmed);
+    if (stats.meanWpm < SANE_WPM_MIN || stats.meanWpm > SANE_WPM_MAX) {
+      return this.persist(getDefaultProfile('default-insufficient', trimmed.length));
+    }
+
+    const profile: BehavioralProfile = {
+      typingSpeed: {
+        meanWpm: stats.meanWpm,
+        variance: stats.variance,
+      },
+      mouseMovement: {
+        // Mouse profile is still on defaults — real curves need webview-side
+        // move events (phase 2). See design doc in docs/superpowers/.
+        curveBias: 'ease-in-out',
+        averageSpeedPxPerMs: 1.2,
+      },
+      source: 'compiled',
+      samples: stats.samples,
+      lastCompiledAt: Date.now(),
+    };
+    return this.persist(profile);
+  }
+
+  /**
+   * Return the currently-persisted profile, or compile a fresh one if
+   * the profile file is missing or unreadable.
+   */
+  getProfile(): BehavioralProfile {
+    if (fs.existsSync(this.profilePath)) {
+      try {
+        const parsed = JSON.parse(fs.readFileSync(this.profilePath, 'utf-8'));
+        if (parsed && typeof parsed === 'object') {
+          return parsed as BehavioralProfile;
         }
+      } catch {
+        // fall through to compile
+      }
     }
+    return this.compile();
+  }
 
-    /**
-     * Reads all raw JSON log chunks, calculates physics heuristics, 
-     * and saves a compiled profile.
-     */
-    public compile(): BehavioralProfile {
-        // If no data exists, return a default safe profile
-        if (!fs.existsSync(this.rawDir) || fs.readdirSync(this.rawDir).length === 0) {
-            return this.getDefaultProfile();
-        }
+  // ─── private ─────────────────────────────────────────────────────
 
-        // In a real scenario, we would parse all MouseEvents and TypeEvents
-        // and extract real Bézier curves and bigram delays. For now we compile 
-        // a basic representation based on defaults.
-        const compiled: BehavioralProfile = {
-            typingSpeed: {
-                meanWpm: 85,
-                variance: 15
-            },
-            mouseMovement: {
-                curveBias: 'ease-in-out',
-                averageSpeedPxPerMs: 1.2
-            }
-        };
-
-        // Save it out
-        fs.writeFileSync(this.profileDir, JSON.stringify(compiled, null, 2));
-
-        return compiled;
+  private collectIntervals(): number[] {
+    if (!fs.existsSync(this.rawDir)) return [];
+    let names: string[];
+    try {
+      names = fs.readdirSync(this.rawDir);
+    } catch {
+      return [];
     }
-
-    public getProfile(): BehavioralProfile {
-        if (fs.existsSync(this.profileDir)) {
-            try {
-                return JSON.parse(fs.readFileSync(this.profileDir, 'utf8'));
-            } catch {
-                return this.getDefaultProfile();
-            }
-        }
-        return this.compile();
+    const jsonl = names.filter((n) => n.endsWith('.jsonl'));
+    const all: number[] = [];
+    for (const name of jsonl) {
+      const full = path.join(this.rawDir, name);
+      let content: string;
+      try {
+        content = fs.readFileSync(full, 'utf-8');
+      } catch {
+        continue;
+      }
+      for (const v of extractIntervalsFromJsonl(content)) {
+        all.push(v);
+      }
     }
+    return all;
+  }
 
-    private getDefaultProfile(): BehavioralProfile {
-        return {
-            typingSpeed: { meanWpm: 60, variance: 10 },
-            mouseMovement: { curveBias: 'ease-in-out', averageSpeedPxPerMs: 1.0 }
-        };
+  private persist(profile: BehavioralProfile): BehavioralProfile {
+    try {
+      const dir = path.dirname(this.profilePath);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(this.profilePath, JSON.stringify(profile, null, 2));
+      try { fs.chmodSync(this.profilePath, 0o600); } catch { /* best effort */ }
+    } catch {
+      // Writes can fail on read-only FS; still return the computed profile.
     }
+    return profile;
+  }
 }
 
 export const behaviorCompiler = new BehaviorCompiler();

--- a/src/behavior/tests/compiler.test.ts
+++ b/src/behavior/tests/compiler.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// vi.mock is hoisted above top-level consts, so the shared in-memory
+// filesystem has to live inside vi.hoisted() to be reachable from the
+// mock factory.
+const { vfs } = vi.hoisted(() => ({ vfs: new Map<string, string>() }));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual('fs') as Record<string, unknown>;
+  const fs = {
+    ...actual,
+    existsSync: vi.fn((p: string) => {
+      const s = String(p);
+      if ([...vfs.keys()].some((k) => k === s || k.startsWith(s + '/'))) return true;
+      return false;
+    }),
+    mkdirSync: vi.fn(),
+    readdirSync: vi.fn((p: string) => {
+      const prefix = String(p).replace(/\/$/, '') + '/';
+      const names = new Set<string>();
+      for (const k of vfs.keys()) {
+        if (k.startsWith(prefix)) {
+          const rest = k.slice(prefix.length);
+          const name = rest.split('/')[0];
+          names.add(name);
+        }
+      }
+      return Array.from(names);
+    }),
+    readFileSync: vi.fn((p: string) => {
+      const content = vfs.get(String(p));
+      if (content === undefined) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      return content;
+    }),
+    writeFileSync: vi.fn((p: string, content: string) => {
+      vfs.set(String(p), String(content));
+    }),
+    chmodSync: vi.fn(),
+  };
+  return { ...fs, default: fs };
+});
+
+vi.mock('../../utils/paths', () => ({
+  tandemDir: vi.fn((...parts: string[]) => ['/tmp/tandem-test', ...parts].join('/')),
+}));
+
+import {
+  BehaviorCompiler,
+  filterOutliers,
+  percentileTrim,
+  computeStatsFromIntervals,
+  extractIntervalsFromJsonl,
+  OUTLIER_MIN_MS,
+  OUTLIER_MAX_MS,
+  SAMPLE_FLOOR,
+} from '../compiler';
+
+function seedKeypressJsonl(filename: string, intervals: number[]): void {
+  const path = `/tmp/tandem-test/behavior/raw/${filename}`;
+  const lines = intervals.map((interval, i) =>
+    JSON.stringify({ type: 'keypress', ts: 1_000_000 + i, data: { interval } }),
+  );
+  vfs.set(path, lines.join('\n'));
+}
+
+function gaussianIntervals(count: number, mean: number, stddev: number, seed = 1): number[] {
+  // Simple seeded PRNG so tests are deterministic.
+  let s = seed;
+  const rand = () => {
+    s = (s * 1664525 + 1013904223) >>> 0;
+    return s / 0x100000000;
+  };
+  const out: number[] = [];
+  for (let i = 0; i < count; i += 2) {
+    const u1 = Math.max(rand(), 1e-10);
+    const u2 = rand();
+    const z0 = Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+    const z1 = Math.sqrt(-2 * Math.log(u1)) * Math.sin(2 * Math.PI * u2);
+    out.push(Math.max(1, Math.round(mean + z0 * stddev)));
+    if (out.length < count) out.push(Math.max(1, Math.round(mean + z1 * stddev)));
+  }
+  return out;
+}
+
+beforeEach(() => {
+  vfs.clear();
+  vi.clearAllMocks();
+});
+
+// ─── Pure helper tests ──────────────────────────────────────────
+
+describe('filterOutliers()', () => {
+  it(`drops intervals < ${OUTLIER_MIN_MS}ms (paste / key-repeat)`, () => {
+    expect(filterOutliers([10, 29, 30, 50])).toEqual([30, 50]);
+  });
+
+  it(`drops intervals > ${OUTLIER_MAX_MS}ms (thinking pauses)`, () => {
+    expect(filterOutliers([100, 200, 2001, 5000])).toEqual([100, 200]);
+  });
+
+  it('keeps intervals inside the acceptable band', () => {
+    expect(filterOutliers([30, 200, 1999, 2000])).toEqual([30, 200, 1999, 2000]);
+  });
+
+  it('handles empty input', () => {
+    expect(filterOutliers([])).toEqual([]);
+  });
+});
+
+describe('percentileTrim()', () => {
+  it('drops top and bottom 5% from an already-sorted array', () => {
+    // 100 values 1..100 → drops 5 smallest and 5 largest → keeps 6..95
+    const input = Array.from({ length: 100 }, (_, i) => i + 1);
+    const out = percentileTrim(input);
+    expect(out[0]).toBe(6);
+    expect(out[out.length - 1]).toBe(95);
+    expect(out.length).toBe(90);
+  });
+
+  it('returns input unchanged for very small arrays (nothing to trim)', () => {
+    expect(percentileTrim([100, 200, 300]).length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('computeStatsFromIntervals()', () => {
+  it('computes meanWpm for a typical typist (mean ≈ 200 ms/key → 60 WPM)', () => {
+    const intervals = Array.from({ length: 500 }, () => 200);
+    const stats = computeStatsFromIntervals(intervals);
+    expect(stats.meanWpm).toBeCloseTo(60, 0);
+    expect(stats.samples).toBe(500);
+  });
+
+  it('computes a non-zero variance for jittery intervals', () => {
+    const intervals = gaussianIntervals(500, 200, 40, 42);
+    const stats = computeStatsFromIntervals(intervals);
+    expect(stats.variance).toBeGreaterThan(20);
+    expect(stats.variance).toBeLessThan(60);
+  });
+
+  it('returns variance=0 for a perfectly constant stream', () => {
+    const intervals = Array.from({ length: 200 }, () => 150);
+    expect(computeStatsFromIntervals(intervals).variance).toBe(0);
+  });
+});
+
+// ─── JSONL parsing ──────────────────────────────────────────────
+
+describe('extractIntervalsFromJsonl()', () => {
+  it('pulls keypress intervals and ignores other event types', () => {
+    const text = [
+      JSON.stringify({ type: 'keypress', ts: 1, data: { interval: 150 } }),
+      JSON.stringify({ type: 'scroll', ts: 2, data: { deltaY: 100 } }),
+      JSON.stringify({ type: 'keypress', ts: 3, data: { interval: 200 } }),
+      JSON.stringify({ type: 'navigate', ts: 4, data: { url: 'x' } }),
+    ].join('\n');
+    expect(extractIntervalsFromJsonl(text)).toEqual([150, 200]);
+  });
+
+  it('ignores keypress events with interval <= 0 (the "first press" records)', () => {
+    const text = [
+      JSON.stringify({ type: 'keypress', ts: 1, data: { interval: 0 } }),
+      JSON.stringify({ type: 'keypress', ts: 2, data: { interval: -5 } }),
+      JSON.stringify({ type: 'keypress', ts: 3, data: { interval: 180 } }),
+    ].join('\n');
+    expect(extractIntervalsFromJsonl(text)).toEqual([180]);
+  });
+
+  it('tolerates malformed JSONL lines without throwing', () => {
+    const text = [
+      'not-json',
+      JSON.stringify({ type: 'keypress', ts: 1, data: { interval: 100 } }),
+      '',
+      '{broken',
+      JSON.stringify({ type: 'keypress', ts: 2, data: { interval: 120 } }),
+    ].join('\n');
+    expect(extractIntervalsFromJsonl(text)).toEqual([100, 120]);
+  });
+
+  it('handles empty input', () => {
+    expect(extractIntervalsFromJsonl('')).toEqual([]);
+  });
+});
+
+// ─── compile() orchestration ────────────────────────────────────
+
+describe('BehaviorCompiler.compile()', () => {
+  it('returns default profile with source="default" when raw dir is empty / missing', () => {
+    const compiler = new BehaviorCompiler();
+    const profile = compiler.compile();
+    expect(profile.source).toBe('default');
+    expect(profile.typingSpeed.meanWpm).toBeGreaterThan(0);
+    expect(profile.samples ?? 0).toBe(0);
+  });
+
+  it(`returns source="default-insufficient" when total intervals < ${SAMPLE_FLOOR}`, () => {
+    seedKeypressJsonl('2026-04-19.jsonl', gaussianIntervals(50, 200, 30, 3));
+    const compiler = new BehaviorCompiler();
+    const profile = compiler.compile();
+    expect(profile.source).toBe('default-insufficient');
+    // Defaults still flow through so downstream replay works
+    expect(profile.typingSpeed.meanWpm).toBeGreaterThan(0);
+  });
+
+  it('produces source="compiled" with real stats when enough sane samples exist', () => {
+    seedKeypressJsonl('2026-04-19.jsonl', gaussianIntervals(500, 250, 50, 7)); // ≈ 48 WPM
+    const compiler = new BehaviorCompiler();
+    const profile = compiler.compile();
+    expect(profile.source).toBe('compiled');
+    expect(profile.typingSpeed.meanWpm).toBeGreaterThan(30);
+    expect(profile.typingSpeed.meanWpm).toBeLessThan(75);
+    expect(profile.samples).toBeGreaterThanOrEqual(SAMPLE_FLOOR);
+    expect(typeof profile.lastCompiledAt).toBe('number');
+  });
+
+  it('aggregates intervals across multiple day files', () => {
+    seedKeypressJsonl('2026-04-18.jsonl', gaussianIntervals(60, 200, 30, 11));
+    seedKeypressJsonl('2026-04-19.jsonl', gaussianIntervals(60, 200, 30, 13));
+    const compiler = new BehaviorCompiler();
+    const profile = compiler.compile();
+    // 60 + 60 = 120 samples → crosses the floor
+    expect(profile.source).toBe('compiled');
+  });
+
+  it('trims outliers so a few paste-bursts or long pauses do not skew the mean', () => {
+    const sane = gaussianIntervals(300, 200, 30, 17);
+    // Inject obvious junk that should be dropped
+    const withOutliers = [...sane, 5, 10, 5000, 10_000];
+    seedKeypressJsonl('2026-04-19.jsonl', withOutliers);
+    const compiler = new BehaviorCompiler();
+    const profile = compiler.compile();
+    expect(profile.source).toBe('compiled');
+    // Without trim, 10_000ms outliers would yank the mean hard
+    expect(profile.typingSpeed.meanWpm).toBeGreaterThan(40);
+    expect(profile.typingSpeed.meanWpm).toBeLessThan(80);
+  });
+
+  it('falls back to default-insufficient when computed meanWpm is outside [20, 150]', () => {
+    // 500 samples all at 5ms → ridiculous WPM, should be rejected as paste noise
+    // (after outlier filter drops <30ms, we'll end up with 0 samples anyway —
+    //  but also test the sane-range branch explicitly with samples that
+    //  survive the filter but produce an insane mean)
+    const bogus = Array.from({ length: 500 }, () => 31); // just inside the min, crazy-fast ~387 WPM
+    seedKeypressJsonl('2026-04-19.jsonl', bogus);
+    const compiler = new BehaviorCompiler();
+    const profile = compiler.compile();
+    expect(profile.source).toBe('default-insufficient');
+  });
+
+  it('writes the compiled profile to disk', () => {
+    seedKeypressJsonl('2026-04-19.jsonl', gaussianIntervals(500, 200, 30, 23));
+    const compiler = new BehaviorCompiler();
+    compiler.compile();
+    const written = vfs.get('/tmp/tandem-test/behavior/profile.json');
+    expect(written).toBeDefined();
+    const parsed = JSON.parse(written!);
+    expect(parsed.source).toBe('compiled');
+  });
+
+  it('getProfile() returns the persisted profile when available', () => {
+    const payload = {
+      typingSpeed: { meanWpm: 72, variance: 33 },
+      mouseMovement: { curveBias: 'ease-in-out', averageSpeedPxPerMs: 1.2 },
+      source: 'compiled',
+      samples: 500,
+      lastCompiledAt: 1_700_000_000_000,
+    };
+    vfs.set('/tmp/tandem-test/behavior/profile.json', JSON.stringify(payload));
+    const compiler = new BehaviorCompiler();
+    const profile = compiler.getProfile();
+    expect(profile.typingSpeed.meanWpm).toBe(72);
+    expect(profile.source).toBe('compiled');
+  });
+
+  it('getProfile() falls back to compile() when profile.json is missing', () => {
+    const compiler = new BehaviorCompiler();
+    const profile = compiler.getProfile();
+    expect(profile.source).toBe('default');
+  });
+});

--- a/src/bootstrap/runtime.ts
+++ b/src/bootstrap/runtime.ts
@@ -52,6 +52,8 @@ import { VoiceManager } from '../voice/recognition';
 import { WatchManager } from '../watch/watcher';
 import { HeadlessManager } from '../headless/manager';
 import { BehaviorObserver } from '../behavior/observer';
+import { behaviorCompiler } from '../behavior/compiler';
+import { behaviorReplay } from '../behavior/replay';
 import { WorkflowEngine } from '../workflow/engine';
 import { WorkspaceManager } from '../workspaces/manager';
 import { ClipboardManager } from '../clipboard/manager';
@@ -187,6 +189,18 @@ export async function initializeRuntimeManagers(opts: InitializeRuntimeOptions):
   runtime.activityTracker = new ActivityTracker(win, runtime.panelManager, runtime.drawManager, runtime.wingmanStream);
   runtime.voiceManager = new VoiceManager(win, runtime.panelManager);
   runtime.behaviorObserver = new BehaviorObserver(win);
+  // Compile the per-user behavioural profile at boot so the agent's
+  // humanized click/type uses *this* user's typing rhythm rather than
+  // the hardcoded default. Cheap (pure JSONL read), async-safe, and
+  // logs the resulting profile source so you can see at a glance
+  // whether the real statistics kicked in this boot.
+  try {
+    const profile = behaviorCompiler.compile();
+    behaviorReplay.refreshProfile();
+    log.info(`🧬 Behaviour profile compiled: source=${profile.source ?? 'default'}, samples=${profile.samples ?? 0}, meanWpm=${profile.typingSpeed.meanWpm}`);
+  } catch (e) {
+    log.warn('Behaviour profile compile failed on boot:', e instanceof Error ? e.message : String(e));
+  }
   runtime.siteMemory = new SiteMemoryManager();
   runtime.watchManager = new WatchManager();
   runtime.headlessManager = new HeadlessManager();


### PR DESCRIPTION
**Phase 1 of the agent-learn layer.** Stops Tandem's humanization system from being cosmetic and makes it do what it says on the tin.

## The gap this closes

Tandem's pitch: *a real browser used by a real human — the AI rides alongside and clicks/types at that human's rhythm*. For that to hold, the behavioural layer has to actually learn from the user.

Before this PR:
- `BehaviorObserver` wrote keypress timings to `~/.tandem/behavior/raw/*.jsonl` — working (especially after the #168 fix).
- `BehaviorCompiler.compile()` **ignored the raw data entirely** and wrote a hardcoded `{ meanWpm: 85, variance: 15, curveBias: 'ease-in-out', averageSpeedPxPerMs: 1.2 }` profile.
- `BehaviorReplay` read that hardcoded profile and fed it into every `humanizedClick` / `humanizedType`.

Net effect: every Tandem install, every user, every agent, typed at the same "average typist" rhythm. That's a stable shared fingerprint — the opposite of per-user humanization.

## What changed

### 1. `src/behavior/compiler.ts` — full rewrite

- Reads every `~/.tandem/behavior/raw/*.jsonl`, extracts `keypress` events with positive interval.
- Drops outliers outside `[30ms, 2000ms]` — paste-bursts below, thinking pauses above. Neither represents typing rhythm.
- Percentile-trims the top and bottom 5% before computing statistics.
- Sanity window: if `meanWpm` falls outside `[20, 150]` the compile is rejected as paste-noise and the profile falls back to defaults.
- Sample floor: fewer than 100 sane intervals → defaults with `source: 'default-insufficient'`. Roughly a paragraph; enough to compute variance meaningfully, small enough to activate within a week of normal use.
- `BehavioralProfile` schema gains additive observability fields: `source`, `samples`, `lastCompiledAt`. `BehaviorReplay` doesn't read them, so no downstream change.
- Written file is `chmod 0o600`, matching the pattern established in audit #34 High-5 for the `.tandem` config tree.
- Pure helpers exported for unit testing: `filterOutliers`, `percentileTrim`, `computeStatsFromIntervals`, `extractIntervalsFromJsonl`.

### 2. `POST /behavior/recompile`

Rate-limited (10/min). Force-recompiles from the current JSONL stream and returns the new profile. Lets the user (or an MCP tool) pull in new rhythm data without restarting Tandem.

### 3. Compile on boot in `runtime.ts`

Right after `BehaviorObserver` is constructed we call `behaviorCompiler.compile()` + `behaviorReplay.refreshProfile()`, and log the resulting `source` / `samples` / `meanWpm` so you can see at a glance whether the real stats kicked in.

## Tests

**22 new compiler tests** (`src/behavior/tests/compiler.test.ts`):
- `filterOutliers`: drops < 30 ms, drops > 2000 ms, keeps band, handles empty.
- `percentileTrim`: removes 5% top/bottom from sorted arrays, short-array safety.
- `computeStatsFromIntervals`: correct meanWpm for a 200 ms/key distribution ≈ 60 WPM, non-zero variance on jittery data, zero variance on constant.
- `extractIntervalsFromJsonl`: skips non-keypress events, skips `interval <= 0` (pre-#168 records), tolerates malformed lines, handles empty.
- `compile()`: empty → default, below floor → default-insufficient, above floor → compiled with real stats, aggregates across multiple day files, outlier trim so paste-bursts don't skew the mean, sane-range gate rejects impossible WPM, writes profile.json to disk.
- `getProfile()`: reads persisted profile, falls back to compile on missing file.

**2 new route tests** (`src/api/tests/routes/misc.test.ts`):
- `POST /behavior/recompile` returns 200 with `ok: true` and a profile payload including a valid `source`.

## Live-verified

Booted Tandem from the new code:
```
[Main] 🧬 Behaviour profile compiled: source=default, samples=0, meanWpm=60
```
`samples=0` is correct for this machine — the historical JSONL is full of the pre-#168 `interval: 0` records, which `extractIntervalsFromJsonl` correctly skips. Fresh typing after this boot feeds real intervals; the next compile (via startup or `POST /behavior/recompile`) will pick them up.

`curl -X POST /behavior/recompile` returned 200 with the expected profile shape.

Full verify clean: **2712 tests pass** (+24 net new), 39 skipped, 1 pre-existing jsdom env error (unrelated), lint ✓, compile ✓, check-consistency ✓.

## Breaking-change review

- `BehavioralProfile` gains optional fields — strict superset, no consumer has to change.
- `BehaviorReplay` uses the existing fields unchanged; if `source === 'default'` the numbers it gets are exactly what they were before (60 WPM — actually a minor nudge from the old hardcoded 85 WPM, matching the more realistic default for a typical typist).
- `POST /behavior/recompile` is new route, additive.
- Startup compile is a single async-safe call; failures are logged and swallowed so they can't block boot.

## Follow-ups (separate PRs, deliberately not in scope)

- **PR B — webview keystroke rhythm capture.** Expands the data source so the agent learns from tab-content typing, not just shell-side keystrokes (URL bar / Wingman chat). Main-process-only (no injected JS, no preload hook); rhythm only, no keys, no site metadata. Privacy floor enforced in tests.
- **Phase 2 — mouse trajectory learning.** Needs webview-side mouse-move observation + Bézier curve fitting. Bigger design round of its own.