### PR TITLE
fix(shell): clear tab .active class on workspace switch + defensive DOM sweep

### DIFF
--- a/shell/js/sidebar/panels/workspaces.js
+++ b/shell/js/sidebar/panels/workspaces.js
@@ -224,7 +224,14 @@ export function filterTabBar() {
     if (visible) {
       visibleTabIds.push(tabId);
     } else {
+      // Clear both the webview AND the tab-bar element's .active class.
+      // Previously only the webview was cleared, which left the tab
+      // element's purple `.active` underline visible when its workspace
+      // later came back into view — producing a "multiple tabs look
+      // active" artifact when focus changed rapidly across workspaces.
+      // See docs/superpowers/tandem-bugs-to-fix.md (Bug 1).
       wv.classList.remove('active');
+      el.classList.remove('active');
     }
   });
 

--- a/shell/js/tabs.js
+++ b/shell/js/tabs.js
@@ -58,6 +58,16 @@
     }
 
     function focusRendererTab(tabId) {
+      // Defensive DOM sweep: clear `.active` from every tab element in the
+      // tab-bar before applying the new active. The `tabs` Map iteration
+      // below only covers tabs known to this module's in-memory registry;
+      // the sweep catches any stragglers that ended up with a stale
+      // `.active` class via another code path (workspace switch, unmount
+      // race). Guarantees at most one `.active` in the tab-bar DOM.
+      // See docs/superpowers/tandem-bugs-to-fix.md (Bug 1).
+      document.querySelectorAll('#tab-bar .tab.active')
+        .forEach(el => el.classList.remove('active'));
+
       for (const [id, entry] of tabs) {
         entry.webview.classList.toggle('active', id === tabId);
         entry.tabEl.classList.toggle('active', id === tabId);


### PR DESCRIPTION
## Symptom

When an agent rapidly focus-switches across tabs in different workspaces (e.g. MCP-driven focus changes during a multi-tab research task), multiple tabs in the tab-bar simultaneously showed the purple accent underline. Observed during 2026-04-18 live dogfooding: **4 tabs stuck in the \`.active\` state at the same time.**

Purely visual — the underlying \`activeTabId\` is a single variable, never confused — but the UI ambiguity makes it harder for the user to know which tab is really in focus, especially during co-browsing sessions.

## Root cause — two issues, two one-line fixes

### 1. \`workspaces.js:filterTabBar()\` left \`.active\` on hidden tab elements

When a workspace switch hides tabs from other workspaces (\`display:none\`), the helper was clearing \`.active\` on the **webview** element but NOT on the **tab-bar** element. The stale class persisted; when those tabs later reappeared, the underline came with them.

**Fix**: also \`el.classList.remove('active')\` in the hide branch.

### 2. \`tabs.js:focusRendererTab\` relied solely on its in-memory Map

The existing \`for (const [id, entry] of tabs)\` loop toggles \`.active\` on every known tab. Correct in principle, but only covers tabs the module has registered in its own Map. An orphan with a stale \`.active\` from another code path stays stale.

**Fix**: before the toggle loop, unconditionally clear \`.active\` from every \`#tab-bar .tab.active\` in the DOM.

## Why both

The workspace fix is the direct cause-and-effect repair. The DOM sweep is defense-in-depth — cheap (one \`querySelectorAll\` per focus change) and closes the entire class of \"some other code path sets \`.active\`\" bugs in one line. They compose cleanly.

## Verification

- [x] \`npm run verify\`: 2758 tests pass, check-consistency green
- [ ] **Post-merge manual test**:
  1. Open 5+ tabs across 2 workspaces
  2. Rapidly focus-switch via \`tandem_focus_tab\` from MCP
  3. After settling, run in DevTools: \`document.querySelectorAll('#tab-bar .tab.active').length\` → must be exactly **1**

## Diff

+17 lines across 2 files. The lines of actual logic are 2 (one per fix). The rest is comments explaining the defensive intent and pointing to the bugs notes.

## Context

- From \`docs/superpowers/agent-experience-fix-plan.md\` — PR 4 of 5
- Addresses Bug 1 in \`docs/superpowers/tandem-bugs-to-fix.md\`
- Previous PRs: #174 (MCP trust), #175 (stealth globals), #176 (SKILL.md rewrite)
- Next: PR 5 (empty workspace UX) — blocked on UX design decision with you