### PR TITLE
docs: surface model-agnosticism as a first-class unlock

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ possible* for the first time:
 - **Cold-start usable** — point a capable model (Claude, Cursor, a local
   Ollama model) at a fresh Tandem install and a normal web task works on day
   one. No per-site recipes to author, no retrain-per-flow phase.
+- **Bring any AI** — Tandem is model-agnostic. Any agent that speaks MCP
+  or HTTP works — Claude, GPT, Gemini, local Ollama, LM Studio, custom
+  scripts. Swap models when a cheaper or faster one ships. Run two at
+  once. Go fully offline with a local model. The browser doesn't care
+  which brain you plug in.
 
 It works on the web that already exists — no site has to opt in, no new
 protocol has to land. Agents connect on the same machine or remotely over
@@ -160,6 +165,11 @@ Depending on what you want to do:
 - **Support development** -> sponsor Tandem on [GitHub Sponsors](https://github.com/sponsors/hydro13)
 
 ## Connect Your AI Agent
+
+**Tandem is model-agnostic.** Any agent that speaks MCP or HTTP works —
+Claude, GPT, Gemini, local Ollama, LM Studio, custom scripts. Swap models,
+combine models, run fully offline. The browser does not care which AI you
+bring.
 
 Tandem supports AI agents running on the same machine or on a remote machine
 over a private Tailscale network. Both can be active at the same time.

--- a/docs/index.html
+++ b/docs/index.html
@@ -159,7 +159,7 @@ footer a:hover{color:var(--text2)}
 <div class="proof-card"><strong>Automate any SaaS, no API needed</strong><span>If you can use it in a browser, your agent can use it in Tandem. Gmail, Coolblue, Funda, internal tools — same session, same login, no wrapper per site.</span></div>
 <div class="proof-card"><strong>Rewrite live UI on the fly</strong><span>&quot;Overlay the square-meter-price on every listing&quot; and the agent injects a script into the real site, in the real session, while you keep scrolling.</span></div>
 <div class="proof-card"><strong>Read beyond what&rsquo;s rendered</strong><span>Accessibility tree + network log + DOM + DevTools. The agent sees structure and hidden traffic, not a screenshot and a guess.</span></div>
-<div class="proof-card"><strong>Strong model, useful on day one</strong><span>No per-site recipes to train. Install Tandem, point Claude or a local model at it, and a normal web task works straight away.</span></div>
+<div class="proof-card"><strong>Bring any AI</strong><span>Tandem is model-agnostic. Claude, GPT, Gemini, local Ollama, LM Studio, custom scripts &mdash; anything that speaks MCP or HTTP. Swap them, combine them, run fully offline.</span></div>
 </div>
 </div>
 
@@ -195,8 +195,8 @@ footer a:hover{color:var(--text2)}
 <p>The moment you install Tandem and connect a strong model, normal web tasks work. No per-site training, no &ldquo;teach it your flow&rdquo; phase, no hand-authored recipes. The capability is in the model; Tandem just gives it a real browser to stand on.</p>
 </div>
 <div class="concept-block">
-<h3>AI improves, Tandem improves with it</h3>
-<p>A better Claude release or a smarter local Ollama model shows up as a better Tandem experience the same day. There is no prompt-chain glue between you and the model that needs to be rewritten every time the frontier moves — the agent&apos;s skill is the agent&apos;s skill, Tandem just gives it working hands.</p>
+<h3>Bring any AI</h3>
+<p>Tandem is model-agnostic. Any agent that speaks MCP or HTTP works &mdash; Claude, GPT, Gemini, local Ollama, LM Studio, custom scripts. Swap models when a cheaper or faster one ships. Run two at once. Go fully offline with a local model. The browser doesn&apos;t care which brain you plug in &mdash; which also means a better Claude release or a smarter Ollama model shows up as a better Tandem experience the same day, without any glue code to rewrite.</p>
 </div>
 </div>
 </section>
@@ -324,8 +324,8 @@ footer a:hover{color:var(--text2)}
 
 <section>
 <div class="section-label">Multi-agent symbiosis</div>
-<div class="section-title">Multiple AI agents + one human. Same browser.</div>
-<p style="font-size:.85rem;color:var(--text2);max-width:640px">Tandem Browser supports multiple AI agents and a human working simultaneously in the same browser. Agents can connect locally or remotely over Tailscale. Each gets their own workspace. All share the same tabs, cookies, and sessions. Tab locks prevent conflicts.</p>
+<div class="section-title">Multiple AI agents + one human. Different model vendors. Same browser.</div>
+<p style="font-size:.85rem;color:var(--text2);max-width:680px">Tandem supports multiple AI agents and a human working simultaneously in the same browser &mdash; and they do not have to be the same model or the same vendor. A local Ollama model for private research, Claude Code on another machine for heavy reasoning, you in the driver&apos;s seat. Agents connect locally or remotely over Tailscale. Each gets their own workspace. All share the same tabs, cookies, and sessions. Tab locks prevent conflicts.</p>
 <div class="riders">
 <div class="rider">
 <div class="rider-icon">&#128100;</div>
@@ -407,7 +407,8 @@ The browser opens. The API starts automatically.</p>
 <div class="step-num">3</div>
 <div class="step-content">
 <h3>Connect your AI</h3>
-<p>Open Settings &rarr; Connected Agents. Choose whether your AI is on this machine or on another machine. Tandem generates the instructions, you paste them into your AI, and the agent discovers the rest through Tandem's own bootstrap surface.</p>
+<p><strong>Bring any AI.</strong> Tandem is model-agnostic. Any agent that speaks MCP or HTTP works &mdash; Claude, GPT, local Ollama, LM Studio, custom scripts. Swap models, combine models, run offline. The browser doesn&apos;t care which AI you bring.</p>
+<p style="margin-top:.4rem">Open Settings &rarr; Connected Agents. Choose whether your AI is on this machine or on another machine. Tandem generates the instructions, you paste them into your AI, and the agent discovers the rest through Tandem&apos;s own bootstrap surface.</p>
 <p style="margin-top:.4rem"><strong>Same machine:</strong> MCP via stdio (250 tools) or HTTP API (300+ endpoints).<br>
 <strong>Another machine:</strong> MCP via Streamable HTTP or HTTP API, over a private Tailscale network. Both machines must be on the same tailnet. Tandem is never exposed to the public internet.</p>
 </div>


### PR DESCRIPTION
## Why

Follow-up to #172. That PR nailed the web-side unlocks (no-API SaaS, live UI rewriting, beyond-pixels, co-browsing, cold-start) but buried a separate axis that is just as much of a differentiator: **you can bring any AI.** For anyone following the model wars — Claude vs GPT vs Gemini vs local Ollama getting steadily better — swap-combine-run-offline is itself a reason to pick Tandem.

## What changes

**Heading + anchor** across both files:
> **Bring any AI.** Tandem is model-agnostic.

Warm hook for non-technical readers, precise anchor for developers.

**Website (`docs/index.html`):**
- Hero proof-strip: \"Strong model, useful on day one\" → \"Bring any AI\" (cold-start story stays in the full unlocks section below)
- \"What this unlocks\": \"AI improves, Tandem improves with it\" → \"Bring any AI\" (the improves-with-AI insight weaves into the last sentence of the new copy, because it follows logically)
- Multi-agent symbiosis subtitle: adds \"**Different model vendors.**\" so the Robin + Kees (Ollama) + Claude Code (Anthropic, remote) example reads as the model-agnostic proof it already was
- Get Started step 3: replaces the flat *\"Choose whether your AI is on this machine or on another machine\"* with an explicit Bring-any-AI paragraph before the local/remote split

**README (`README.md`):**
- Intro: adds a 6th unlock bullet (Bring any AI)
- \"Connect Your AI Agent\": opens with \"**Tandem is model-agnostic.**\" ahead of the local/remote split

## What does not change

- No version, tool-count, or endpoint numbers touched
- No new sections; existing sections reworded or augmented in place
- Cold-start unlock remains (in the full unlocks section, just not in the hero strip)
- `npm run check-consistency` passes

## Test plan

- [x] `npm run check-consistency` passes (v0.75.0, 250 tools)
- [ ] After merge, verify tandembrowser.org renders hero strip + Get Started + Multi-agent sections correctly
- [ ] Read README on GitHub: the Bring-any-AI bullet should land as equal weight to the other five unlocks, not as a footnote