### PR TITLE
fix(tabs): open a fresh newtab in the emptied workspace instead of sweeping focus elsewhere

### DIFF
--- a/src/bootstrap/runtime.ts
+++ b/src/bootstrap/runtime.ts
@@ -265,6 +265,35 @@ export async function initializeRuntimeManagers(opts: InitializeRuntimeOptions):
       { notify: true, followFocusedTab: true },
     );
   });
+  // Workspace-emptied handler: when closing a tab would leave its workspace
+  // empty, open Tandem's newtab.html in that workspace so the user keeps
+  // the workspace selected instead of silently sweeping into another one.
+  // Matches how most browsers handle "closed the last tab" (show a new
+  // tab page) while preserving workspace identity — the fix for Bug 2.
+  runtime.tabManager.setWorkspaceEmptiedHandler(async (workspaceId) => {
+    try {
+      const path = await import('path');
+      const newTabUrl = `file://${path.join(__dirname, '..', '..', 'shell', 'newtab.html')}`;
+      // focus:false so we can move-to-workspace first, then focus explicitly —
+      // same pattern used by POST /tabs/open when a workspaceId is supplied.
+      const tab = await runtime.tabManager.openTab(
+        newTabUrl,
+        undefined,
+        'user',
+        'persist:tandem',
+        false,
+      );
+      if (!tab) return null;
+      runtime.workspaceManager.moveTab(tab.webContentsId, workspaceId);
+      return tab;
+    } catch (e) {
+      log.warn(
+        `workspaceEmptiedHandler failed for ${workspaceId}:`,
+        e instanceof Error ? e.message : String(e),
+      );
+      return null;
+    }
+  });
   runtime.historyManager.setSyncManager(runtime.syncManager);
   runtime.workspaceManager.setSyncManager(runtime.syncManager);
   runtime.workspaceManager.setTabStateResolvers({

--- a/src/tabs/manager.ts
+++ b/src/tabs/manager.ts
@@ -66,6 +66,7 @@ export class TabManager {
   private sessionTimer: ReturnType<typeof setTimeout> | null = null;
   private workspaceIdResolver: ((webContentsId: number) => string | null) | null = null;
   private activeTabChangedHandler: ((tab: Tab | null) => void | Promise<void>) | null = null;
+  private workspaceEmptiedHandler: ((workspaceId: string) => Promise<Tab | null>) | null = null;
 
   // === 2. Constructor (BrowserWindow variant) ===
 
@@ -91,6 +92,26 @@ export class TabManager {
    */
   setWorkspaceIdResolver(resolver: ((webContentsId: number) => string | null) | null): void {
     this.workspaceIdResolver = resolver;
+  }
+
+  /**
+   * Set the callback invoked when closing a tab would leave its workspace
+   * with zero tabs. The handler is expected to open a fresh tab (typically
+   * Tandem's newtab page) and assign it to the given workspace, then
+   * return the created Tab. If it returns null, `closeTab` falls back to
+   * picking any remaining tab from another workspace, preserving prior
+   * behavior.
+   *
+   * Without this handler, closing the last tab in a non-default workspace
+   * silently transports the user to whichever workspace owns the fallback
+   * tab — the Bug-2 pattern observed during live dogfooding on 2026-04-18.
+   *
+   * @param handler - async function that creates and assigns a replacement
+   * tab to the emptied workspace, or returns null to defer to the default
+   * fallback
+   */
+  setWorkspaceEmptiedHandler(handler: ((workspaceId: string) => Promise<Tab | null>) | null): void {
+    this.workspaceEmptiedHandler = handler;
   }
 
   /** Wire a callback that runs after the active tab changes. */
@@ -285,10 +306,42 @@ export class TabManager {
 
     this.tabs.delete(tabId);
 
-    // If we closed the active tab, focus another
+    // If we closed the active tab, focus another.
+    //
+    // Successor selection rules (in order):
+    //   1. Prefer a tab in the SAME workspace as the closed tab. Prevents
+    //      silent cross-workspace focus swings during close.
+    //   2. If the closed workspace has no remaining tabs, delegate to the
+    //      workspace-emptied handler. The handler is expected to open a
+    //      fresh newtab.html in that workspace so the workspace itself
+    //      stays selected. This is the fix for Bug 2 (empty workspace
+    //      silently falls through to another workspace).
+    //   3. If no handler is wired, or it returns null, fall back to any
+    //      remaining tab anywhere. Preserves prior behavior for tests
+    //      and for edge cases where the closed workspace is unknown.
     if (this.activeTabId === tabId) {
       this.activeTabId = null;
-      const successor = this.pickCloseSuccessor(closedWorkspaceId);
+      let successor: Tab | null = null;
+
+      if (closedWorkspaceId) {
+        successor = this.pickSameWorkspaceSuccessor(closedWorkspaceId);
+      }
+
+      if (!successor && closedWorkspaceId && this.workspaceEmptiedHandler) {
+        try {
+          successor = await this.workspaceEmptiedHandler(closedWorkspaceId);
+        } catch (e) {
+          log.warn(
+            `workspaceEmptiedHandler failed for ${closedWorkspaceId}:`,
+            e instanceof Error ? e.message : String(e),
+          );
+        }
+      }
+
+      if (!successor) {
+        successor = this.pickAnyRemainingSuccessor();
+      }
+
       if (successor) {
         await this.focusTab(successor.id);
       } else {
@@ -580,30 +633,33 @@ export class TabManager {
   }
 
   /**
-   * Pick the next tab to focus after closing the active tab.
+   * Pick the most-recently-inserted remaining tab in the same workspace
+   * as the closed tab, or null if that workspace has no other tabs.
    *
-   * Prefers a tab in the same workspace as the closed tab so closing a new
-   * tab doesn't silently move the user to another workspace (the
-   * activeTabChanged reconcile runs followFocusedTab, which would otherwise
-   * switch activeId to whichever workspace the successor belongs to).
-   *
-   * If the closed tab's workspace is unknown or empty, fall back to the
-   * most-recently-inserted remaining tab from any workspace so the user
-   * isn't left on a blank screen.
+   * Same-workspace preference prevents silent cross-workspace focus
+   * swings: closing a new tab in workspace X should keep focus in X
+   * rather than reconciling activeId to whichever workspace owns the
+   * alphabetically-last remaining tab.
    */
-  private pickCloseSuccessor(closedWorkspaceId: string | null): Tab | null {
+  private pickSameWorkspaceSuccessor(closedWorkspaceId: string): Tab | null {
+    if (!this.workspaceIdResolver) return null;
+    const remaining = Array.from(this.tabs.values());
+    const sameWorkspace = remaining.filter(
+      (t) => this.workspaceIdResolver?.(t.webContentsId) === closedWorkspaceId,
+    );
+    if (sameWorkspace.length === 0) return null;
+    return sameWorkspace[sameWorkspace.length - 1];
+  }
+
+  /**
+   * Fallback successor picker used when neither the same-workspace
+   * preference nor the workspace-emptied handler produces a tab.
+   * Returns the most-recently-inserted remaining tab from any workspace,
+   * or null if no tabs remain anywhere.
+   */
+  private pickAnyRemainingSuccessor(): Tab | null {
     const remaining = Array.from(this.tabs.values());
     if (remaining.length === 0) return null;
-
-    if (closedWorkspaceId && this.workspaceIdResolver) {
-      const sameWorkspace = remaining.filter(
-        (t) => this.workspaceIdResolver?.(t.webContentsId) === closedWorkspaceId,
-      );
-      if (sameWorkspace.length > 0) {
-        return sameWorkspace[sameWorkspace.length - 1];
-      }
-    }
-
     return remaining[remaining.length - 1];
   }
 

--- a/src/tabs/tests/tabs.test.ts
+++ b/src/tabs/tests/tabs.test.ts
@@ -232,7 +232,7 @@ describe('TabManager', () => {
       expect(tm.getActiveTab()?.id).toBe(tabA.id);
     });
 
-    it('falls back to any remaining tab when the closed tab was the last in its workspace', async () => {
+    it('falls back to any remaining tab when the closed tab was the last in its workspace AND no workspace-emptied handler is set', async () => {
       const tabKees = await tm.openTab('https://kees.com');
       const tabDefault = await tm.openTab('https://default.com'); // active
 
@@ -244,7 +244,87 @@ describe('TabManager', () => {
       await tm.closeTab(tabDefault.id);
 
       // Default is empty after closing tabDefault — falling back to kees is
-      // fine (user has no other choice).
+      // fine when no handler is wired (legacy behavior preserved for tests
+      // and edge cases where the closed workspace is unknown).
+      expect(tm.getActiveTab()?.id).toBe(tabKees.id);
+    });
+
+    // Repro for Bug 2 fix: closing the last tab in a non-default workspace
+    // used to silently sweep the user to another workspace. With a
+    // workspace-emptied handler wired, the handler opens a replacement tab
+    // in the emptied workspace and close focuses that instead.
+    it('invokes the workspace-emptied handler and focuses its returned tab when the closed workspace has no other tabs', async () => {
+      const tabKees = await tm.openTab('https://kees.com');
+      const tabDefault = await tm.openTab('https://default.com'); // active
+
+      tm.setWorkspaceIdResolver((wcId) => {
+        if (wcId === tabKees.webContentsId) return 'kees';
+        return 'default';
+      });
+
+      const handlerCalls: string[] = [];
+      tm.setWorkspaceEmptiedHandler(async (workspaceId) => {
+        handlerCalls.push(workspaceId);
+        // Simulate the handler creating a fresh new-tab in the emptied ws.
+        const replacement = await tm.openTab('file:///newtab.html', undefined, 'user', 'persist:tandem', false);
+        return replacement;
+      });
+
+      await tm.closeTab(tabDefault.id);
+
+      expect(handlerCalls).toEqual(['default']);
+      // Focus lands on the replacement tab, NOT on kees
+      const active = tm.getActiveTab();
+      expect(active?.id).not.toBe(tabKees.id);
+      expect(active?.url).toBe('file:///newtab.html');
+    });
+
+    it('does NOT invoke the workspace-emptied handler when the closed workspace still has other tabs', async () => {
+      const tabA = await tm.openTab('https://default-a.com');
+      const tabB = await tm.openTab('https://default-b.com'); // active, same ws
+
+      tm.setWorkspaceIdResolver(() => 'default');
+
+      const handler = vi.fn(async () => null);
+      tm.setWorkspaceEmptiedHandler(handler);
+
+      await tm.closeTab(tabB.id);
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(tm.getActiveTab()?.id).toBe(tabA.id);
+    });
+
+    it('falls back to any remaining tab if the workspace-emptied handler returns null', async () => {
+      const tabKees = await tm.openTab('https://kees.com');
+      const tabDefault = await tm.openTab('https://default.com'); // active
+
+      tm.setWorkspaceIdResolver((wcId) => {
+        if (wcId === tabKees.webContentsId) return 'kees';
+        return 'default';
+      });
+
+      tm.setWorkspaceEmptiedHandler(async () => null);
+
+      await tm.closeTab(tabDefault.id);
+
+      // Handler punted — legacy behavior kicks in.
+      expect(tm.getActiveTab()?.id).toBe(tabKees.id);
+    });
+
+    it('falls back to any remaining tab if the workspace-emptied handler throws', async () => {
+      const tabKees = await tm.openTab('https://kees.com');
+      const tabDefault = await tm.openTab('https://default.com'); // active
+
+      tm.setWorkspaceIdResolver((wcId) => {
+        if (wcId === tabKees.webContentsId) return 'kees';
+        return 'default';
+      });
+
+      tm.setWorkspaceEmptiedHandler(async () => { throw new Error('boom'); });
+
+      await tm.closeTab(tabDefault.id);
+
+      // Handler errored out — still land on a live tab, don't leave blank.
       expect(tm.getActiveTab()?.id).toBe(tabKees.id);
     });
 


### PR DESCRIPTION
## Bug

Closing the last tab in a non-default workspace silently swept the user into a different workspace. Observed during 2026-04-18 live dogfooding: after closing all 9 tabs in my Claude-code workspace, the main window showed Robin's LinkedIn from Default — and subsequent \"open new tab\" actions then landed in Default too, not in the now-empty Claude-code. Workspace identity quietly escaped the user's control.

**Root cause**: \`pickCloseSuccessor\` in TabManager preferred the most-recently-inserted tab from ANY workspace when the closed tab's workspace had no remaining tabs. The \`activeTabChanged\` reconcile then swung the active workspace to match — a workspace switch with no UI signal.

## Fix (per Robin's framing)

An \"empty workspace\" should actually hold **1 fresh newtab.html**, matching how Chrome and Opera handle \"you closed the last tab\" — show a new tab page, don't go blank. Workspace identity stays with the user. No special empty-state UI needed.

### TabManager changes

- Split \`pickCloseSuccessor\` into two named helpers:
  - \`pickSameWorkspaceSuccessor(workspaceId)\` — tabs in the closed ws only
  - \`pickAnyRemainingSuccessor()\` — legacy fallback across all tabs
- **New callback slot** \`setWorkspaceEmptiedHandler(handler)\` — async \`(workspaceId) => Promise<Tab | null>\`. Invoked ONLY when the closed workspace has zero remaining tabs. Handler is expected to open a fresh tab and assign it to the emptied workspace, then return that Tab for \`closeTab\` to focus.
- \`closeTab\` new successor order:
  1. Same-workspace tab
  2. Workspace-emptied handler's returned tab
  3. Any remaining tab anywhere (legacy fallback, preserved for tests and edge cases with no handler wired)
- Handler errors are swallowed (logged) so \`closeTab\` never hangs or leaves the user on a blank screen; falls through to legacy fallback.

### Runtime wiring

In \`src/bootstrap/runtime.ts\`, wire up the handler to:
- Open \`shell/newtab.html\` via \`tabManager.openTab(url, ..., focus:false)\`
- Assign the created tab to the emptied workspace via \`workspaceManager.moveTab(wcId, workspaceId)\` — same pattern as \`POST /tabs/open\` when given a \`workspaceId\` body
- Return the tab so \`closeTab\` focuses it

The new tab inherits the standard Tandem new-tab experience (\`shell/newtab.html\`). Workspace identity preserved.

## Tests

Four new cases in \`src/tabs/tests/tabs.test.ts\`:

- [x] Handler invoked when closed workspace has no other tabs → focus lands on replacement tab, not another workspace's tab
- [x] Handler NOT invoked when closed workspace still has other tabs
- [x] Legacy fallback when handler returns null
- [x] Legacy fallback when handler throws

Existing test \"falls back to any remaining tab\" reclassified explicitly as \"... AND no workspace-emptied handler is set\" — legacy behavior preserved when no handler wired.

**Full suite: 2762 passed (+4), check-consistency green.**

## Verify

- [x] \`npm run verify\` green
- [ ] Post-merge live test:
  1. Create a non-default workspace, add 1 or 2 tabs to it
  2. Close all tabs in that workspace
  3. Expected: fresh newtab.html opens in the same workspace (NOT a switch to Default)
  4. \`tandem_active_tab_context\` should still report the original workspace id

## Scope

**PR 5 of 5 — final** from \`docs/superpowers/agent-experience-fix-plan.md\`. Addresses Bug 2 in \`tandem-bugs-to-fix.md\`. Previous PRs in this sequence: #174, #175, #176, #177.

After this lands, the full 2026-04-18 dogfooding punch-list is complete.