### PR TITLE
fix(stealth): move __tandem* globals into CDP isolated worlds

### DIFF
--- a/src/devtools/manager.ts
+++ b/src/devtools/manager.ts
@@ -15,6 +15,14 @@ const log = createLogger('CDP');
 
 export type { CDPSubscriber };
 
+/**
+ * Name of the CDP isolated world that hosts Wingman Vision bindings and the
+ * listener script. Page JS in the main world cannot see globals declared in
+ * this world, which closes the `window.__tandem*` fingerprint leak that
+ * existed before this change. The name is CDP-internal — pages never see it.
+ */
+const WINGMAN_WORLD = 'TandemVision';
+
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 interface AttachedSession {
@@ -61,6 +69,12 @@ export class DevToolsManager {
 
   // CDP subscriber system (Phase 3: security modules subscribe to events)
   private subscribers: CDPSubscriber[] = [];
+
+  // Wingman Vision idempotency: replaces the page-visible
+  // `window.__tandemVisionActive` guard that was fingerprintable from page JS.
+  // The bindings + listener script live in an isolated world ('TandemVision');
+  // this Set prevents double-installation on the main-process side.
+  private wingmanBindingsInstalled: Set<number> = new Set();
 
   // === 2. Constructor ===
 
@@ -423,25 +437,44 @@ export class DevToolsManager {
 
   private async installWingmanBindings(wc: WebContents): Promise<void> {
     if (!this.wingmanStream) return;
+    // Main-process idempotency guard: replaces the former main-world
+    // `window.__tandemVisionActive` flag that was fingerprintable from page JS.
+    if (this.wingmanBindingsInstalled.has(wc.id)) return;
 
     try {
-      // Create hidden bindings
-      await wc.debugger.sendCommand('Runtime.addBinding', { name: '__tandemScroll' });
-      await wc.debugger.sendCommand('Runtime.addBinding', { name: '__tandemSelection' });
-      await wc.debugger.sendCommand('Runtime.addBinding', { name: '__tandemFormFocus' });
+      // Stealth posture: the Wingman Vision bindings and the listener script
+      // both live in an ISOLATED world named 'TandemVision'. Page JS in the
+      // main world cannot see `__tandemScroll`, `__tandemSelection`, or
+      // `__tandemFormFocus` on its `window`, and cannot enumerate any
+      // Tandem-branded global. The binding surface is invisible to the page
+      // while still fully callable from inside the isolated world.
+      await wc.debugger.sendCommand('Runtime.addBinding', {
+        name: '__tandemScroll',
+        executionContextName: WINGMAN_WORLD,
+      });
+      await wc.debugger.sendCommand('Runtime.addBinding', {
+        name: '__tandemSelection',
+        executionContextName: WINGMAN_WORLD,
+      });
+      await wc.debugger.sendCommand('Runtime.addBinding', {
+        name: '__tandemFormFocus',
+        executionContextName: WINGMAN_WORLD,
+      });
 
-      // Inject listeners (runs in page context but communicates via invisible bindings)
+      // Inject listeners into the isolated world
       await this.injectWingmanListeners(wc);
+      this.wingmanBindingsInstalled.add(wc.id);
     } catch (e) {
       log.warn('⚠️ Wingman Vision bindings failed:', e instanceof Error ? e.message : e);
     }
   }
 
   private async injectWingmanListeners(wc: WebContents): Promise<void> {
+    // Script runs inside the 'TandemVision' isolated world. No need for a
+    // `window.__tandemVisionActive` guard — the main-process side already
+    // guarantees installWingmanBindings only runs once per webContents
+    // (wingmanBindingsInstalled Set).
     const script = `(function(){
-      if(window.__tandemVisionActive) return;
-      window.__tandemVisionActive = true;
-
       // --- Scroll ---
       var _sT=null, _lastPct=-1;
       window.addEventListener('scroll', function(){
@@ -479,20 +512,36 @@ export class DevToolsManager {
     })()`;
 
     try {
-      // Use addScriptToEvaluateOnNewDocument — runs in main world, survives navigations,
-      // and has reliable access to Runtime.addBinding bindings
+      // Future navigations: script auto-runs in the named isolated world
       await wc.debugger.sendCommand('Page.addScriptToEvaluateOnNewDocument', {
         source: script,
-        worldName: '', // empty string = main world
+        worldName: WINGMAN_WORLD,
       });
 
-      // Also run it immediately on the current page (addScriptToEvaluateOnNewDocument
-      // only runs on FUTURE navigations)
-      await wc.debugger.sendCommand('Runtime.evaluate', {
-        expression: script,
-        silent: true,
-        returnByValue: true,
-      });
+      // Current document: create the isolated world explicitly for this frame,
+      // then evaluate inside it.
+      try {
+        const frame = await wc.debugger.sendCommand('Page.getFrameTree') as { frameTree?: { frame?: { id?: string } } };
+        const frameId = frame?.frameTree?.frame?.id;
+        if (frameId) {
+          const isolated = await wc.debugger.sendCommand('Page.createIsolatedWorld', {
+            frameId,
+            worldName: WINGMAN_WORLD,
+            grantUniveralAccess: true,
+          }) as { executionContextId?: number };
+          if (typeof isolated?.executionContextId === 'number') {
+            await wc.debugger.sendCommand('Runtime.evaluate', {
+              expression: script,
+              silent: true,
+              returnByValue: true,
+              contextId: isolated.executionContextId,
+            });
+          }
+        }
+      } catch {
+        // current-page inject is best-effort; addScriptToEvaluateOnNewDocument
+        // will still fire on the next navigation.
+      }
     } catch {
       // Page may not be ready
     }

--- a/src/security/script-guard.ts
+++ b/src/security/script-guard.ts
@@ -17,6 +17,19 @@ import { createLogger } from '../utils/logger';
 
 const log = createLogger('ScriptGuard');
 
+/**
+ * Name of the CDP isolated world that hosts the security-alert binding and
+ * the bridge listener. Security monitors still run in the MAIN world (they
+ * must, in order to hook page APIs like `addEventListener`,
+ * `WebAssembly.instantiate`, `navigator.clipboard`, and `form.action`), but
+ * when an alert fires the monitor dispatches a same-frame CustomEvent which
+ * is relayed by a bridge script in this isolated world. The binding
+ * `__tandemSecurityAlert` is scoped to this world so page JS cannot see it
+ * on `window`. The CustomEvent name is not branded.
+ */
+const SECURITY_WORLD = 'TandemSecurity';
+const SECURITY_EVENT = '__tdm_sec_alert';
+
 // Re-export pure functions for backward compatibility
 export { calculateEntropy, normalizeScriptSource, computeASTHash, computeSimilarity } from './script-utils';
 
@@ -651,9 +664,30 @@ export class ScriptGuard {
   }
 
   /**
-   * Inject security monitor code into the current page.
-   * Uses Runtime.addBinding (invisible to page — same pattern as Wingman Vision).
-   * Uses Page.addScriptToEvaluateOnNewDocument for persistence across navigations.
+   * Inject security monitors into the current page.
+   *
+   * **Architecture (post-stealth fix 2026-04-18):**
+   * - The MONITOR script runs in the MAIN world because it must hook page
+   *   APIs (`addEventListener`, `WebAssembly.instantiate`,
+   *   `navigator.clipboard.readText`, `HTMLFormElement.prototype.action`).
+   *   Those hooks only work against the real main-world prototypes that
+   *   page JS uses.
+   * - When the monitor wants to alert, it dispatches a `CustomEvent` with
+   *   a non-branded type (`__tdm_sec_alert`) on `document`. The event is
+   *   local to the frame, not fingerprintable from another origin, and
+   *   doesn't expose any `window.__tandem*` global.
+   * - A BRIDGE script runs in an ISOLATED world ('TandemSecurity') and
+   *   listens for the CustomEvent. The CDP binding `__tandemSecurityAlert`
+   *   is scoped to this isolated world via `executionContextName`, so page
+   *   JS in the main world cannot see it on `window`.
+   * - Main-process idempotency (`state.monitorInjected`) replaces the
+   *   previous `window.__tandemSecurityMonitorsActive` guard, which was
+   *   itself a page-visible fingerprint.
+   *
+   * Net effect: page JS sees no Tandem-branded global, cannot enumerate any
+   * `__tandem*` on `window`, and the only trace is the non-branded
+   * CustomEvent type — which is only emitted when a known attack pattern
+   * fires, so its presence is conditional.
    */
   async injectMonitors(wcId?: number): Promise<void> {
     const resolvedWcId = wcId ?? this.resolveCurrentWcId();
@@ -662,10 +696,17 @@ export class ScriptGuard {
     const state = this.getOrCreateTabState(resolvedWcId);
     if (state.monitorInjected) return;
 
+    // MAIN-world monitor script. No window.__tandem* globals are exposed.
+    // Main-process `state.monitorInjected` prevents double-injection, so the
+    // previous JS-level guard flag is removed. Alerts are relayed via a
+    // same-frame CustomEvent instead of a direct binding call.
     const monitorScript = `(function() {
-      // Guard against double-injection
-      if (window.__tandemSecurityMonitorsActive) return;
-      window.__tandemSecurityMonitorsActive = true;
+      var EV = '${SECURITY_EVENT}';
+      function alertSec(data) {
+        try {
+          document.dispatchEvent(new CustomEvent(EV, { detail: JSON.stringify(data) }));
+        } catch(e) {}
+      }
 
       // === Keylogger detection ===
       var origAddEventListener = EventTarget.prototype.addEventListener;
@@ -674,15 +715,13 @@ export class ScriptGuard {
             (this instanceof HTMLInputElement || this instanceof HTMLTextAreaElement)) {
           try {
             var stack = new Error().stack || '';
-            if (typeof __tandemSecurityAlert === 'function') {
-              __tandemSecurityAlert(JSON.stringify({
-                type: 'keylogger_suspect',
-                eventType: type,
-                elementTag: this.tagName,
-                elementName: this.name || this.id || 'unknown',
-                callerStack: stack.substring(0, 500),
-              }));
-            }
+            alertSec({
+              type: 'keylogger_suspect',
+              eventType: type,
+              elementTag: this.tagName,
+              elementName: this.name || this.id || 'unknown',
+              callerStack: stack.substring(0, 500),
+            });
           } catch(e) {}
         }
         return origAddEventListener.call(this, type, listener, options);
@@ -693,12 +732,7 @@ export class ScriptGuard {
         var origWasmInstantiate = WebAssembly.instantiate;
         WebAssembly.instantiate = function() {
           try {
-            if (typeof __tandemSecurityAlert === 'function') {
-              __tandemSecurityAlert(JSON.stringify({
-                type: 'wasm_instantiate',
-                timestamp: Date.now(),
-              }));
-            }
+            alertSec({ type: 'wasm_instantiate', timestamp: Date.now() });
           } catch(e) {}
           return origWasmInstantiate.apply(this, arguments);
         };
@@ -709,12 +743,7 @@ export class ScriptGuard {
         var origClipboardRead = navigator.clipboard.readText.bind(navigator.clipboard);
         navigator.clipboard.readText = function() {
           try {
-            if (typeof __tandemSecurityAlert === 'function') {
-              __tandemSecurityAlert(JSON.stringify({
-                type: 'clipboard_read',
-                timestamp: Date.now(),
-              }));
-            }
+            alertSec({ type: 'clipboard_read', timestamp: Date.now() });
           } catch(e) {}
           return origClipboardRead.apply(this, arguments);
         };
@@ -728,13 +757,11 @@ export class ScriptGuard {
           get: formActionDescriptor.get,
           set: function(value) {
             try {
-              if (typeof __tandemSecurityAlert === 'function') {
-                __tandemSecurityAlert(JSON.stringify({
-                  type: 'form_action_change',
-                  newAction: String(value).substring(0, 200),
-                  formId: this.id || 'unknown',
-                }));
-              }
+              alertSec({
+                type: 'form_action_change',
+                newAction: String(value).substring(0, 200),
+                formId: this.id || 'unknown',
+              });
             } catch(e) {}
             return origSet.call(this, value);
           },
@@ -744,10 +771,24 @@ export class ScriptGuard {
       }
     })();`;
 
+    // ISOLATED-world bridge. Listens for the CustomEvent and forwards to the
+    // binding, which is only reachable from this world.
+    const bridgeScript = `(function() {
+      document.addEventListener('${SECURITY_EVENT}', function(e) {
+        try {
+          if (typeof __tandemSecurityAlert === 'function') {
+            __tandemSecurityAlert(String(e.detail || ''));
+          }
+        } catch(err) {}
+      });
+    })();`;
+
     try {
-      // Register the binding FIRST (invisible CDP-level binding)
+      // Register the binding scoped to the isolated world. Main-world page JS
+      // cannot see this binding on `window`.
       await this.devToolsManager.sendCommandToTab(resolvedWcId, 'Runtime.addBinding', {
         name: '__tandemSecurityAlert',
+        executionContextName: SECURITY_WORLD,
       });
 
       // Subscribe to binding calls
@@ -763,20 +804,51 @@ export class ScriptGuard {
         }
       });
 
-      // Inject as persistent script (survives navigations)
+      // Persistent injection (future navigations).
+      // Main-world monitor:
       await this.devToolsManager.sendCommandToTab(resolvedWcId, 'Page.addScriptToEvaluateOnNewDocument', {
         source: monitorScript,
-        worldName: '', // main world — must see page scripts
+        worldName: '', // main world — must see and hook page prototypes
+      });
+      // Isolated-world bridge (CDP auto-creates the world per document):
+      await this.devToolsManager.sendCommandToTab(resolvedWcId, 'Page.addScriptToEvaluateOnNewDocument', {
+        source: bridgeScript,
+        worldName: SECURITY_WORLD,
       });
 
-      // Also run immediately on current page
+      // Immediate injection (current page).
+      // Main-world monitor runs via default Runtime.evaluate:
       await this.devToolsManager.sendCommandToTab(resolvedWcId, 'Runtime.evaluate', {
         expression: monitorScript,
         silent: true,
       });
+      // Bridge needs an explicit isolated world on the current frame:
+      try {
+        const tree = await this.devToolsManager.sendCommandToTab(resolvedWcId, 'Page.getFrameTree') as {
+          frameTree?: { frame?: { id?: string } };
+        };
+        const frameId = tree?.frameTree?.frame?.id;
+        if (frameId) {
+          const isolated = await this.devToolsManager.sendCommandToTab(resolvedWcId, 'Page.createIsolatedWorld', {
+            frameId,
+            worldName: SECURITY_WORLD,
+            grantUniveralAccess: true,
+          }) as { executionContextId?: number };
+          if (typeof isolated?.executionContextId === 'number') {
+            await this.devToolsManager.sendCommandToTab(resolvedWcId, 'Runtime.evaluate', {
+              expression: bridgeScript,
+              silent: true,
+              contextId: isolated.executionContextId,
+            });
+          }
+        }
+      } catch {
+        // Bridge immediate-inject is best-effort; persistent variant will
+        // install on the next navigation.
+      }
 
       state.monitorInjected = true;
-      log.info('Security monitors injected');
+      log.info('Security monitors injected (main-world monitor + isolated-world bridge)');
     } catch (e) {
       log.warn('Monitor injection failed:', e instanceof Error ? e.message : String(e));
     }

--- a/src/security/tests/script-guard.test.ts
+++ b/src/security/tests/script-guard.test.ts
@@ -303,27 +303,50 @@ describe('ScriptGuard', () => {
       guard = new ScriptGuard(makeDB(), FAKE_GUARDIAN, dt as unknown as DevToolsManager);
     });
 
-    it('registers the __tandemSecurityAlert binding', async () => {
+    it('registers __tandemSecurityAlert binding scoped to the TandemSecurity isolated world', async () => {
       await guard.injectMonitors(42);
       const bindingCall = dt.sendCommandToTab.mock.calls.find(c => c[1] === 'Runtime.addBinding');
       expect(bindingCall).toBeDefined();
-      expect(bindingCall![2]).toEqual({ name: '__tandemSecurityAlert' });
+      // Stealth: binding must NOT be in main world — scoped via executionContextName
+      expect(bindingCall![2]).toEqual({
+        name: '__tandemSecurityAlert',
+        executionContextName: 'TandemSecurity',
+      });
     });
 
-    it('injects the monitor script via Page.addScriptToEvaluateOnNewDocument', async () => {
+    it('injects a main-world monitor script WITHOUT any __tandem* global', async () => {
       await guard.injectMonitors(42);
-      const pageCall = dt.sendCommandToTab.mock.calls.find(c => c[1] === 'Page.addScriptToEvaluateOnNewDocument');
-      expect(pageCall).toBeDefined();
-      // Should include the monitor source and use the main world
-      const args = pageCall![2] as { source: string; worldName: string };
-      expect(args.source).toContain('__tandemSecurityMonitorsActive');
-      expect(args.worldName).toBe('');
+      const pageCalls = dt.sendCommandToTab.mock.calls.filter(c => c[1] === 'Page.addScriptToEvaluateOnNewDocument');
+      // Two calls: the main-world monitor and the isolated-world bridge
+      expect(pageCalls.length).toBeGreaterThanOrEqual(2);
+      const monitorCall = pageCalls.find(c => (c[2] as { worldName: string }).worldName === '');
+      expect(monitorCall).toBeDefined();
+      const src = (monitorCall![2] as { source: string }).source;
+      // Stealth regression guard: main-world monitor must not define any
+      // `__tandem*` global. The former guard flag is gone; the binding is
+      // reached via a CustomEvent bridge, not direct access.
+      expect(src).not.toContain('__tandemSecurityMonitorsActive');
+      expect(src).not.toContain('window.__tandem');
+      expect(src).not.toMatch(/\b__tandemSecurityAlert\(/);
+      // It DOES call alertSec(...) which dispatches a CustomEvent
+      expect(src).toContain('alertSec(');
+      expect(src).toContain('__tdm_sec_alert');
     });
 
-    it('also runs the script immediately via Runtime.evaluate', async () => {
+    it('injects a TandemSecurity isolated-world bridge that relays CustomEvent → binding', async () => {
       await guard.injectMonitors(42);
-      const runtimeCall = dt.sendCommandToTab.mock.calls.find(c => c[1] === 'Runtime.evaluate');
-      expect(runtimeCall).toBeDefined();
+      const pageCalls = dt.sendCommandToTab.mock.calls.filter(c => c[1] === 'Page.addScriptToEvaluateOnNewDocument');
+      const bridgeCall = pageCalls.find(c => (c[2] as { worldName: string }).worldName === 'TandemSecurity');
+      expect(bridgeCall).toBeDefined();
+      const src = (bridgeCall![2] as { source: string }).source;
+      expect(src).toContain('__tdm_sec_alert');
+      expect(src).toContain('__tandemSecurityAlert');
+    });
+
+    it('also runs the monitor script immediately via Runtime.evaluate', async () => {
+      await guard.injectMonitors(42);
+      const runtimeCalls = dt.sendCommandToTab.mock.calls.filter(c => c[1] === 'Runtime.evaluate');
+      expect(runtimeCalls.length).toBeGreaterThanOrEqual(1);
     });
 
     it('is idempotent — second call does not re-inject', async () => {

--- a/src/security/tests/stealth-globals-regression.test.ts
+++ b/src/security/tests/stealth-globals-regression.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Stealth-globals regression guard.
+ *
+ * Background (2026-04-18 dogfooding):
+ *   During a live MCP session, `Object.keys(window).filter(k => /^__tandem/.test(k))`
+ *   in a real page context returned:
+ *     __tandemScroll, __tandemSelection, __tandemFormFocus,
+ *     __tandemVisionActive, __tandemSecurityAlert, __tandemSecurityMonitorsActive
+ *   That's a shared-signal fingerprint — any page could detect "this is
+ *   Tandem" with one property check.
+ *
+ * The fix moves every Tandem-branded global OUT of the page's main-world
+ * `window` object, by injecting scripts into CDP isolated worlds and
+ * scoping Runtime.addBinding calls via `executionContextName`. Security
+ * monitors that *must* run in the main world use a non-branded
+ * `CustomEvent` → isolated-world bridge → binding pathway.
+ *
+ * This file is the guardian. If a future PR reintroduces a `__tandem*`
+ * reference in a main-world injection script, these tests fail loud.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { ScriptGuard } from '../script-guard';
+import type { DevToolsManager } from '../../devtools/manager';
+import type { SecurityDB } from '../security-db';
+import type { Guardian } from '../guardian';
+
+interface CapturedCommand {
+  method: string;
+  params: Record<string, unknown>;
+}
+
+function makeCaptureMock(): {
+  commands: CapturedCommand[];
+  dt: {
+    subscribe: ReturnType<typeof vi.fn>;
+    unsubscribe: ReturnType<typeof vi.fn>;
+    sendCommandToTab: ReturnType<typeof vi.fn>;
+    getAttachedWebContents: ReturnType<typeof vi.fn>;
+    getDispatchWebContents: ReturnType<typeof vi.fn>;
+  };
+} {
+  const commands: CapturedCommand[] = [];
+  const fakeWC = { id: 42, getURL: () => 'https://page.example' };
+  return {
+    commands,
+    dt: {
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+      sendCommandToTab: vi.fn(async (_wcId: number, method: string, params: Record<string, unknown>) => {
+        commands.push({ method, params });
+        return {};
+      }),
+      getAttachedWebContents: vi.fn(() => fakeWC),
+      getDispatchWebContents: vi.fn(() => fakeWC),
+    },
+  };
+}
+
+function makeDB(): SecurityDB {
+  return {
+    logEvent: vi.fn(),
+    getScriptFingerprint: vi.fn(() => null),
+    getDomainInfo: vi.fn(() => null),
+    upsertScriptFingerprint: vi.fn(),
+    updateScriptHash: vi.fn(),
+    updateNormalizedHash: vi.fn(),
+    updateAstHash: vi.fn(),
+    updateAstFeatures: vi.fn(),
+    markScriptHashAnalyzed: vi.fn(),
+    isScriptHashAnalyzed: vi.fn(() => false),
+    getDomainsForHash: vi.fn(() => []),
+    getDomainsForNormalizedHash: vi.fn(() => []),
+    getDomainsForAstHash: vi.fn(() => []),
+    getAstMatches: vi.fn(() => []),
+    getScriptsWithAstFeatures: vi.fn(() => []),
+  } as unknown as SecurityDB;
+}
+
+describe('Stealth globals regression guard', () => {
+  describe('ScriptGuard injects no __tandem* names into the main-world script', () => {
+    it('never writes window.__tandem* in the main-world monitor source', async () => {
+      const { commands, dt } = makeCaptureMock();
+      const guard = new ScriptGuard(makeDB(), {} as Guardian, dt as unknown as DevToolsManager);
+      await guard.injectMonitors(42);
+
+      const pageScripts = commands.filter(c => c.method === 'Page.addScriptToEvaluateOnNewDocument');
+      // One main-world + one isolated-world
+      expect(pageScripts.length).toBeGreaterThanOrEqual(2);
+      const mainWorldScript = pageScripts.find(c => (c.params as { worldName: string }).worldName === '');
+      expect(mainWorldScript).toBeDefined();
+      const src = (mainWorldScript!.params as { source: string }).source;
+
+      // The core stealth claim: no Tandem-branded name leaks into main world
+      expect(src).not.toMatch(/__tandem\w*/);
+      expect(src).not.toMatch(/window\.__tandem/);
+    });
+
+    it('never calls Runtime.addBinding for __tandem* without isolated-world scoping', async () => {
+      const { commands, dt } = makeCaptureMock();
+      const guard = new ScriptGuard(makeDB(), {} as Guardian, dt as unknown as DevToolsManager);
+      await guard.injectMonitors(42);
+
+      const bindingCalls = commands.filter(c => c.method === 'Runtime.addBinding');
+      for (const call of bindingCalls) {
+        const params = call.params as { name: string; executionContextName?: string };
+        if (/__tandem/.test(params.name)) {
+          // Any __tandem-named binding MUST be scoped to a Tandem isolated world,
+          // never the default main world (which would expose it as window.X)
+          expect(params.executionContextName).toBeDefined();
+          expect(params.executionContextName).toMatch(/^Tandem/);
+        }
+      }
+    });
+
+    it('runs an isolated-world bridge that carries the __tandem* binding', async () => {
+      const { commands, dt } = makeCaptureMock();
+      const guard = new ScriptGuard(makeDB(), {} as Guardian, dt as unknown as DevToolsManager);
+      await guard.injectMonitors(42);
+
+      const pageScripts = commands.filter(c => c.method === 'Page.addScriptToEvaluateOnNewDocument');
+      const bridgeScript = pageScripts.find(c => (c.params as { worldName: string }).worldName === 'TandemSecurity');
+      expect(bridgeScript).toBeDefined();
+      const src = (bridgeScript!.params as { source: string }).source;
+
+      // Bridge DOES reference the binding (that's fine — it lives in isolated world)
+      expect(src).toContain('__tandemSecurityAlert');
+      // Bridge listens on the non-branded CustomEvent name
+      expect(src).toContain('__tdm_sec_alert');
+    });
+
+    it('alerting path in main-world uses CustomEvent, not direct binding call', async () => {
+      const { commands, dt } = makeCaptureMock();
+      const guard = new ScriptGuard(makeDB(), {} as Guardian, dt as unknown as DevToolsManager);
+      await guard.injectMonitors(42);
+
+      const mainWorldScript = commands
+        .filter(c => c.method === 'Page.addScriptToEvaluateOnNewDocument')
+        .find(c => (c.params as { worldName: string }).worldName === '');
+      const src = (mainWorldScript!.params as { source: string }).source;
+
+      // No direct binding invocation in main world
+      expect(src).not.toMatch(/__tandemSecurityAlert\(/);
+      // CustomEvent dispatch pathway
+      expect(src).toContain('dispatchEvent');
+      expect(src).toContain('CustomEvent');
+    });
+  });
+});


### PR DESCRIPTION
## The leak

Before this change, any page's JavaScript could detect Tandem with a single property check:

\`\`\`js
Object.keys(window).filter(k => /^__tandem/.test(k))
// → ['__tandemScroll', '__tandemSelection', '__tandemFormFocus',
//    '__tandemVisionActive', '__tandemSecurityAlert',
//    '__tandemSecurityMonitorsActive']
\`\`\`

That's a shared-signal fingerprint across every Tandem install — the stealth equivalent of the Date.now jitter shared-signal fixed in #168. Found during live MCP dogfooding on 2026-04-18.

## The fix

### Wingman Vision (scroll / selection / form-focus)

Nothing in this path hooks main-world prototypes — the listeners only read DOM state and report via CDP binding. **Moved entirely to isolated world.**

- \`Page.addScriptToEvaluateOnNewDocument\` now uses \`worldName: 'TandemVision'\`
- \`Runtime.addBinding\` scoped via \`executionContextName: 'TandemVision'\`
- Current-document injection explicitly creates the isolated world with \`Page.createIsolatedWorld\` on the top frame, then \`Runtime.evaluate\`s with the returned \`contextId\`
- \`window.__tandemVisionActive\` guard flag removed — replaced by a main-process \`wingmanBindingsInstalled: Set<number>\` that guarantees \`installWingmanBindings\` only runs once per webContents

**Net:** page main world has no \`__tandemScroll\`, \`__tandemSelection\`, \`__tandemFormFocus\`, or \`__tandemVisionActive\`.

### Security monitors (keylogger / wasm / clipboard / form-action)

These MUST run in main world — they hook \`EventTarget.prototype.addEventListener\`, \`WebAssembly.instantiate\`, \`navigator.clipboard.readText\`, and \`HTMLFormElement.prototype.action\`. An isolated-world copy would only hook that world's prototypes, which page JS never touches.

**Hybrid architecture:**

- **Main-world monitor** script: unchanged hooking logic, but replaces direct \`__tandemSecurityAlert(...)\` calls with \`document.dispatchEvent(new CustomEvent('__tdm_sec_alert', { detail: JSON.stringify(data) }))\`. The event type is non-branded; the event is only emitted when a known attack pattern fires, so its presence is conditional, not a static fingerprint.
- **Isolated-world bridge** (worldName: 'TandemSecurity'): listens for the CustomEvent, forwards \`e.detail\` to the \`__tandemSecurityAlert\` CDP binding. Binding scoped to the isolated world via \`executionContextName\`, so page JS can't see it.
- \`window.__tandemSecurityMonitorsActive\` guard flag removed — \`state.monitorInjected\` on the main process already prevents double injection.

**Net:** page main world has no \`__tandemSecurityAlert\` or \`__tandemSecurityMonitorsActive\`. The only main-world trace is the \`__tdm_sec_alert\` CustomEvent type, and only when an attack pattern actually fires.

## Regression guard

**NEW** \`src/security/tests/stealth-globals-regression.test.ts\` — programmatically asserts:

1. Main-world monitor source contains **zero** \`/__tandem\\w*/\` matches
2. Every \`Runtime.addBinding\` for a \`__tandem*\` name MUST include \`executionContextName\` matching \`/^Tandem/\`
3. The isolated-world bridge exists with worldName \`'TandemSecurity'\`
4. Main-world source uses \`CustomEvent\` / \`dispatchEvent\`, never a direct binding call

Future PRs that reintroduce a \`__tandem*\` global in main world will fail this test loud.

## Updated existing tests

\`src/security/tests/script-guard.test.ts\` now asserts the new shape: binding scoping, two \`Page.addScriptToEvaluateOnNewDocument\` calls (monitor + bridge), main-world source has no \`__tandem*\`, and bridge exists with the correct worldName.

## Verify

- [x] \`npm run verify\`: 2758 tests pass (+ 5 new regression-guard cases)
- [x] \`check-consistency\` green
- [x] Existing \`Runtime.bindingCalled\` handling for \`__tandemSecurityAlert\` unchanged — main-process code still receives alerts exactly as before
- [ ] Post-merge live test in a real page: \`Object.keys(window).filter(k => /__tandem/i.test(k))\` returns \`[]\`

## Context

- From \`docs/superpowers/agent-experience-fix-plan.md\` — PR 2 of 5
- Addresses Bug 3 in \`docs/superpowers/tandem-bugs-to-fix.md\`
- Follows the same shared-signal-removal pattern as #168 (Date.now jitter)