### PR TITLE
chore: release v0.75.0

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -101,7 +101,7 @@ All persistent data is stored in `~/.tandem/`:
 | Workspaces | `workspaces.json` | WorkspaceManager |
 | Bookmarks | `bookmarks/` | BookmarkManager |
 | History | `history/` | HistoryManager |
-| Behavior profiles | `behavior/` | BehaviorObserver |
+| Behavior profiles | `behavior/` (raw JSONL + compiled `profile.json`) | BehaviorObserver + BehaviorCompiler |
 | Sessions | `sessions/` | SessionManager |
 | Extensions | `extensions/` | ExtensionLoader |
 | Passwords | `passwords/` (AES-256-GCM) | Password vault |
@@ -178,6 +178,34 @@ Security code lives in `src/security/`. Key files:
 | `prompt-injection-guard.ts` | Layer 8 — injection defense |
 | `security-manager.ts` | Orchestrator for all layers |
 | `guardian.ts` | Unified threat coordination |
+
+### Approval gates on posture-weakening actions
+
+Since v0.75.0, API routes that would **weaken** the security posture for a
+domain require an interactive user approval via the Wingman panel before the
+change takes effect. Covers `/security/guardian/mode` (lowering mode),
+`/security/domains/:domain/trust` (raising trust), `/security/outbound/whitelist`
+(adding a bypass pair), and `/security/injection-override` for agent-initiated
+callers. Tightening and no-op changes pass through without friction. The gate
+exists because a prompt-injected agent must not be able to silence the
+defences that protect against the injection itself.
+
+### Humanized interaction + stealth
+
+Tandem's stealth layer (`src/stealth/manager.ts`) injects per-session
+fingerprint-noise patches (canvas / WebGL / audio / font / timing) and
+scrubs Electron giveaways from `window`. Each install uses a random
+per-install base secret persisted in `~/.tandem/config.json`, so noise
+patterns are unique per install — there is no shared "Tandem" fingerprint.
+
+Agent-driven input (`/click`, `/type`) flows through `src/input/humanized.ts`
+which uses OS-level `sendInputEvent` (so `Event.isTrusted` is `true`), adds
+Gaussian offsets inside the target element, hesitates before the click, and
+samples a per-user Bézier-ish trajectory. The typing delay and trajectory
+come from `BehaviorReplay`, which reads a `profile.json` compiled from the
+raw keystroke JSONL by `BehaviorCompiler` on every boot (and on-demand via
+`POST /behavior/recompile`). Each user's agent types at that user's rhythm
+once enough samples have accumulated.
 
 ## Shell Architecture
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,44 @@
 
 All notable changes to Tandem Browser will be documented in this file.
 
+## [v0.75.0] - 2026-04-18
+
+Large release driven by an external security audit (#34) by **[@samantha-gb](https://github.com/samantha-gb)** and follow-up work that surfaced while implementing her findings. Five High-tier security fixes plus CORS and agent-initiated override hardening landed alongside a proper per-user behavioural learning pipeline and audio/visual escalation for agent-blocked approvals.
+
+Twelve merged PRs. Grouped below by area.
+
+### Security — audit #34 findings addressed
+
+- **Scheme + private-IP guard on `/navigate` and `/headless/open` (High-2)** — new `isSafeNavigationUrl()` helper rejects non-http(s) schemes (file://, javascript:, data:, …) and RFC1918 / link-local / cloud-metadata IP literals, including IPv6 edge cases. ([#159](https://github.com/hydro13/tandem-browser/pull/159))
+- **Form-memory files hardened to `0o600` (High-5)** — `{ mode: 0o600 }` on `~/.tandem/config.json` and `~/.tandem/forms/*.json`, with a `chmodSync` migration step that tightens pre-existing loose files on next boot. ([#159](https://github.com/hydro13/tandem-browser/pull/159))
+- **Per-install random stealth seed (Low/stealth)** — replaced the deterministic `sha256('persist:tandem')` seed with a per-install random secret persisted in `~/.tandem/config.json`. Every install now produces a unique fingerprint-noise pattern; previously every install shared the same signature. ([#159](https://github.com/hydro13/tandem-browser/pull/159))
+- **Security-weakening endpoints behind user approval (High-1)** — `POST /security/guardian/mode`, `POST /security/domains/:domain/trust`, and `POST /security/outbound/whitelist` now require interactive user approval via `taskManager.requestApproval` when the change would weaken posture. Tightening and no-op changes still pass through without friction. ([#161](https://github.com/hydro13/tandem-browser/pull/161))
+- **Unused `EXECUTE_JS` IPC channel removed (High-4)** — the channel had zero callers but would have amplified any XSS reaching the shell into arbitrary JS in the active tab. Agent-driven JS execution continues to flow through the scanner-protected HTTP routes. ([#162](https://github.com/hydro13/tandem-browser/pull/162))
+- **CRX3 RSA signature verification on extension install (High-3)** — hand-rolled protobuf decoder parses the CRX3 envelope, verifies the SHA-256-with-RSA signature, and binds the signing key back to the expected extension ID. CRX2 downloads are rejected outright. Defends against MITM or CDN compromise during CWS downloads. ([#163](https://github.com/hydro13/tandem-browser/pull/163))
+- **Agent-initiated `/security/injection-override` behind user approval (Medium #3)** — silencing the prompt-injection scanner now requires either the user clicking "Override" in the scanner modal (existing flow, unchanged) or an interactive approval prompt for any other caller. Prevents a prompt-injected agent from disabling the defence against its own compromise. ([#164](https://github.com/hydro13/tandem-browser/pull/164), corrected in [#165](https://github.com/hydro13/tandem-browser/pull/165))
+- **CORS `Origin: null` rejected on public routes (Medium #1)** — closes a cross-tab information leak where a sandboxed iframe or `data:` URI could fetch `/status` from localhost and read the active tab's URL/title. Shell-fetches pass through because modern Electron strips the Origin header (verified via logging investigation). ([#165](https://github.com/hydro13/tandem-browser/pull/165))
+- **Date.now jitter removed from the stealth script (Low #4)** — the ±1 ms jitter was itself a reliable "not real Chrome" fingerprint (real Chrome returns the same ms for back-to-back calls). `performance.now` rounding to 100 μs (Firefox parity) remains as the effective timing-fingerprint defence. Also fixed a BehaviorObserver bug that persisted `interval: 0` on every keypress event, and removed the unwired `recordClick` method. ([#168](https://github.com/hydro13/tandem-browser/pull/168))
+
+### Wingman UX
+
+- **Wingman Activity and Chat panels now sync on approval resolution** — clicking Approve/Reject in one panel dismisses the matching card in the other. The underlying `approval-response` event is now forwarded to the shell via a new IPC channel mirroring `APPROVAL_REQUEST`. ([#166](https://github.com/hydro13/tandem-browser/pull/166))
+- **Audio ping + escalation + user-return re-alert on approval requests** — when an agent stalls waiting for human input, the user now gets: (a) an immediate native-OS notification with the system sound; (b) a second ping after 12 s if the request is still unacknowledged; (c) a third ping when the user returns to Tandem after being away for more than 10 s. A 5 s rate limit prevents stacking. Exists because "AI is stalled on a call" is an invisible state today if the user happens to be in a different workspace or away. ([#167](https://github.com/hydro13/tandem-browser/pull/167))
+
+### Agent-learn layer — phase 1
+
+- **BehaviorCompiler is real now, not a stub** — reads `~/.tandem/behavior/raw/*.jsonl`, extracts valid keypress intervals, drops outliers (below 30 ms / above 2000 ms), percentile-trims 5%, and computes a per-user `meanWpm` / `variance`. Fallback to hardcoded defaults below a 100-sample floor or outside a `[20, 150]` WPM sane range. `BehavioralProfile` gained additive observability fields: `source` (default / default-insufficient / compiled), `samples`, `lastCompiledAt`. Compiled at every Tandem boot; new `POST /behavior/recompile` endpoint forces a fresh compile on demand. Was previously a comment saying "in a real scenario we would parse the data; for now we compile defaults" — so every install's agent typed at the same average-typist rhythm. ([#169](https://github.com/hydro13/tandem-browser/pull/169))
+- **Webview keystroke rhythm capture (intervals only, no content)** — a `before-input-event` listener inside the existing `web-contents-created` handler captures typing rhythm from tab content, feeding the same JSONL stream the shell observer already populates. PRIVACY FLOOR: only `input.type` and `input.key.length` are read; the key value itself, the webContents URL, origin, partition, and tabId are never read. Persisted events contain only `{type, ts, data: {interval}}`. A regression-guard test inspects every persisted event and fails red if anything else appears. ([#170](https://github.com/hydro13/tandem-browser/pull/170))
+
+### Documentation
+
+- **[@samantha-gb](https://github.com/samantha-gb) acknowledged in SECURITY.md and on the contributor graph via `Co-authored-by:` trailers.** Her security audit drove nine of the twelve PRs in this release. ([#160](https://github.com/hydro13/tandem-browser/pull/160))
+- **SECURITY.md restructured** with explicit "anonymous / pseudonymous reports welcome" copy, a "no bounty, yes gratitude" section describing what contributors can expect in exchange for a responsible report, and a new Hall of Fame.
+
+### Internal notes
+
+- **Threat model clarified for future security reviews.** Tandem's trust perimeter sits between web content and the team (user + paired local/remote agents), not between team members. Findings that describe authenticated callers receiving internal tokens or state are, under this model, not vulnerabilities. Several items from the #34 audit were re-evaluated and intentionally not changed on that basis; the reasoning is documented inline in the relevant PR comments and in `SECURITY.md`.
+- **Cross-panel sync bug surfaced and fixed while testing the injection-override approval flow.** The audio/escalation UX work was added after live-testing revealed that agent stalls could go unnoticed when the user was in a different workspace.
+
 ## [v0.74.0] - 2026-04-17
 
 - refactor: split the renderer shell into ES modules + fix a long-standing workspace assignment race

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -31,7 +31,7 @@ The security layer exists because when an AI has access to your browser, your th
 Data stays local. Sessions are isolated. Nothing leaves the machine through Tandem Browser without going through a filter first.
 
 **GitHub:** `hydro13/tandem-browser`  
-**Current version:** `0.74.0`  
+**Current version:** `0.75.0`  
 **Repository status:** Public developer preview  
 **Started:** February 11, 2026
 

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ contributors, not yet a polished mass-user release.
 - Secondary platform: Linux
 - Windows: validated as a remote agent host (VS Code + Claude Code over Tailscale)
 - Binaries: not published yet (source-only)
-- Current version: `0.74.0`
+- Current version: `0.75.0`
 - Package metadata: [package.json](package.json)
 
 ## Community

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,13 +5,22 @@ issue with exploit details.
 
 ## Reporting
 
-Use GitHub private vulnerability reporting when it is enabled for the repository.
-If that is not available yet, open a minimal issue without exploit details and
-request a private contact channel from the maintainers.
+**Preferred**: use GitHub's private vulnerability reporting —
+<https://github.com/hydro13/tandem-browser/security/advisories/new>. That keeps
+exploit details out of the public issue stream until a fix ships.
+
+**Alternative**: open a minimal issue without exploit details and ask for a
+private contact channel. Something like *"Security: need a private channel"*
+with no payload is perfectly fine.
+
+**Anonymous / pseudonymous reports are welcome.** You do not have to use your
+main GitHub account. Tandem's first external security audit came from a
+purpose-built pseudonym; that's a completely legitimate way to report, and
+we'll treat it with the same seriousness as any signed report.
 
 Include:
 
-- a clear description or the issue
+- a clear description of the issue
 - affected version or commit
 - reproduction steps
 - impact assessment
@@ -19,7 +28,7 @@ Include:
 
 ## Scope
 
-Security issues or particular interest include:
+Security issues of particular interest include:
 
 - local API exposure or auth bypass
 - Electron sandbox or isolation breaks
@@ -37,18 +46,61 @@ Strong reports usually include:
 - whether OpenClaw integration is required for reproduction
 - whether the issue leaks data, breaks containment, or creates a detectable fingerprint
 
+## Threat model
+
+Tandem's security perimeter sits between **web content** and the **team**.
+The team is the human user plus every AI agent that's explicitly connected —
+local (same machine) or remote (paired over a private Tailscale network). All
+team members share tabs, sessions, and authenticated browser state; that's the
+product, not a bug. Tandem's eight-layer security stack is there to stop
+hostile content on the web from compromising a team member — especially via
+prompt injection against an agent.
+
+That framing matters when evaluating reports:
+
+- "Endpoint X returns value Y to any authenticated caller" is, on Tandem,
+  not a vulnerability — authenticated callers are team members by design.
+- "Web content can cause a team member to do X" is the core threat model
+  and is exactly the kind of report we want.
+
+If a report is ambiguous about which category it falls into, say so and we'll
+discuss.
+
 ## Disclosure
 
 Please allow time for triage and a fix before public disclosure.
 
-## Acknowledgments
+## No bounty, yes gratitude
 
-Tandem Browser is grateful to the security researchers who have responsibly
-reported issues and helped strengthen the project. If you would like to be
-listed here after reporting, say so in your report.
+Tandem is a solo-maintained open-source project without any budget for paid
+bounties. What you *can* expect in exchange for a responsible report:
+
+- A direct reply from the maintainer within a few days, and transparent
+  updates as fixes ship.
+- An acknowledgement in this document's Hall of Fame below, under the name
+  or pseudonym you specify — or, if you ask, no public mention at all.
+- A `Co-authored-by:` trailer on the PRs that address your findings, so
+  your (pseudonymous) GitHub identity appears on the contributor graph for
+  those commits.
+- The knowledge that the fixes land in local-first software that real
+  humans and their AI agents use in daily workflows.
+
+If that trade doesn't match your time — fair, and thanks for considering it.
+
+## Hall of Fame
+
+Tandem is grateful to the security researchers who have responsibly reported
+issues and helped strengthen the project. If you would like to be listed here
+after reporting, say so in your report. Anonymous and pseudonymous names are
+welcome; no real-name requirement.
 
 - **[@samantha-gb](https://github.com/samantha-gb)** — external security audit
-  covering ungated JS execution, URL-scheme validation in the agent-facing API,
-  credential-file permissions, and fingerprint-seed determinism
-  ([#34](https://github.com/hydro13/tandem-browser/issues/34)). Findings are
-  being addressed across several releases starting with [#159](https://github.com/hydro13/tandem-browser/pull/159).
+  covering ungated JS execution, URL-scheme validation in the agent-facing
+  API, credential-file permissions, CORS hardening, CRX signature
+  verification, approval gates on security-weakening endpoints, and
+  fingerprint-seed determinism
+  ([#34](https://github.com/hydro13/tandem-browser/issues/34)). Findings were
+  addressed across #159, #161, #162, #163, #164, #165, and #168 — reviewed
+  under Tandem's trust model.
+
+  *Thank you, wherever you are. The door stays open.*

--- a/docs/api-current.md
+++ b/docs/api-current.md
@@ -5,8 +5,63 @@ It is based on the current code in `src/api/routes/` and related modules.
 
 ## Route Count
 
-Tandem currently exposes `301` HTTP routes across the API and security route
+Tandem currently exposes `302` HTTP routes across the API and security route
 modules.
+
+## New in v0.75.0
+
+### `POST /behavior/recompile`
+
+Forces an on-demand recompile of the per-user behavioural profile from the
+current `~/.tandem/behavior/raw/*.jsonl` stream and returns the freshly-
+computed profile. Useful after a long typing session when you want the
+agent's humanized click/type to incorporate new rhythm data without
+restarting Tandem.
+
+Response shape:
+
+```json
+{
+  "ok": true,
+  "profile": {
+    "typingSpeed": { "meanWpm": 62, "variance": 38 },
+    "mouseMovement": { "curveBias": "ease-in-out", "averageSpeedPxPerMs": 1.2 },
+    "source": "compiled",
+    "samples": 142,
+    "lastCompiledAt": 1776519584976
+  }
+}
+```
+
+The `source` discriminator lets callers tell at a glance whether the profile
+reflects real user data (`compiled`) or still-at-floor fallback values
+(`default-insufficient` = data exists but below the 100-sample floor;
+`default` = no data at all). Rate-limited at 10 requests / minute.
+
+The behavioural profile also auto-compiles on every Tandem boot. You only
+need `/behavior/recompile` if you want freshly-typed data to flow into the
+agent within the same session.
+
+### Interactive approval on security-weakening endpoints
+
+The following endpoints now require an interactive user approval via the
+Wingman panel when the requested change would *weaken* Tandem's security
+posture. Tightening and no-op changes still pass through without friction.
+Rejected requests return `403 { rejected: true }`.
+
+- `POST /security/guardian/mode` — lowering the per-domain guardian mode
+  (e.g., `balanced → permissive`) requires approval.
+- `POST /security/domains/:domain/trust` — raising the trust level for a
+  domain requires approval.
+- `POST /security/outbound/whitelist` — always requires approval (adding
+  a whitelist pair is inherently a bypass).
+- `POST /security/injection-override` — requires approval for agent / MCP
+  callers. Shell-initiated calls (after the scanner's own double-
+  confirmation modal) pass through via the `X-Tandem-Shell-Initiated: 1`
+  header.
+
+Approval tasks appear in Wingman's Activity panel and Chat panel with
+Approve / Reject buttons; clicking either dismisses both.
 
 ## `POST /tabs/open`
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -140,7 +140,7 @@ footer a:hover{color:var(--text2)}
 </header>
 
 <div class="hero">
-<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v0.74.0</div>
+<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v0.75.0</div>
 <h1>Tandem Browser is the <em>human-AI symbiotic browser</em></h1>
 <p>A local-first browser where humans and AI agents work in shared context. Same tabs, same sessions, same authenticated browser state, with explicit handoffs when the human needs to step in. Local or remote, one agent or several. Not generic browser automation, an actual shared browser workspace for the web that already exists.</p>
 <div class="hero-stats">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tandem-browser",
-  "version": "0.74.0",
+  "version": "0.75.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tandem-browser",
-      "version": "0.74.0",
+      "version": "0.75.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-browser",
-  "version": "0.74.0",
+  "version": "0.75.0",
   "description": "Local-first Electron browser with a 250-tool MCP server, MCP/HTTP control surfaces, and built-in security controls",
   "main": "dist/main.js",
   "author": "Tandem Browser contributors",


### PR DESCRIPTION
Release prep for **v0.75.0** — bumps every version-aware file to `0.75.0`, inserts a structured CHANGELOG entry covering the twelve merged PRs since `v0.74.0`, and brings SECURITY.md, api-current.md, and ARCHITECTURE.md in line with what the code actually does now.

## What's in 0.75.0 (by area)

### Security — audit #34 findings

Nine of twelve PRs came out of @samantha-gb's external audit in [#34](https://github.com/hydro13/tandem-browser/issues/34). All five High-tier findings shipped; relevant Medium/Low items shipped or were re-evaluated under Tandem's trust model.

- #159 URL scheme + private-IP guard, form-memory 0o600, per-install stealth seed
- #161 user approval on security-weakening endpoints (guardian-mode / trust / whitelist)
- #162 unused EXECUTE_JS IPC removed
- #163 CRX3 RSA signature verification + key→ID binding + CRX2 reject
- #164 + #165 injection-override approval gate + CORS `null` origin reject + shell-detection regression fix
- #168 Date.now jitter removed (was itself anti-stealth), keypress bug fix, dead code removed

### Wingman UX

- #166 Activity ↔ Chat approval card sync — approve/reject in one panel dismisses the card in the other.
- #167 audio ping + escalation + user-return re-alert. Agents stalling on a human approval now surface audibly, with re-pings on the 12 s escalation timer and when the user returns to Tandem after being away for 10 s+. 5 s rate limit prevents stacking.

### Agent-learn — phase 1

- #169 BehaviorCompiler rewrite: real JSONL parsing, per-user `meanWpm`/`variance`, outlier + percentile trim, 100-sample floor, sane-range gate, `source` discriminator in profile for observability. Startup compile + `POST /behavior/recompile` endpoint.
- #170 webview keystroke rhythm capture with a hard privacy floor — interval-only, no keys, no URL, no tab metadata. Regression-guard test fails red on any content leak.

### Docs / credits

- #160 @samantha-gb acknowledged in SECURITY.md and via `Co-authored-by:` trailers on the relevant commits.

## What this PR does

- `npm version 0.75.0 --no-git-tag-version` (bumps `package.json` + `package-lock.json`)
- `node scripts/check-consistency.js --fix` carries the version through `README.md`, `PROJECT.md`, and `docs/index.html` (the website hero)
- `CHANGELOG.md` — new v0.75.0 entry organised by area (Security / Wingman UX / Agent-learn / Docs / Internal notes)
- `SECURITY.md` — restructured with:
  - explicit *"anonymous / pseudonymous reports welcome"* copy
  - a new **Threat model** section clarifying the web↔team perimeter so future reviewers don't repeat the authenticated-caller-is-team-member discussion
  - a new **No bounty, yes gratitude** section that's honest about the project's solo-maintainer economics
  - a **Hall of Fame** that welcomes pseudonyms
- `docs/api-current.md` — new sections for `POST /behavior/recompile` and the four interactive-approval endpoints
- `ARCHITECTURE.md` — minor updates on the approval gates, stealth seed per-install, humanized-input pipeline now backed by real profile data

Everything additive; no breaking changes. Downstream artefacts and binary build workflow are not in scope here (follow-up — Tandem still distributes source-only).

## Verification

- `npm run compile` ✓
- `npm run lint` ✓ (no issues)
- `npm test` — 2716 tests pass, 39 skipped, 1 pre-existing jsdom env error (unrelated)
- `npm run check-consistency` — `v0.75.0, 250 tools` across all checked files

## After this merges

1. `git tag v0.75.0`
2. `git push origin v0.75.0`
3. GitHub Release with the CHANGELOG entry as body