### PR TITLE
feat(behavior): capture webview keystroke rhythm (intervals only, no content)

### DIFF
--- a/src/behavior/observer.ts
+++ b/src/behavior/observer.ts
@@ -58,6 +58,26 @@ export class BehaviorObserver {
   // click-cadence profile, the wiring belongs in ActivityTracker on the
   // same webContents.before-input-event listener that handles keypress.
 
+  /**
+   * Record a keystroke rhythm interval observed inside a tab webview.
+   *
+   * PRIVACY FLOOR — this method deliberately accepts only a bare interval
+   * number. The caller (src/main.ts webContents.before-input-event hook)
+   * must never pass the key, the webContents URL, origin, tabId, or any
+   * other identifying metadata. The persisted JSONL event contains
+   * exactly {type, ts, data:{interval}} — shaped identically to the
+   * shell keypress event so BehaviorCompiler can consume both the same
+   * way. Keystroke *content* never touches disk.
+   */
+  recordWebviewKeypress(interval: number): void {
+    if (!Number.isFinite(interval) || interval <= 0 || interval >= 5000) return;
+    if (this.keypressIntervals.length >= this.MAX_SAMPLES) {
+      this.keypressIntervals.shift();
+    }
+    this.keypressIntervals.push(interval);
+    this.record({ type: 'keypress', ts: Date.now(), data: { interval } });
+  }
+
   /** Record a scroll event */
   recordScroll(deltaY: number, url?: string): void {
     this.record({ type: 'scroll', ts: Date.now(), data: { deltaY, url } });

--- a/src/behavior/tests/observer.test.ts
+++ b/src/behavior/tests/observer.test.ts
@@ -123,3 +123,90 @@ describe('BehaviorObserver — keypress interval', () => {
     observer.destroy();
   });
 });
+
+describe('BehaviorObserver.recordWebviewKeypress — privacy floor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+  });
+
+  it('persists keypress events that contain ONLY {type, ts, data.interval} — no keys, no site, no tab metadata', () => {
+    const win = makeMockWindow();
+    const observer = new BehaviorObserver(win as any);
+
+    observer.recordWebviewKeypress(150);
+    observer.recordWebviewKeypress(180);
+
+    const lines = extractWrittenKeypressLines();
+    expect(lines.length).toBe(2);
+    for (const parsed of lines) {
+      // The only allowed fields at the top level:
+      expect(Object.keys(parsed).sort()).toEqual(['data', 'ts', 'type']);
+      expect(parsed.type).toBe('keypress');
+      expect(typeof parsed.ts).toBe('number');
+      // And data may only carry "interval":
+      expect(Object.keys(parsed.data).sort()).toEqual(['interval']);
+      expect(typeof parsed.data.interval).toBe('number');
+    }
+    observer.destroy();
+  });
+
+  it('rejects non-positive intervals (no persisted event at all)', () => {
+    const win = makeMockWindow();
+    const observer = new BehaviorObserver(win as any);
+
+    observer.recordWebviewKeypress(0);
+    observer.recordWebviewKeypress(-5);
+    observer.recordWebviewKeypress(NaN);
+
+    expect(extractWrittenKeypressLines().length).toBe(0);
+    observer.destroy();
+  });
+
+  it('rejects intervals >= 5000ms as cross-session pauses (no persisted event)', () => {
+    const win = makeMockWindow();
+    const observer = new BehaviorObserver(win as any);
+
+    observer.recordWebviewKeypress(4999); // accepted
+    observer.recordWebviewKeypress(5000); // rejected
+    observer.recordWebviewKeypress(6000); // rejected
+
+    const lines = extractWrittenKeypressLines();
+    expect(lines.length).toBe(1);
+    expect(lines[0].data.interval).toBe(4999);
+    observer.destroy();
+  });
+
+  it('feeds recorded intervals into the same keypressIntervals stats as shell keypresses', () => {
+    const win = makeMockWindow();
+    const observer = new BehaviorObserver(win as any);
+
+    observer.recordWebviewKeypress(150);
+    observer.recordWebviewKeypress(180);
+    observer.recordWebviewKeypress(210);
+
+    const stats = observer.getStats() as Record<string, unknown>;
+    expect(stats.keypressSamples).toBe(3);
+    expect(stats.avgKeypressIntervalMs).toBe(Math.round((150 + 180 + 210) / 3));
+    observer.destroy();
+  });
+});
+
+/** Parse every keypress line written by the mocked file stream. */
+function extractWrittenKeypressLines(): Array<{ type: string; ts: number; data: { interval: number } }> {
+  const streamCalls = vi.mocked(fs.createWriteStream).mock.results;
+  const out: Array<{ type: string; ts: number; data: { interval: number } }> = [];
+  for (const r of streamCalls) {
+    if (r.type !== 'return') continue;
+    const stream = r.value as { write: ReturnType<typeof vi.fn> };
+    for (const [line] of stream.write.mock.calls) {
+      const text = String(line).trim();
+      if (!text) continue;
+      try {
+        const parsed = JSON.parse(text);
+        if (parsed.type === 'keypress') out.push(parsed);
+      } catch { /* ignore */ }
+    }
+  }
+  return out;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -319,6 +319,28 @@ async function createWindow(): Promise<BrowserWindow> {
         }
       });
 
+      // Webview keystroke rhythm capture for the BehaviorCompiler.
+      // PRIVACY FLOOR: we ONLY look at input.type to decide this is a
+      // character keydown, and we NEVER read input.key, input.code, the
+      // webContents URL, partition, tabId, or any other identifying
+      // metadata. The observer receives just a millisecond interval and
+      // persists it as the same shape as the shell keypress JSONL event.
+      // Keystroke content never touches disk. See design doc in
+      // docs/superpowers/behavior-compiler-design.md (phase 1, PR B).
+      let lastWebviewKeypressTs = 0;
+      contents.on('before-input-event', (_inputEvt, input) => {
+        if (input.type !== 'keyDown') return;
+        // input.key.length === 1 filters out modifier/arrow/function keys
+        // without reading the value — only its length.
+        if (!input.key || input.key.length !== 1) return;
+        const now = Date.now();
+        const interval = lastWebviewKeypressTs > 0 ? now - lastWebviewKeypressTs : 0;
+        lastWebviewKeypressTs = now;
+        if (interval > 0) {
+          runtime?.behaviorObserver?.recordWebviewKeypress(interval);
+        }
+      });
+
       if (!isSidebarWebview) {
         contents.on('did-finish-load', () => {
           runtime?.securityManager.onTabNavigated(contents.id).catch(e => log.warn('securityManager.onTabNavigated failed:', e instanceof Error ? e.message : e));


### PR DESCRIPTION
**Phase 1b of the agent-learn layer.** Extends the behaviour-observer's data source from shell-only (URL bar + Wingman chat — mostly short commands) to also include tab-content typing. That's where most of the user's real typing happens, so it's where the per-user rhythm statistics actually come from.

## Privacy floor — the central design constraint

Keystroke **content** never touches disk. The hook reads only:
- `input.type` (to confirm this is a `keyDown`)
- `input.key.length` (to confirm it's a single-character key, not a modifier/arrow/function key)

It **never** reads `input.key` itself, the webContents URL / origin / partition, the tabId, or any other identifying metadata.

`BehaviorObserver.recordWebviewKeypress` accepts exactly one argument — a millisecond interval — and persists it as a JSONL event shaped identically to the existing shell keypress event:

```json
{"type":"keypress","ts":1776519550041,"data":{"interval":360}}
```

No other fields. Same shape the BehaviorCompiler (from #169) already consumes, so **no change to the downstream pipeline**.

A regression-guard test inspects every persisted keypress line and fails red if any field other than `{type, ts, data.interval}` appears.

## What changed

### 1. `src/behavior/observer.ts` — new `recordWebviewKeypress` method

Accepts a bare interval number. Rejects non-finite / `<= 0` / `>= 5000` values (same gate as the shell observer's in-memory interval tracker). Accepted intervals flow through the existing `record()` code path and also populate the in-memory `keypressIntervals` array, so `getStats()` reflects the full keypress sample from both sources.

### 2. `src/main.ts` — `before-input-event` listener inside the existing `web-contents-created` handler

Gated on `contents.getType() === 'webview'` so it only fires for tab-content webContents (not the shell, not popup BrowserWindows, not extension helper views).

The handler keeps a **per-webContents** `lastTs` in a closure so cross-tab focus switches (which can take minutes) don't pollute rhythm with huge intervals. The observer's own filter drops anything `>= 5000ms` as a second line of defense.

**Main-process only. No injected JS, no preload hook** — smallest possible expansion of the stealth surface.

## Tests

4 new tests in `src/behavior/tests/observer.test.ts` under a new *privacy floor* describe block:

- Persisted keypress events contain **only** the top-level keys `{type, ts, data}` and `data` has **only** `{interval}`. Any regression that leaks `input.key` / `url` / `tabId` / `origin` / `partition` / `host` fails this test.
- Rejects non-positive and `NaN` intervals (no event written).
- Rejects intervals `>= 5000ms` as cross-session pauses.
- Intervals feed the same `getStats()` sample pool as shell keypresses, so the compiler sees one aggregate stream.

Full verify clean: **2716 tests pass** (+4 net new), 39 skipped, 1 pre-existing jsdom env error (unrelated), lint ✓, compile ✓, check-consistency ✓.

## Live-verified

Booted Tandem from the new code. Baseline after boot:

```
keypressSamples=0 avgKeypressIntervalMs=null
```

Typed a short sentence in a real tab (Google.com search box). After ~10 seconds:

```
keypressSamples=41 avgKeypressIntervalMs=372
```

Tailed today's JSONL — every new keypress line has exactly the expected shape:

```json
{"type":"keypress","ts":1776519550041,"data":{"interval":360}}
{"type":"keypress","ts":1776519550475,"data":{"interval":434}}
{"type":"keypress","ts":1776519550758,"data":{"interval":283}}
...
```

Privacy-leak grep on all today's keypress events for `key` / `url` / `tabId` / `origin` / `partition` / `host` — **empty**. Clean.

`POST /behavior/recompile` against the fresh data returned `source=default-insufficient` (`samples=36` after the compiler's `[30, 2000]ms` outlier filter, still below the 100-floor). That confirms both paths work — once the user crosses the floor the source flips to `compiled` on the next compile.

## Breaking-change review — none

The observer gains a public method; existing `recordScroll` / `recordNavigation` / `recordTabSwitch` / keypress observation all unchanged. The main.ts listener sits alongside the existing stealth injection and context menu registration — no re-ordering, no new globals, no new IPC. No API surface change.

## What comes next — phase 2, separate PR / session

Mouse trajectory learning still needs webview-side mouse-move observation plus Bézier curve fitting on top of that stream. Bigger design round of its own.