### PR TITLE
feat(security): agent trust tiers — T2/T3/T4 reduce approval friction for legitimate agent work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ how it works, and why it exists.
 
 - **Repo:** `hydro13/tandem-browser` (GitHub: hydro13)
 - **Stack:** Electron 40 + TypeScript + Express.js API (`localhost:8765`) +
-  MCP server (250 tools)
+  MCP server (253 tools)
 - **Goal:** An agent-first browser where any AI (via MCP, HTTP API, or
   WebSocket) and a human browse together
 - **Philosophy:** Local-first, privacy-first, no cloud dependencies in the
@@ -39,7 +39,7 @@ tandem-browser/
 │   ├── snapshot/                 # Accessibility tree with @refs
 │   ├── network/                  # Inspector + mocking
 │   ├── sessions/                 # Multi-session isolation
-│   ├── mcp/                      # MCP server (250 tools, full API parity)
+│   ├── mcp/                      # MCP server (253 tools, full API parity)
 │   │   ├── server.ts             # MCP server entry point
 │   │   └── tools/                # Tool definitions (one file per domain)
 │   ├── agents/                   # TaskManager, X-Scout, TabLockManager

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -10,7 +10,7 @@ bicycle: two riders, one machine, each contributing what the other can't do
 alone.
 
 The browser runs two things in parallel. The human uses it like any other browser
-while AI agents operate through a built-in **MCP server** (250 tools) or a
+while AI agents operate through a built-in **MCP server** (253 tools) or a
 **300+ endpoint HTTP API** for navigation, interaction, data extraction,
 automation, sessions, sync, extensions, and developer tooling. Local agents can
 use MCP or HTTP. Remote agents on the same Tailscale network connect via HTTP

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Want the fastest path in?
 | **System** | 6 | Browser status, headless mode, Google Photos, security overrides |
 | **Awareness** | 2 | Activity digest, real-time focus detection — the AI knows what you're doing |
 
-**250 tools total** — full parity with the HTTP API.
+**253 tools total** — full parity with the HTTP API.
 
 ## Why Not Just Use Playwright?
 
@@ -207,7 +207,7 @@ Cursor, Windsurf, or any MCP client):
 }
 ```
 
-Start Tandem, and 250 tools are available immediately.
+Start Tandem, and 253 tools are available immediately.
 
 **HTTP API** — Use the local API token directly:
 
@@ -253,7 +253,7 @@ Connected Agents UI.
 
 **HTTP API** works the same way as local, using the binding token as Bearer auth.
 
-Both transports give remote agents the same 250 tools and 300+ endpoints as local agents.
+Both transports give remote agents the same 253 tools and 300+ endpoints as local agents.
 
 <details>
 <summary>Manual pairing (for scripts or custom tooling)</summary>

--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,7 @@ Last updated: April 16, 2026
 ## Current Snapshot
 
 - Current app version: `0.72.2`
-- MCP server: 250 tools (full API parity + awareness)
+- MCP server: 253 tools (full API parity + awareness)
 - The codebase scope is larger than this backlog summary and includes major subsystems such as `sidebar`, `workspaces`, `pinboards`, `sync`, `headless`, and `sessions`.
 - Scheduled browsing already exists in baseline form via `WatchManager` and the `/watch/*` API routes.
 - Session isolation already exists in baseline form via `SessionManager` and the `/sessions/*` API routes.

--- a/docs/api.html
+++ b/docs/api.html
@@ -117,7 +117,7 @@ footer a:hover{color:var(--text2)}
 <div class="hero-stats">
 <div class="stat"><span class="stat-num">280+</span><span class="stat-label">Endpoints</span></div>
 <div class="stat"><span class="stat-num">19</span><span class="stat-label">Domains</span></div>
-<div class="stat"><span class="stat-num">250</span><span class="stat-label">MCP tools</span></div>
+<div class="stat"><span class="stat-num">253</span><span class="stat-label">MCP tools</span></div>
 </div>
 </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -331,7 +331,7 @@ footer a:hover{color:var(--text2)}
 <p>Tandem Browser is built around a simple shift: the AI is not a sidebar talking <em>about</em> your browser, it is <em>inside</em> it. Same tabs, same cookies, same logged-in sessions, same page you are looking at right now. Reading the accessibility tree, watching the network, writing live styles, handing back to you when something needs a human. It turns the web that already exists into something agents can actually operate on — no per-site API, no RPA rig, no screenshot loop. The real browser, as a shared human-AI symbiotic runtime.</p>
 <div class="hero-stats">
 <div class="stat"><span class="stat-num">513</span><span class="stat-label">GitHub stars</span></div>
-<div class="stat"><span class="stat-num">250</span><span class="stat-label">MCP tools</span></div>
+<div class="stat"><span class="stat-num">253</span><span class="stat-label">MCP tools</span></div>
 <div class="stat"><span class="stat-num">300+</span><span class="stat-label">HTTP endpoints</span></div>
 <div class="stat"><span class="stat-num">8</span><span class="stat-label">Security layers</span></div>
 </div>
@@ -606,7 +606,7 @@ The browser opens. The API starts automatically.</p>
 <h3>Connect your AI</h3>
 <p><strong>Bring any AI.</strong> Tandem Browser is model-agnostic. Any agent that speaks MCP or HTTP works &mdash; Claude, GPT, OpenClaw, local Ollama, LM Studio, custom scripts. Swap models, combine models, run offline. The browser doesn&apos;t care which AI you bring.</p>
 <p style="margin-top:.4rem">Open Settings &rarr; Connected Agents. Choose whether your AI is on this machine or on another machine. Tandem generates the instructions, you paste them into your AI, and the agent discovers the rest through Tandem&apos;s own bootstrap surface.</p>
-<p style="margin-top:.4rem"><strong>Same machine:</strong> MCP via stdio (250 tools) or HTTP API (300+ endpoints).<br>
+<p style="margin-top:.4rem"><strong>Same machine:</strong> MCP via stdio (253 tools) or HTTP API (300+ endpoints).<br>
 <strong>Another machine:</strong> MCP via Streamable HTTP or HTTP API, over a private Tailscale network. Both machines must be on the same tailnet. Tandem is never exposed to the public internet.</p>
 </div>
 </div>

--- a/docs/public-launch.md
+++ b/docs/public-launch.md
@@ -20,7 +20,7 @@ Tandem Browser is now public: the local-first browser for shared human-AI browse
 Tandem Browser is now public.
 
 Tandem Browser is a local-first browser built for human-AI collaboration on the local
-machine. The human browses normally. Any AI agent that speaks MCP (250 tools) or
+machine. The human browses normally. Any AI agent that speaks MCP (253 tools) or
 HTTP (300+ endpoints) can operate inside the same real browser context for
 navigation, extraction, automation, screenshots, session work, and observability,
 while websites continue to see a normal Chromium browser instead of an "AI

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tandem-browser",
   "version": "0.75.0",
-  "description": "Local-first Electron browser with a 250-tool MCP server, MCP/HTTP control surfaces, and built-in security controls",
+  "description": "Local-first Electron browser with a 253-tool MCP server, MCP/HTTP control surfaces, and built-in security controls",
   "main": "dist/main.js",
   "author": "Tandem Browser contributors",
   "license": "MIT",

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -65,7 +65,7 @@ Practical notes:
 
 ### Option 1: MCP Server (local or remote)
 
-The MCP server exposes 250 tools with full API parity.
+The MCP server exposes 253 tools with full API parity.
 
 **Same machine (stdio):** Add to your MCP client configuration
 (e.g. `~/.claude/settings.json` for Claude Code):
@@ -717,6 +717,75 @@ curl -sS "$API/screenshot" \
   -H "X-Tab-Id: $TAB_ID" \
   -o screenshot.png
 ```
+
+## Trust tiers — when you get modaled and when you don't
+
+Tandem gates three content-mutating operations behind user approval:
+
+- `POST /execute-js/confirm` (MCP: `tandem_execute_js`) — run ad-hoc JS
+- `POST /scripts/add` — register a persistent userscript
+- `POST /styles/add` — register a persistent CSS injection
+
+By default each call fires a user-approval modal. Once the user has
+granted you trust on a domain (or globally, or permanently), subsequent
+calls on the covered surface skip the modal.
+
+### Four tiers
+
+1. **T1 Default** — modal every call (this is the default).
+2. **T2 Per-domain window** — from the approval modal the user can grant
+   "allow on X for 15min / 1h / this session" when they approve your
+   action. Covers just that domain for the window. Session-scoped.
+3. **T3 Trusted sites** — a persistent allowlist per agent. The user can
+   add sites from Settings → Connected Agents → <agent> → Trusted sites,
+   OR you can request a domain be added via
+   `tandem_request_trusted_domain(domain, rationale)`.
+4. **T4 Global window** — temporary cross-site access for 30 or 60
+   minutes. Agent-requested via `tandem_request_global_window(minutes,
+   rationale)`. Auto-expires. Must be re-requested afterward.
+
+### When to request a grant
+
+Ask yourself: *will I do repeat work on this surface?*
+
+- One-shot overlay experiment? Let the default T1 modal fire, user picks
+  "Just this once".
+- Iterative work on one site over the next ~15 min (e.g., debugging a
+  userscript on Funda)? Let the T1 modal fire, note that the user can
+  choose a T2 window from the same modal.
+- Recurring work on a specific site you expect to return to?
+  `tandem_request_trusted_domain` — one approval, then free forever on
+  that site until the user revokes.
+- Cross-site sweep happening now (research across 10 sites)?
+  `tandem_request_global_window` — one approval, 30 or 60 min of
+  cross-site freedom.
+
+### Rate limits
+
+`tandem_request_trusted_domain` and `tandem_request_global_window` are
+rate-limited to one per 5 minutes per agent. On rate-limit the tool
+returns an error string that includes `retryAfterMs`. Back off — do not
+modal-spam the user. If the task is urgent, tell the user and let them
+grant the trust manually from Settings.
+
+### What NEVER skips a modal
+
+These endpoints always require interactive approval regardless of your
+trust tier:
+
+- `POST /security/injection-override`
+- `POST /security/guardian/mode` (when lowering posture)
+- `POST /security/domains/:domain/trust` (when raising a domain's trust)
+- `POST /security/outbound/whitelist`
+
+Those are meta-level actions that must always be a conscious decision.
+Your T3/T4 grants do not propagate to them.
+
+### Check current trust state
+
+`tandem_list_trust` returns a snapshot of active windows, trusted sites,
+and any global window. Useful before deciding whether to request a new
+grant (maybe you already have one).
 
 ## Interaction Confirmation
 

--- a/src/api/context.ts
+++ b/src/api/context.ts
@@ -8,6 +8,39 @@ import { DEFAULT_PARTITION } from '../utils/constants';
 export type RouteContext = ManagerRegistry & { win: BrowserWindow };
 export type TabTargetSource = 'header' | 'body' | 'query' | 'session' | 'active';
 
+/**
+ * Derive a stable agent identifier from the incoming request.
+ *
+ * Used by the agent-trust system (T2/T3/T4 tiers) to key per-agent
+ * trust state. Local agents (using `~/.tandem/api-token`) resolve to
+ * `'local'`. Paired remote agents (binding tokens starting with
+ * `tdm_ast_`) resolve to a short stable suffix of their binding token,
+ * so two paired agents get separate trust buckets. Requests with no
+ * bearer token resolve to `'shell'` (shell-internal paths).
+ *
+ * NOTE: This is intentionally simple and does not consult pairingManager
+ * for the human-readable agentLabel. That's a UI concern — the store
+ * only needs a *stable* key. If the binding-metadata lookup becomes
+ * cheap later, we can upgrade this helper without touching callers.
+ */
+export function agentIdFromRequest(req: Request): string {
+  const auth = req.headers.authorization;
+  if (!auth) return 'shell';
+  const trimmed = String(auth).trim();
+  const match = /^Bearer\s+(.+)$/i.exec(trimmed);
+  if (!match) return 'shell';
+  const token = match[1].trim();
+  if (token.startsWith('tdm_ast_')) {
+    // Paired binding token — take the 8-char suffix after the prefix as
+    // the stable per-agent id. Collisions within that 8-char space are
+    // astronomically unlikely given the tokens are already random.
+    const rest = token.slice('tdm_ast_'.length);
+    return 'agent:' + rest.slice(0, 8);
+  }
+  // Any other valid bearer = local api-token user.
+  return 'local';
+}
+
 export interface RequestedTabResolution {
   requestedTabId: string | null;
   tab: Tab | null;

--- a/src/api/context.ts
+++ b/src/api/context.ts
@@ -26,10 +26,21 @@ export type TabTargetSource = 'header' | 'body' | 'query' | 'session' | 'active'
 export function agentIdFromRequest(req: Request): string {
   const auth = req.headers.authorization;
   if (!auth) return 'shell';
+  // Manual, linear-time parse. Avoids a regex with a greedy `\s+`
+  // quantifier on uncontrolled input (CodeQL ReDoS warning).
   const trimmed = String(auth).trim();
-  const match = /^Bearer\s+(.+)$/i.exec(trimmed);
-  if (!match) return 'shell';
-  const token = match[1].trim();
+  if (trimmed.length > 8192) return 'shell'; // header size sanity
+  // Case-insensitive "Bearer " prefix.
+  if (trimmed.length < 7) return 'shell';
+  const prefix = trimmed.slice(0, 6);
+  if (prefix.toLowerCase() !== 'bearer') return 'shell';
+  // Exactly one whitespace separator required between "Bearer" and token.
+  // This matches the existing auth middleware's expectations and avoids a
+  // backtracking quantifier.
+  const separator = trimmed.charCodeAt(6);
+  if (separator !== 0x20 && separator !== 0x09) return 'shell';
+  const token = trimmed.slice(7).trim();
+  if (!token) return 'shell';
   if (token.startsWith('tdm_ast_')) {
     // Paired binding token — take the 8-char suffix after the prefix as
     // the stable per-agent id. Collisions within that 8-char space are

--- a/src/api/routes/agent-trust.ts
+++ b/src/api/routes/agent-trust.ts
@@ -1,0 +1,233 @@
+/**
+ * HTTP routes for the agent trust-tier system (T2 windows, T3 trusted
+ * domains, T4 global windows).
+ *
+ * See docs/superpowers/agent-trust-tiers-design.md for the design.
+ *
+ * All mutation routes are local-automation-authenticated (same middleware
+ * as the rest of the API). User-initiated grants (from the shell UI) hit
+ * these routes directly. Agent-initiated grants (requesting persistent
+ * trust or a global window) arrive via `/security/agent-trust/request-*`
+ * and always require user approval via `taskManager.requestApproval`
+ * before the grant lands.
+ */
+
+import type { Router, Request, Response } from 'express';
+import type { RouteContext } from '../context';
+import { agentIdFromRequest } from '../context';
+import { handleRouteError } from '../../utils/errors';
+import { DEFAULT_TIMEOUT_MS } from '../../utils/constants';
+import {
+  ALLOWED_GLOBAL_WINDOW_MINUTES,
+  DOMAIN_WINDOW_DURATIONS,
+  domainKeyFromUrl,
+  type AllowedGlobalWindowMinutes,
+  type DomainWindowDuration,
+} from '../../security/agent-trust';
+
+export function registerAgentTrustRoutes(router: Router, ctx: RouteContext): void {
+
+  // ─── Read state ──────────────────────────────────────────────
+  router.get('/security/agent-trust', (req: Request, res: Response) => {
+    try {
+      const byAgent = ctx.agentTrust.listAgentIds().map((id) => ctx.agentTrust.snapshot(id));
+      // Also include the requesting agent's own bucket even if empty,
+      // so UIs can bootstrap against it.
+      const selfId = agentIdFromRequest(req);
+      if (!byAgent.some((s) => s.agentId === selfId)) {
+        byAgent.push(ctx.agentTrust.snapshot(selfId));
+      }
+      res.json({ agents: byAgent });
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+
+  // ─── Direct grants (user-initiated from shell) ───────────────
+  router.post('/security/agent-trust/grant-domain-window', (req: Request, res: Response) => {
+    try {
+      const { agentId, domain, durationLabel } = req.body as {
+        agentId?: string; domain?: string; durationLabel?: string;
+      };
+      if (!agentId || typeof agentId !== 'string') { res.status(400).json({ error: 'agentId required' }); return; }
+      const normalized = domainKeyFromUrl(domain ?? '');
+      if (!normalized) { res.status(400).json({ error: 'valid http/https domain required' }); return; }
+      if (!durationLabel || !(durationLabel in DOMAIN_WINDOW_DURATIONS)) {
+        res.status(400).json({ error: `durationLabel must be one of ${Object.keys(DOMAIN_WINDOW_DURATIONS).join(', ')}` });
+        return;
+      }
+      ctx.agentTrust.grantDomainWindow(agentId, normalized, durationLabel as DomainWindowDuration);
+      res.json({ ok: true, snapshot: ctx.agentTrust.snapshot(agentId) });
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+
+  router.post('/security/agent-trust/grant-trusted-domain', (req: Request, res: Response) => {
+    try {
+      const { agentId, domain } = req.body as { agentId?: string; domain?: string };
+      if (!agentId || typeof agentId !== 'string') { res.status(400).json({ error: 'agentId required' }); return; }
+      const normalized = domainKeyFromUrl(domain ?? '');
+      if (!normalized) { res.status(400).json({ error: 'valid http/https domain required' }); return; }
+      ctx.agentTrust.grantTrustedDomain(agentId, normalized);
+      res.json({ ok: true, snapshot: ctx.agentTrust.snapshot(agentId) });
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+
+  router.post('/security/agent-trust/grant-global-window', (req: Request, res: Response) => {
+    try {
+      const { agentId, minutes } = req.body as { agentId?: string; minutes?: number };
+      if (!agentId || typeof agentId !== 'string') { res.status(400).json({ error: 'agentId required' }); return; }
+      if (!ALLOWED_GLOBAL_WINDOW_MINUTES.includes(minutes as AllowedGlobalWindowMinutes)) {
+        res.status(400).json({ error: `minutes must be one of ${ALLOWED_GLOBAL_WINDOW_MINUTES.join(', ')}` });
+        return;
+      }
+      ctx.agentTrust.grantGlobalWindow(agentId, minutes as AllowedGlobalWindowMinutes);
+      res.json({ ok: true, snapshot: ctx.agentTrust.snapshot(agentId) });
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+
+  // ─── Direct revokes (user-initiated from shell) ──────────────
+  router.post('/security/agent-trust/revoke-domain-window', (req: Request, res: Response) => {
+    try {
+      const { agentId, domain } = req.body as { agentId?: string; domain?: string };
+      if (!agentId || !domain) { res.status(400).json({ error: 'agentId and domain required' }); return; }
+      ctx.agentTrust.revokeDomainWindow(agentId, String(domain).toLowerCase());
+      res.json({ ok: true, snapshot: ctx.agentTrust.snapshot(agentId) });
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+
+  router.post('/security/agent-trust/revoke-trusted-domain', (req: Request, res: Response) => {
+    try {
+      const { agentId, domain } = req.body as { agentId?: string; domain?: string };
+      if (!agentId || !domain) { res.status(400).json({ error: 'agentId and domain required' }); return; }
+      ctx.agentTrust.revokeTrustedDomain(agentId, String(domain).toLowerCase());
+      res.json({ ok: true, snapshot: ctx.agentTrust.snapshot(agentId) });
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+
+  router.post('/security/agent-trust/revoke-global-window', (req: Request, res: Response) => {
+    try {
+      const { agentId } = req.body as { agentId?: string };
+      if (!agentId) { res.status(400).json({ error: 'agentId required' }); return; }
+      ctx.agentTrust.revokeGlobalWindow(agentId);
+      res.json({ ok: true, snapshot: ctx.agentTrust.snapshot(agentId) });
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+
+  router.post('/security/agent-trust/revoke-all', (req: Request, res: Response) => {
+    try {
+      const { agentId } = req.body as { agentId?: string };
+      if (!agentId) { res.status(400).json({ error: 'agentId required' }); return; }
+      ctx.agentTrust.revokeAll(agentId);
+      res.json({ ok: true, snapshot: ctx.agentTrust.snapshot(agentId) });
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+
+  // ─── Agent-initiated requests (require user approval) ────────
+
+  // T3 request: agent asks to add a domain to its persistent trusted list.
+  // Rate-limited per agent to prevent approval-fatigue spam.
+  router.post('/security/agent-trust/request-trusted-domain', async (req: Request, res: Response) => {
+    try {
+      const { domain, rationale } = req.body as { domain?: string; rationale?: string };
+      const agentId = agentIdFromRequest(req);
+      const normalized = domainKeyFromUrl(domain ?? '');
+      if (!normalized) { res.status(400).json({ error: 'valid http/https domain required' }); return; }
+      if (!rationale || typeof rationale !== 'string' || rationale.length < 10) {
+        res.status(400).json({ error: 'rationale (min 10 chars) required — what is this trust for?' });
+        return;
+      }
+
+      const canRequest = ctx.agentTrust.canRequestGrant(agentId);
+      if (!canRequest.ok) {
+        res.status(429).json({
+          error: 'rate limit exceeded',
+          retryAfterMs: canRequest.retryAfterMs,
+        });
+        return;
+      }
+
+      const description =
+        `Agent "${agentId}" asks to add ${normalized} to trusted sites.\n` +
+        `Reason: ${rationale.slice(0, 240)}`;
+      const task = ctx.taskManager.createTask(
+        description,
+        'claude', 'claude',
+        [{ description, action: { type: 'trust_grant', params: { tier: 'T3', domain: normalized } }, riskLevel: 'high', requiresApproval: true }],
+      );
+      const approved = await Promise.race([
+        ctx.taskManager.requestApproval(task, 0),
+        new Promise<boolean>((resolve) => setTimeout(() => resolve(false), DEFAULT_TIMEOUT_MS)),
+      ]);
+      if (!approved) {
+        res.status(403).json({ error: 'User rejected trust-grant request', rejected: true });
+        return;
+      }
+
+      ctx.agentTrust.grantTrustedDomain(agentId, normalized);
+      res.json({ ok: true, agentId, domain: normalized, snapshot: ctx.agentTrust.snapshot(agentId) });
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+
+  // T4 request: agent asks for cross-site god-mode for 30 or 60 minutes.
+  router.post('/security/agent-trust/request-global-window', async (req: Request, res: Response) => {
+    try {
+      const { minutes, rationale } = req.body as { minutes?: number; rationale?: string };
+      const agentId = agentIdFromRequest(req);
+      if (!ALLOWED_GLOBAL_WINDOW_MINUTES.includes(minutes as AllowedGlobalWindowMinutes)) {
+        res.status(400).json({ error: `minutes must be one of ${ALLOWED_GLOBAL_WINDOW_MINUTES.join(', ')}` });
+        return;
+      }
+      if (!rationale || typeof rationale !== 'string' || rationale.length < 10) {
+        res.status(400).json({ error: 'rationale (min 10 chars) required — what is this window for?' });
+        return;
+      }
+
+      const canRequest = ctx.agentTrust.canRequestGrant(agentId);
+      if (!canRequest.ok) {
+        res.status(429).json({
+          error: 'rate limit exceeded',
+          retryAfterMs: canRequest.retryAfterMs,
+        });
+        return;
+      }
+
+      const description =
+        `Agent "${agentId}" asks for ${minutes}-minute cross-site access.\n` +
+        `Reason: ${rationale.slice(0, 240)}`;
+      const task = ctx.taskManager.createTask(
+        description,
+        'claude', 'claude',
+        [{ description, action: { type: 'trust_grant', params: { tier: 'T4', minutes } }, riskLevel: 'high', requiresApproval: true }],
+      );
+      const approved = await Promise.race([
+        ctx.taskManager.requestApproval(task, 0),
+        new Promise<boolean>((resolve) => setTimeout(() => resolve(false), DEFAULT_TIMEOUT_MS)),
+      ]);
+      if (!approved) {
+        res.status(403).json({ error: 'User rejected global-window request', rejected: true });
+        return;
+      }
+
+      ctx.agentTrust.grantGlobalWindow(agentId, minutes as AllowedGlobalWindowMinutes);
+      res.json({ ok: true, agentId, minutes, snapshot: ctx.agentTrust.snapshot(agentId) });
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+}

--- a/src/api/routes/agents.ts
+++ b/src/api/routes/agents.ts
@@ -1,9 +1,10 @@
 import type { Router, Request, Response } from 'express';
 import type { RouteContext} from '../context';
-import { getSessionWC } from '../context';
+import { getSessionWC, agentIdFromRequest } from '../context';
 import { handleRouteError } from '../../utils/errors';
 import { DEFAULT_TIMEOUT_MS } from '../../utils/constants';
 import type { TaskStatus } from '../../agents/task-manager';
+import { domainKeyFromUrl } from '../../security/agent-trust';
 
 /**
  * Register agent task management, tab-lock, workflow, and watch routes.
@@ -112,31 +113,59 @@ export function registerAgentRoutes(router: Router, ctx: RouteContext): void {
 
       const preview = code.length > 120 ? code.substring(0, 120) + '...' : code;
 
-      // Create a task with a single step that requires approval
-      const task = ctx.taskManager.createTask(
-        `Execute JavaScript: ${preview}`,
-        'claude',
-        'claude',
-        [{
-          description: `Execute JS in active tab: ${preview}`,
-          action: { type: 'execute_js', params: { code } },
-          riskLevel: 'high',
-          requiresApproval: true,
-        }]
-      );
-
-      // Request approval — resolves when user clicks approve/reject
-      const approved = await Promise.race([
-        ctx.taskManager.requestApproval(task, 0),
-        new Promise<boolean>((resolve) => setTimeout(() => resolve(false), DEFAULT_TIMEOUT_MS)),
-      ]);
-
-      if (!approved) {
-        res.status(403).json({ error: 'User rejected JS execution', rejected: true });
-        return;
+      // Agent-trust precheck: if this (agent, domain) pair is already
+      // covered by a T2 window, T3 trusted-domain entry, or T4 global
+      // window, skip the modal and execute directly. This lets legitimate
+      // iterative agent work proceed without per-call friction while
+      // keeping full per-call approval as the default.
+      //
+      // The domain used for the check is the URL of the target tab at
+      // the moment of the call. Cross-domain navigation invalidates T2
+      // windows naturally (different key), which is intentional. Any
+      // error in the precheck is swallowed — the call falls through to
+      // the normal approval modal, which is the safe default.
+      let isTrusted = false;
+      try {
+        const agentId = agentIdFromRequest(req);
+        const preTargetWC = await getSessionWC(ctx, req);
+        const targetUrl = preTargetWC && !preTargetWC.isDestroyed() && typeof preTargetWC.getURL === 'function'
+          ? preTargetWC.getURL()
+          : '';
+        const domain = domainKeyFromUrl(targetUrl);
+        if (domain && ctx.agentTrust.isApproved(agentId, domain)) {
+          isTrusted = true;
+        }
+      } catch {
+        // precheck is best-effort; fall through to approval
       }
 
-      // User approved — execute the code.
+      if (!isTrusted) {
+        // Create a task with a single step that requires approval
+        const task = ctx.taskManager.createTask(
+          `Execute JavaScript: ${preview}`,
+          'claude',
+          'claude',
+          [{
+            description: `Execute JS in active tab: ${preview}`,
+            action: { type: 'execute_js', params: { code } },
+            riskLevel: 'high',
+            requiresApproval: true,
+          }]
+        );
+
+        // Request approval — resolves when user clicks approve/reject
+        const approved = await Promise.race([
+          ctx.taskManager.requestApproval(task, 0),
+          new Promise<boolean>((resolve) => setTimeout(() => resolve(false), DEFAULT_TIMEOUT_MS)),
+        ]);
+
+        if (!approved) {
+          res.status(403).json({ error: 'User rejected JS execution', rejected: true });
+          return;
+        }
+      }
+
+      // User approved (or trust tier covered this) — execute the code.
       // Use getSessionWC so the route honors X-Tab-Id / X-Session headers
       // like other tab-aware routes. Falls back to active tab when no
       // targeting header is present, preserving prior behavior.

--- a/src/api/routes/content.ts
+++ b/src/api/routes/content.ts
@@ -1,7 +1,64 @@
 import type { Router, Request, Response } from 'express';
 import type { RouteContext} from '../context';
-import { getActiveWC, getSessionWC } from '../context';
+import { getActiveWC, getSessionWC, agentIdFromRequest } from '../context';
 import { handleRouteError } from '../../utils/errors';
+import { DEFAULT_TIMEOUT_MS } from '../../utils/constants';
+import { domainKeyFromUrl } from '../../security/agent-trust';
+
+/**
+ * Shared precheck for agent-initiated script/style persistence.
+ *
+ * Fix for the asymmetry uncovered in 2026-04-20 review: `/execute-js/confirm`
+ * was approval-gated but `/scripts/add` and `/styles/add` were not, even
+ * though registering a persistent script is *more* powerful (runs on every
+ * matching page, forever). Same agent-trust precheck as execute-js:
+ * if the (agent, current-tab-domain) pair is covered by T2/T3/T4 trust,
+ * pass through; otherwise fire the approval modal.
+ *
+ * Returns true if the call may proceed. Returns false iff the user
+ * explicitly rejected the modal; in that case the caller must have
+ * already sent a 403 response.
+ */
+async function requireAgentApproval(
+  ctx: RouteContext,
+  req: Request,
+  res: Response,
+  description: string,
+  riskLevel: 'medium' | 'high',
+): Promise<boolean> {
+  try {
+    const agentId = agentIdFromRequest(req);
+    const wc = await getSessionWC(ctx, req);
+    const targetUrl = wc && !wc.isDestroyed() && typeof wc.getURL === 'function' ? wc.getURL() : '';
+    const domain = domainKeyFromUrl(targetUrl);
+    if (domain && ctx.agentTrust.isApproved(agentId, domain)) {
+      return true;
+    }
+  } catch {
+    // precheck best-effort — fall through to approval modal
+  }
+
+  const task = ctx.taskManager.createTask(
+    description,
+    'claude',
+    'claude',
+    [{
+      description,
+      action: { type: 'script_inject', params: {} },
+      riskLevel,
+      requiresApproval: true,
+    }],
+  );
+  const approved = await Promise.race([
+    ctx.taskManager.requestApproval(task, 0),
+    new Promise<boolean>((resolve) => setTimeout(() => resolve(false), DEFAULT_TIMEOUT_MS)),
+  ]);
+  if (!approved) {
+    res.status(403).json({ error: 'User rejected script/style injection', rejected: true });
+    return false;
+  }
+  return true;
+}
 
 /**
  * Register content extraction and URL-fetch routes.
@@ -118,10 +175,17 @@ export function registerContentRoutes(router: Router, ctx: RouteContext): void {
     }
   });
 
-  router.post('/scripts/add', (req: Request, res: Response) => {
+  router.post('/scripts/add', async (req: Request, res: Response) => {
     const { name, code } = req.body;
     if (!name || !code) { res.status(400).json({ error: 'name and code required' }); return; }
     try {
+      const preview = String(code).slice(0, 120);
+      const ok = await requireAgentApproval(
+        ctx, req, res,
+        `Register persistent script "${name}": ${preview}`,
+        'high',
+      );
+      if (!ok) return; // response already sent
       const entry = ctx.scriptInjector.addScript(name, code);
       res.json({ ok: true, name: entry.name, active: entry.enabled });
     } catch (e) {
@@ -186,6 +250,13 @@ export function registerContentRoutes(router: Router, ctx: RouteContext): void {
     const { name, css } = req.body;
     if (!name || !css) { res.status(400).json({ error: 'name and css required' }); return; }
     try {
+      const preview = String(css).slice(0, 120);
+      const ok = await requireAgentApproval(
+        ctx, req, res,
+        `Register persistent style "${name}": ${preview}`,
+        'medium',
+      );
+      if (!ok) return;
       ctx.scriptInjector.addStyle(name, css);
       // Inject immediately into active tab
       const wc = await getSessionWC(ctx, req);

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -18,6 +18,7 @@ import { registerExtensionRoutes, TRUSTED_EXTENSION_ROUTE_PATHS } from './routes
 import { registerNetworkRoutes } from './routes/network';
 import { registerSessionRoutes } from './routes/sessions';
 import { registerAgentRoutes } from './routes/agents';
+import { registerAgentTrustRoutes } from './routes/agent-trust';
 import { registerDataRoutes } from './routes/data';
 import { registerContentRoutes } from './routes/content';
 import { registerMediaRoutes } from './routes/media';
@@ -505,6 +506,7 @@ export class TandemAPI {
     registerNetworkRoutes(router, ctx);
     registerSessionRoutes(router, ctx);
     registerAgentRoutes(router, ctx);
+    registerAgentTrustRoutes(router, ctx);
     registerDataRoutes(router, ctx);
     registerContentRoutes(router, ctx);
     registerMediaRoutes(router, ctx);

--- a/src/api/tests/context.test.ts
+++ b/src/api/tests/context.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import type { Request } from 'express';
+import { agentIdFromRequest } from '../context';
+
+function mkReq(authHeader?: string): Request {
+  return { headers: authHeader === undefined ? {} : { authorization: authHeader } } as unknown as Request;
+}
+
+describe('agentIdFromRequest', () => {
+  it('returns "shell" when no Authorization header is set', () => {
+    expect(agentIdFromRequest(mkReq())).toBe('shell');
+  });
+
+  it('returns "shell" for empty or whitespace header', () => {
+    expect(agentIdFromRequest(mkReq(''))).toBe('shell');
+    expect(agentIdFromRequest(mkReq('   '))).toBe('shell');
+  });
+
+  it('returns "shell" for headers that do not start with Bearer', () => {
+    expect(agentIdFromRequest(mkReq('Basic xxx'))).toBe('shell');
+    expect(agentIdFromRequest(mkReq('Token abc'))).toBe('shell');
+  });
+
+  it('returns "shell" when Bearer is not followed by a whitespace separator', () => {
+    // "Bearerxyz" — missing space
+    expect(agentIdFromRequest(mkReq('Bearerxyz'))).toBe('shell');
+  });
+
+  it('returns "shell" for truncated headers', () => {
+    expect(agentIdFromRequest(mkReq('Bear'))).toBe('shell');
+    expect(agentIdFromRequest(mkReq('Bearer'))).toBe('shell');
+    expect(agentIdFromRequest(mkReq('Bearer '))).toBe('shell'); // no token
+  });
+
+  it('returns "local" for a plain local api-token', () => {
+    expect(agentIdFromRequest(mkReq('Bearer abc123'))).toBe('local');
+    expect(agentIdFromRequest(mkReq('bearer abc123'))).toBe('local'); // case-insensitive
+    expect(agentIdFromRequest(mkReq('BEARER abc123'))).toBe('local');
+  });
+
+  it('returns a deterministic per-agent id for binding tokens', () => {
+    // tdm_ast_ prefix + 8-char suffix → "agent:<8char>"
+    expect(agentIdFromRequest(mkReq('Bearer tdm_ast_abc12345xyz'))).toBe('agent:abc12345');
+    expect(agentIdFromRequest(mkReq('Bearer tdm_ast_ABCDEFGHIJKLMN'))).toBe('agent:ABCDEFGH');
+  });
+
+  it('distinct binding tokens map to distinct agent ids', () => {
+    const a = agentIdFromRequest(mkReq('Bearer tdm_ast_aaaaaaaaXXX'));
+    const b = agentIdFromRequest(mkReq('Bearer tdm_ast_bbbbbbbbYYY'));
+    expect(a).toBe('agent:aaaaaaaa');
+    expect(b).toBe('agent:bbbbbbbb');
+    expect(a).not.toBe(b);
+  });
+
+  it('rejects absurdly long headers (ReDoS sanity)', () => {
+    // Even if the regex approach were still used, this is a linear
+    // implementation now. Verify it does not hang on pathological input.
+    const pathological = 'Bearer' + '\t'.repeat(50_000) + 'tail';
+    const start = Date.now();
+    const result = agentIdFromRequest(mkReq(pathological));
+    const elapsed = Date.now() - start;
+    // Size-guarded: header > 8192 chars → 'shell'. Either way, fast.
+    expect(result).toBe('shell');
+    expect(elapsed).toBeLessThan(100); // generous upper bound
+  });
+
+  it('accepts tab character as separator (RFC 7235)', () => {
+    // Our linear parser honours space or tab as the single separator
+    // after "Bearer", matching the HTTP Authorization spec.
+    expect(agentIdFromRequest(mkReq('Bearer\tabc123'))).toBe('local');
+  });
+});

--- a/src/api/tests/helpers.ts
+++ b/src/api/tests/helpers.ts
@@ -2,6 +2,7 @@ import { vi } from 'vitest';
 import express from 'express';
 import type { Router } from 'express';
 import type { RouteContext } from '../context';
+import { AgentTrustStore } from '../../security/agent-trust';
 
 /**
  * Creates a mock WebContents object with common methods stubbed.
@@ -686,6 +687,12 @@ export function createMockContext(): RouteContext {
       on: vi.fn(),
       emit: vi.fn(),
     } as any,
+
+    // ── agentTrust ──────────────────────────────
+    // Real store (in-memory T2/T4 work fine; T3 persist() would touch disk
+    // at ~/.tandem/agent-trust.json — tests that care should inject their
+    // own path via new AgentTrustStore(path)).
+    agentTrust: new AgentTrustStore(),
   };
 
   return ctx;

--- a/src/api/tests/routes/agent-trust.test.ts
+++ b/src/api/tests/routes/agent-trust.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Route tests for `/security/agent-trust/*`.
+ *
+ * Full happy-path + validation + rate-limit coverage for the 9 routes
+ * registered by `registerAgentTrustRoutes`. The underlying
+ * `AgentTrustStore` is already exhaustively unit-tested (41 cases in
+ * `src/security/tests/agent-trust.test.ts`); this file focuses on the
+ * HTTP surface: input validation, domain normalization, rate limiting,
+ * and the agent-initiated approval-flow integration.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+
+vi.mock('electron', () => ({
+  BrowserWindow: vi.fn(),
+  session: {},
+  webContents: {
+    fromId: vi.fn(),
+    getAllWebContents: vi.fn().mockReturnValue([]),
+  },
+}));
+
+import { registerAgentTrustRoutes } from '../../routes/agent-trust';
+import { createMockContext, createTestApp } from '../helpers';
+import type { RouteContext } from '../../context';
+
+describe('Agent Trust Routes', () => {
+  let ctx: RouteContext;
+  let app: ReturnType<typeof createTestApp>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ctx = createMockContext();
+    app = createTestApp(registerAgentTrustRoutes, ctx);
+  });
+
+  describe('GET /security/agent-trust', () => {
+    it('returns empty snapshot for unknown agents', async () => {
+      const res = await request(app).get('/security/agent-trust');
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('agents');
+      expect(Array.isArray(res.body.agents)).toBe(true);
+    });
+
+    it('includes the requesting agent even when it has no state', async () => {
+      const res = await request(app)
+        .get('/security/agent-trust')
+        .set('Authorization', 'Bearer abc');
+      expect(res.status).toBe(200);
+      expect(res.body.agents).toEqual(expect.arrayContaining([
+        expect.objectContaining({ agentId: 'local', trustedDomains: [] }),
+      ]));
+    });
+
+    it('shows granted trusted domains for an agent', async () => {
+      ctx.agentTrust.grantTrustedDomain('claude', 'funda.nl');
+      ctx.agentTrust.grantTrustedDomain('claude', 'linkedin.com');
+      const res = await request(app).get('/security/agent-trust');
+      const claude = res.body.agents.find((a: { agentId: string }) => a.agentId === 'claude');
+      expect(claude).toBeDefined();
+      expect(claude.trustedDomains).toEqual(['funda.nl', 'linkedin.com']);
+    });
+  });
+
+  describe('POST /security/agent-trust/grant-domain-window', () => {
+    it('grants a 15min window and returns a fresh snapshot', async () => {
+      const res = await request(app)
+        .post('/security/agent-trust/grant-domain-window')
+        .send({ agentId: 'claude', domain: 'funda.nl', durationLabel: '15min' });
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.snapshot.perDomainWindows).toHaveLength(1);
+      expect(res.body.snapshot.perDomainWindows[0].domain).toBe('funda.nl');
+      expect(ctx.agentTrust.isApproved('claude', 'funda.nl')).toBe(true);
+    });
+
+    it('normalizes full URLs to the bare hostname', async () => {
+      const res = await request(app)
+        .post('/security/agent-trust/grant-domain-window')
+        .send({ agentId: 'claude', domain: 'https://www.funda.nl/zoeken', durationLabel: '1hour' });
+      expect(res.status).toBe(200);
+      expect(res.body.snapshot.perDomainWindows[0].domain).toBe('www.funda.nl');
+    });
+
+    it('returns 400 for missing agentId', async () => {
+      const res = await request(app)
+        .post('/security/agent-trust/grant-domain-window')
+        .send({ domain: 'funda.nl', durationLabel: '15min' });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for invalid domain schemes', async () => {
+      const res = await request(app)
+        .post('/security/agent-trust/grant-domain-window')
+        .send({ agentId: 'claude', domain: 'file:///etc/passwd', durationLabel: '15min' });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 for unknown durationLabel', async () => {
+      const res = await request(app)
+        .post('/security/agent-trust/grant-domain-window')
+        .send({ agentId: 'claude', domain: 'funda.nl', durationLabel: '5min' });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('POST /security/agent-trust/grant-trusted-domain', () => {
+    it('adds a persistent trusted domain', async () => {
+      const res = await request(app)
+        .post('/security/agent-trust/grant-trusted-domain')
+        .send({ agentId: 'claude', domain: 'linkedin.com' });
+      expect(res.status).toBe(200);
+      expect(ctx.agentTrust.isApproved('claude', 'linkedin.com')).toBe(true);
+      expect(res.body.snapshot.trustedDomains).toContain('linkedin.com');
+    });
+
+    it('rejects invalid domains', async () => {
+      const res = await request(app)
+        .post('/security/agent-trust/grant-trusted-domain')
+        .send({ agentId: 'claude', domain: 'not a domain' });
+      expect(res.status).toBe(400);
+    });
+
+    it('requires agentId', async () => {
+      const res = await request(app)
+        .post('/security/agent-trust/grant-trusted-domain')
+        .send({ domain: 'linkedin.com' });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('POST /security/agent-trust/grant-global-window', () => {
+    it('grants a 30-minute global window', async () => {
+      const res = await request(app)
+        .post('/security/agent-trust/grant-global-window')
+        .send({ agentId: 'claude', minutes: 30 });
+      expect(res.status).toBe(200);
+      expect(res.body.snapshot.globalWindow).not.toBeNull();
+      expect(res.body.snapshot.globalWindow.minutes).toBe(30);
+      expect(ctx.agentTrust.isApproved('claude', 'any-domain.com')).toBe(true);
+    });
+
+    it('grants a 60-minute global window', async () => {
+      const res = await request(app)
+        .post('/security/agent-trust/grant-global-window')
+        .send({ agentId: 'claude', minutes: 60 });
+      expect(res.status).toBe(200);
+      expect(res.body.snapshot.globalWindow.minutes).toBe(60);
+    });
+
+    it('rejects invalid durations', async () => {
+      for (const bad of [15, 45, 90, 120, 0, -1]) {
+        const res = await request(app)
+          .post('/security/agent-trust/grant-global-window')
+          .send({ agentId: 'claude', minutes: bad });
+        expect(res.status).toBe(400);
+      }
+    });
+
+    it('requires agentId', async () => {
+      const res = await request(app)
+        .post('/security/agent-trust/grant-global-window')
+        .send({ minutes: 30 });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('revoke routes', () => {
+    it('revoke-domain-window removes the window', async () => {
+      ctx.agentTrust.grantDomainWindow('claude', 'funda.nl', '15min');
+      const res = await request(app)
+        .post('/security/agent-trust/revoke-domain-window')
+        .send({ agentId: 'claude', domain: 'funda.nl' });
+      expect(res.status).toBe(200);
+      expect(ctx.agentTrust.isApproved('claude', 'funda.nl')).toBe(false);
+    });
+
+    it('revoke-trusted-domain removes the domain', async () => {
+      ctx.agentTrust.grantTrustedDomain('claude', 'linkedin.com');
+      const res = await request(app)
+        .post('/security/agent-trust/revoke-trusted-domain')
+        .send({ agentId: 'claude', domain: 'linkedin.com' });
+      expect(res.status).toBe(200);
+      expect(ctx.agentTrust.isApproved('claude', 'linkedin.com')).toBe(false);
+    });
+
+    it('revoke-global-window clears it', async () => {
+      ctx.agentTrust.grantGlobalWindow('claude', 30);
+      const res = await request(app)
+        .post('/security/agent-trust/revoke-global-window')
+        .send({ agentId: 'claude' });
+      expect(res.status).toBe(200);
+      expect(ctx.agentTrust.isApproved('claude', 'any.com')).toBe(false);
+    });
+
+    it('revoke-all clears T2/T3/T4 for an agent', async () => {
+      ctx.agentTrust.grantDomainWindow('claude', 'a.com', '15min');
+      ctx.agentTrust.grantTrustedDomain('claude', 'b.com');
+      ctx.agentTrust.grantGlobalWindow('claude', 60);
+      const res = await request(app)
+        .post('/security/agent-trust/revoke-all')
+        .send({ agentId: 'claude' });
+      expect(res.status).toBe(200);
+      expect(ctx.agentTrust.isApproved('claude', 'a.com')).toBe(false);
+      expect(ctx.agentTrust.isApproved('claude', 'b.com')).toBe(false);
+      expect(ctx.agentTrust.isApproved('claude', 'c.com')).toBe(false);
+    });
+
+    it('all revoke routes require agentId', async () => {
+      for (const route of [
+        'revoke-domain-window',
+        'revoke-trusted-domain',
+        'revoke-global-window',
+        'revoke-all',
+      ]) {
+        const res = await request(app).post(`/security/agent-trust/${route}`).send({});
+        expect(res.status).toBe(400);
+      }
+    });
+  });
+
+  describe('POST /security/agent-trust/request-trusted-domain', () => {
+    it('grants on user approval', async () => {
+      vi.mocked(ctx.taskManager.requestApproval).mockResolvedValue(true);
+      const res = await request(app)
+        .post('/security/agent-trust/request-trusted-domain')
+        .send({ domain: 'funda.nl', rationale: 'Iterative overlay work' });
+      expect(res.status).toBe(200);
+      expect(res.body.domain).toBe('funda.nl');
+      expect(ctx.agentTrust.isApproved('shell', 'funda.nl')).toBe(true);
+      expect(ctx.taskManager.createTask).toHaveBeenCalled();
+    });
+
+    it('returns 403 when user rejects', async () => {
+      vi.mocked(ctx.taskManager.requestApproval).mockResolvedValue(false);
+      const res = await request(app)
+        .post('/security/agent-trust/request-trusted-domain')
+        .send({ domain: 'funda.nl', rationale: 'Iterative overlay work' });
+      expect(res.status).toBe(403);
+      expect(res.body.rejected).toBe(true);
+      expect(ctx.agentTrust.isApproved('shell', 'funda.nl')).toBe(false);
+    });
+
+    it('validates rationale minimum length', async () => {
+      const res = await request(app)
+        .post('/security/agent-trust/request-trusted-domain')
+        .send({ domain: 'funda.nl', rationale: 'short' });
+      expect(res.status).toBe(400);
+    });
+
+    it('validates domain format', async () => {
+      const res = await request(app)
+        .post('/security/agent-trust/request-trusted-domain')
+        .send({ domain: '', rationale: 'long enough rationale' });
+      expect(res.status).toBe(400);
+    });
+
+    it('rate-limits repeat requests from the same agent', async () => {
+      vi.mocked(ctx.taskManager.requestApproval).mockResolvedValue(true);
+      const first = await request(app)
+        .post('/security/agent-trust/request-trusted-domain')
+        .send({ domain: 'a.com', rationale: 'first request ever happens now' });
+      expect(first.status).toBe(200);
+
+      const second = await request(app)
+        .post('/security/agent-trust/request-trusted-domain')
+        .send({ domain: 'b.com', rationale: 'immediate second request which should 429' });
+      expect(second.status).toBe(429);
+      expect(second.body.retryAfterMs).toBeGreaterThan(0);
+    });
+  });
+
+  describe('POST /security/agent-trust/request-global-window', () => {
+    it('grants on user approval (30 min)', async () => {
+      vi.mocked(ctx.taskManager.requestApproval).mockResolvedValue(true);
+      const res = await request(app)
+        .post('/security/agent-trust/request-global-window')
+        .send({ minutes: 30, rationale: 'Cross-site research sweep' });
+      expect(res.status).toBe(200);
+      expect(res.body.minutes).toBe(30);
+      expect(ctx.agentTrust.isApproved('shell', 'any.com')).toBe(true);
+    });
+
+    it('rejects 15 or 120 minutes', async () => {
+      for (const bad of [15, 120]) {
+        const res = await request(app)
+          .post('/security/agent-trust/request-global-window')
+          .send({ minutes: bad, rationale: 'Valid rationale string' });
+        expect(res.status).toBe(400);
+      }
+    });
+
+    it('returns 403 when user rejects', async () => {
+      vi.mocked(ctx.taskManager.requestApproval).mockResolvedValue(false);
+      const res = await request(app)
+        .post('/security/agent-trust/request-global-window')
+        .send({ minutes: 30, rationale: 'Valid rationale string' });
+      expect(res.status).toBe(403);
+    });
+
+    it('requires rationale', async () => {
+      const res = await request(app)
+        .post('/security/agent-trust/request-global-window')
+        .send({ minutes: 30 });
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/src/bootstrap/runtime.ts
+++ b/src/bootstrap/runtime.ts
@@ -5,6 +5,7 @@ import { ActivityTracker } from '../activity/tracker';
 import { WingmanStream } from '../activity/wingman-stream';
 import { TaskManager } from '../agents/task-manager';
 import { TaskHandoffCoordinator } from '../agents/task-handoff-coordinator';
+import { AgentTrustStore } from '../security/agent-trust';
 import { TabLockManager } from '../agents/tab-lock-manager';
 import { LoginManager } from '../auth/login-manager';
 import { GooglePhotosManager } from '../integrations/google-photos';
@@ -227,6 +228,11 @@ export async function initializeRuntimeManagers(opts: InitializeRuntimeOptions):
   runtime.eventStream = new EventStreamManager();
   runtime.handoffManager = new HandoffManager();
   runtime.taskManager = new TaskManager();
+  runtime.agentTrust = new AgentTrustStore();
+  // Load persisted T3 trusted domains from disk. Errors are logged
+  // internally; a failure leaves the store in the empty state which is
+  // the safe default (every action returns to T1 modal).
+  await runtime.agentTrust.load();
   runtime.taskHandoffCoordinator = new TaskHandoffCoordinator(runtime.taskManager, runtime.handoffManager);
   runtime.tabLockManager = new TabLockManager();
   runtime.devToolsManager = new DevToolsManager(runtime.tabManager);
@@ -454,6 +460,7 @@ export function createManagerRegistry(runtime: RuntimeManagers): ManagerRegistry
     googlePhotosManager: runtime.googlePhotosManager,
     clipboardManager: runtime.clipboardManager,
     pairingManager: runtime.pairingManager,
+    agentTrust: runtime.agentTrust,
   };
 }
 

--- a/src/bootstrap/types.ts
+++ b/src/bootstrap/types.ts
@@ -1,3 +1,4 @@
+import type { AgentTrustStore } from '../security/agent-trust';
 import type { ExtensionLoader } from '../extensions/loader';
 import type { ActivityTracker } from '../activity/tracker';
 import type { TabManager } from '../tabs/manager';
@@ -100,6 +101,7 @@ export interface RuntimeManagers {
   googlePhotosManager: GooglePhotosManager;
   clipboardManager: ClipboardManager;
   pairingManager: PairingManager;
+  agentTrust: AgentTrustStore;
 }
 
 export interface PendingTabRegister {

--- a/src/mcp/register-all.ts
+++ b/src/mcp/register-all.ts
@@ -42,6 +42,7 @@ import { registerEventTools } from './tools/events.js';
 import { registerSystemTools } from './tools/system.js';
 import { registerAwarenessTools } from './tools/awareness.js';
 import { registerClipboardTools } from './tools/clipboard.js';
+import { registerAgentTrustTools } from './tools/agent-trust.js';
 
 /** Register all MCP tools on the given server instance. */
 export function registerAllTools(server: McpServer): void {
@@ -78,6 +79,7 @@ export function registerAllTools(server: McpServer): void {
   registerSystemTools(server);
   registerAwarenessTools(server);
   registerClipboardTools(server);
+  registerAgentTrustTools(server);
 }
 
 /** Register all MCP resources on the given server instance. */

--- a/src/mcp/tests/agent-trust.test.ts
+++ b/src/mcp/tests/agent-trust.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../api-client.js', () => ({
+  apiCall: vi.fn(),
+  logActivity: vi.fn(),
+}));
+
+import { apiCall, logActivity } from '../api-client.js';
+import { registerAgentTrustTools } from '../tools/agent-trust.js';
+import { createMockServer, getHandler, expectTextContent } from './mcp-test-helper.js';
+
+const mockApiCall = vi.mocked(apiCall);
+const mockLogActivity = vi.mocked(logActivity);
+
+describe('MCP agent-trust tools', () => {
+  const { server, tools } = createMockServer();
+  registerAgentTrustTools(server);
+
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  describe('tandem_request_trusted_domain', () => {
+    const handler = getHandler(tools, 'tandem_request_trusted_domain');
+
+    it('calls the HTTP route with domain + rationale', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: true, agentId: 'shell', domain: 'funda.nl' });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      await handler({ domain: 'funda.nl', rationale: 'Iterative overlay work' });
+      expect(mockApiCall).toHaveBeenCalledWith(
+        'POST',
+        '/security/agent-trust/request-trusted-domain',
+        { domain: 'funda.nl', rationale: 'Iterative overlay work' },
+      );
+    });
+
+    it('returns text confirming the grant', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: true, domain: 'funda.nl' });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({ domain: 'funda.nl', rationale: 'Iterative overlay work' });
+      expectTextContent(result, 'Trusted-domain grant approved for funda.nl');
+    });
+
+    it('surfaces rate-limit as isError with a clear message', async () => {
+      mockApiCall.mockRejectedValueOnce(new Error('rate limit exceeded'));
+      const result = await handler({ domain: 'a.com', rationale: 'second request burst' });
+      expect(result.isError).toBe(true);
+      expectTextContent(result, 'Rate limit');
+    });
+
+    it('surfaces rejection as isError with a clear message', async () => {
+      mockApiCall.mockRejectedValueOnce(new Error('User rejected trust-grant request'));
+      const result = await handler({ domain: 'a.com', rationale: 'Valid rationale here' });
+      expect(result.isError).toBe(true);
+      expectTextContent(result, 'rejected');
+    });
+
+    it('propagates unexpected errors', async () => {
+      mockApiCall.mockRejectedValueOnce(new Error('network down'));
+      await expect(handler({ domain: 'a.com', rationale: 'Valid rationale here' })).rejects.toThrow('network down');
+    });
+  });
+
+  describe('tandem_request_global_window', () => {
+    const handler = getHandler(tools, 'tandem_request_global_window');
+
+    it('calls HTTP route with minutes + rationale (30)', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: true, minutes: 30 });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      await handler({ minutes: 30, rationale: 'Cross-site sweep across providers' });
+      expect(mockApiCall).toHaveBeenCalledWith(
+        'POST',
+        '/security/agent-trust/request-global-window',
+        { minutes: 30, rationale: 'Cross-site sweep across providers' },
+      );
+    });
+
+    it('calls HTTP route with minutes=60', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: true, minutes: 60 });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      await handler({ minutes: 60, rationale: 'Longer cross-site research' });
+      expect(mockApiCall).toHaveBeenCalledWith(
+        'POST',
+        '/security/agent-trust/request-global-window',
+        { minutes: 60, rationale: 'Longer cross-site research' },
+      );
+    });
+
+    it('returns text confirming the grant', async () => {
+      mockApiCall.mockResolvedValueOnce({ ok: true, minutes: 30 });
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({ minutes: 30, rationale: 'Cross-site sweep across providers' });
+      expectTextContent(result, 'Cross-site window approved for 30 minutes');
+    });
+
+    it('surfaces rate-limit errors', async () => {
+      mockApiCall.mockRejectedValueOnce(new Error('rate limit exceeded'));
+      const result = await handler({ minutes: 30, rationale: 'Cross-site sweep across providers' });
+      expect(result.isError).toBe(true);
+      expectTextContent(result, 'Rate limit');
+    });
+
+    it('surfaces rejection', async () => {
+      mockApiCall.mockRejectedValueOnce(new Error('User rejected global-window request'));
+      const result = await handler({ minutes: 30, rationale: 'Cross-site sweep across providers' });
+      expect(result.isError).toBe(true);
+      expectTextContent(result, 'rejected');
+    });
+  });
+
+  describe('tandem_list_trust', () => {
+    const handler = getHandler(tools, 'tandem_list_trust');
+
+    it('fetches GET /security/agent-trust and returns JSON', async () => {
+      const snapshot = {
+        agents: [{ agentId: 'claude', trustedDomains: ['funda.nl'], perDomainWindows: [], globalWindow: null }],
+      };
+      mockApiCall.mockResolvedValueOnce(snapshot);
+      mockLogActivity.mockResolvedValueOnce(undefined);
+      const result = await handler({});
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/security/agent-trust');
+      expectTextContent(result, '"trustedDomains"');
+      expectTextContent(result, 'funda.nl');
+    });
+  });
+});

--- a/src/mcp/tools/agent-trust.ts
+++ b/src/mcp/tools/agent-trust.ts
@@ -1,0 +1,102 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { apiCall, logActivity } from '../api-client.js';
+
+/**
+ * Agent-trust MCP tools — let the agent request bigger trust scopes from
+ * the user. Each request produces a user-approval modal with the agent's
+ * domain/minutes and rationale visible, then records the grant on success.
+ *
+ * These calls are rate-limited per agent (5 minutes between requests) to
+ * prevent approval-fatigue spam. On rate-limit the HTTP route returns 429
+ * with a `retryAfterMs`; this tool surfaces that as an error string the
+ * agent can read and back off from.
+ *
+ * See docs/superpowers/agent-trust-tiers-design.md for the full design.
+ */
+export function registerAgentTrustTools(server: McpServer): void {
+  server.tool(
+    'tandem_request_trusted_domain',
+    'Ask the user to add a domain to the agent\'s permanent trusted-sites list. ' +
+      'Trusted sites let the agent run scripts, register persistent scripts, and inject ' +
+      'styles on that domain without per-call approval, until the user revokes. ' +
+      'The user sees a modal with the domain and your rationale and decides. ' +
+      'Rate-limited: max one trust-grant request per 5 minutes per agent. ' +
+      'Use this when you expect repeat work on the same site (e.g., an inbox triage ' +
+      'workflow on linkedin.com, or iterative UI overlays on funda.nl).',
+    {
+      domain: z.string().describe('The domain to request (e.g. "funda.nl" or "https://funda.nl/"). Subdomains are treated as separate entries.'),
+      rationale: z.string().min(10).describe('Why you want this persistent trust. Shown to the user in the approval modal. Min 10 chars.'),
+    },
+    {
+      destructiveHint: false,
+      readOnlyHint: false,
+      openWorldHint: false,
+    },
+    async ({ domain, rationale }) => {
+      try {
+        const result = await apiCall('POST', '/security/agent-trust/request-trusted-domain', { domain, rationale });
+        await logActivity('trust_request_domain', `${domain}: ${rationale.slice(0, 60)}`);
+        return { content: [{ type: 'text', text: `Trusted-domain grant approved for ${domain}.\n${JSON.stringify(result, null, 2)}` }] };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes('rate limit')) {
+          return { content: [{ type: 'text', text: `Rate limit: wait a few minutes before requesting another trust grant.\n${msg}` }], isError: true };
+        }
+        if (msg.includes('rejected')) {
+          return { content: [{ type: 'text', text: `User rejected the trusted-domain request for ${domain}.` }], isError: true };
+        }
+        throw err;
+      }
+    },
+  );
+
+  server.tool(
+    'tandem_request_global_window',
+    'Ask the user for a temporary cross-site window (30 or 60 minutes) where the agent ' +
+      'can run scripts, register persistent scripts, and inject styles on ANY domain ' +
+      'without per-call approval. Auto-expires; must be requested again afterward. ' +
+      'Power-user mode — use only when the task genuinely spans many sites (e.g., ' +
+      'cross-site research sweep, bulk data enrichment across providers). ' +
+      'Rate-limited: max one request per 5 minutes per agent. ' +
+      'Security-posture-weakening endpoints (lowering trust, whitelisting) still ' +
+      'require separate per-call approval even during a global window.',
+    {
+      minutes: z.union([z.literal(30), z.literal(60)]).describe('Duration in minutes. Only 30 or 60 accepted; no other values.'),
+      rationale: z.string().min(10).describe('Why you want this window. Shown to the user. Min 10 chars.'),
+    },
+    {
+      destructiveHint: false,
+      readOnlyHint: false,
+      openWorldHint: false,
+    },
+    async ({ minutes, rationale }) => {
+      try {
+        const result = await apiCall('POST', '/security/agent-trust/request-global-window', { minutes, rationale });
+        await logActivity('trust_request_window', `${minutes}min: ${rationale.slice(0, 60)}`);
+        return { content: [{ type: 'text', text: `Cross-site window approved for ${minutes} minutes.\n${JSON.stringify(result, null, 2)}` }] };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes('rate limit')) {
+          return { content: [{ type: 'text', text: `Rate limit: wait a few minutes before requesting another trust grant.\n${msg}` }], isError: true };
+        }
+        if (msg.includes('rejected')) {
+          return { content: [{ type: 'text', text: `User rejected the global-window request.` }], isError: true };
+        }
+        throw err;
+      }
+    },
+  );
+
+  server.tool(
+    'tandem_list_trust',
+    'List the agent\'s current trust state: active per-domain windows, trusted sites, ' +
+      'and the global window if any. Useful before deciding whether to request a new grant.',
+    {},
+    async () => {
+      const data = await apiCall('GET', '/security/agent-trust');
+      await logActivity('trust_list');
+      return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+    },
+  );
+}

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -4,6 +4,7 @@
  * Replaces the 35+ param TandemAPIOptions object and the duplicate RouteContext interface.
  * Built once in main.ts, passed to TandemAPI, and used as RouteContext for route handlers.
  */
+import type { AgentTrustStore } from './security/agent-trust';
 import type { TabManager } from './tabs/manager';
 import type { PanelManager } from './panel/manager';
 import type { DrawOverlayManager } from './draw/overlay';
@@ -147,4 +148,6 @@ export interface ManagerRegistry {
   clipboardManager: ClipboardManager;
   /** Remote agent pairing with setup codes, binding tokens, and lifecycle management. See src/pairing/manager.ts */
   pairingManager: PairingManager;
+  /** Per-agent trust tiers (T2 windows, T3 trusted domains, T4 global window) layered over approval gates. See src/security/agent-trust.ts */
+  agentTrust: AgentTrustStore;
 }

--- a/src/security/agent-trust.ts
+++ b/src/security/agent-trust.ts
@@ -1,0 +1,381 @@
+/**
+ * AgentTrustStore — per-agent approval-tier cache.
+ *
+ * Solves the friction introduced by audit #34: Tandem's
+ * every-call-needs-approval UX was too heavy for legitimate team-member
+ * agent work (building overlays, iterating scripts). This store layers
+ * four tiers on top of the existing `taskManager.requestApproval` gate:
+ *
+ *   T1  Default              Modal every call (current behavior)
+ *   T2  Per-domain window    Modal asks once; agent free on that domain for N min
+ *   T3  Trusted sites        Persistent allowlist per agent; never asks
+ *   T4  Global window        30/60-min cross-site god-mode, agent-requested, user-approved
+ *
+ * What stays at T1 regardless (never bypassed):
+ *   - /security/injection-override
+ *   - /security/guardian/mode (weakening)
+ *   - /security/domains/:domain/trust (raising)
+ *   - /security/outbound/whitelist
+ * Those endpoints still always require explicit per-call approval; raising
+ * them is a meta-level capability that must not ride on cached trust.
+ *
+ * See docs/superpowers/agent-trust-tiers-design.md for the full design.
+ */
+
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { createLogger } from '../utils/logger';
+
+const log = createLogger('AgentTrust');
+
+/** Minimum time between agent-initiated grant requests (ms). */
+export const GRANT_REQUEST_COOLDOWN_MS = 5 * 60 * 1000;
+
+/** Only these durations are valid for T4 global windows. */
+export const ALLOWED_GLOBAL_WINDOW_MINUTES = [30, 60] as const;
+export type AllowedGlobalWindowMinutes = (typeof ALLOWED_GLOBAL_WINDOW_MINUTES)[number];
+
+/** T2 window duration labels. */
+export const DOMAIN_WINDOW_DURATIONS = {
+  '15min': 15 * 60 * 1000,
+  '1hour': 60 * 60 * 1000,
+  'session': 24 * 60 * 60 * 1000, // session ~= browser stays open; we cap at 24h as a safety net
+} as const;
+export type DomainWindowDuration = keyof typeof DOMAIN_WINDOW_DURATIONS;
+
+interface DomainWindow {
+  expiresAt: number;
+  durationLabel: DomainWindowDuration;
+}
+
+interface GlobalWindow {
+  expiresAt: number;
+  minutes: AllowedGlobalWindowMinutes;
+}
+
+interface AgentTrustState {
+  agentId: string;
+  trustedDomains: Set<string>;              // T3 — persisted
+  perDomainWindows: Map<string, DomainWindow>; // T2 — memory only
+  globalWindow: GlobalWindow | null;         // T4 — memory only
+  lastGrantRequestAt: number | null;         // for rate limiting
+}
+
+/** Snapshot shape exposed to UI / API. */
+export interface AgentTrustSnapshot {
+  agentId: string;
+  trustedDomains: string[];
+  perDomainWindows: Array<{
+    domain: string;
+    expiresAt: number;
+    remainingMs: number;
+    durationLabel: string;
+  }>;
+  globalWindow: {
+    expiresAt: number;
+    remainingMs: number;
+    minutes: number;
+  } | null;
+}
+
+/** Persisted file shape. */
+interface PersistedState {
+  version: number;
+  agents: Record<string, { trustedDomains: string[] }>;
+}
+
+const PERSIST_VERSION = 1;
+
+/**
+ * Normalize a URL or hostname to a bare domain used as the cache key.
+ * Strips protocol, port, and path. Lowercased. Returns empty string for
+ * input that does not resolve to a recognizable HTTP(S) domain — callers
+ * should treat empty string as "not trust-eligible" and fall through to T1.
+ */
+export function domainKeyFromUrl(input: string): string {
+  if (!input || typeof input !== 'string') return '';
+  const s = input.trim().toLowerCase();
+  if (!s) return '';
+  try {
+    // If it parses as a URL, use the hostname.
+    const u = new URL(s);
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return '';
+    return u.hostname;
+  } catch {
+    // Not a full URL — treat as bare host. Reject schemes / weird chars.
+    if (/[:/\s]/.test(s)) return '';
+    return s;
+  }
+}
+
+export class AgentTrustStore {
+  private states: Map<string, AgentTrustState> = new Map();
+  private storePath: string;
+  private persistInFlight: Promise<void> | null = null;
+
+  constructor(storePath?: string) {
+    this.storePath = storePath ?? path.join(os.homedir(), '.tandem', 'agent-trust.json');
+  }
+
+  /**
+   * Check whether the agent is currently approved to act on `domain`
+   * without a new user-approval modal. Returns true iff any of T2/T3/T4
+   * matches. Does not mutate state (expired windows are NOT removed here;
+   * reaped by housekeeping or on next mutation).
+   */
+  isApproved(agentId: string, domain: string): boolean {
+    if (!agentId || !domain) return false;
+    const state = this.states.get(agentId);
+    if (!state) return false;
+
+    const now = Date.now();
+
+    // T4 — global window
+    if (state.globalWindow && state.globalWindow.expiresAt > now) {
+      return true;
+    }
+
+    // T3 — persistent trusted domains
+    if (state.trustedDomains.has(domain)) {
+      return true;
+    }
+
+    // T2 — per-domain windows
+    const window = state.perDomainWindows.get(domain);
+    if (window && window.expiresAt > now) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /** Grant or extend a T2 window for the given agent+domain. */
+  grantDomainWindow(
+    agentId: string,
+    domain: string,
+    durationLabel: DomainWindowDuration,
+  ): void {
+    if (!agentId || !domain) return;
+    const state = this.ensureState(agentId);
+    const durationMs = DOMAIN_WINDOW_DURATIONS[durationLabel];
+    if (!durationMs) return;
+    state.perDomainWindows.set(domain, {
+      expiresAt: Date.now() + durationMs,
+      durationLabel,
+    });
+    log.info(`T2 grant: ${agentId} on ${domain} for ${durationLabel}`);
+  }
+
+  /** Grant a T3 trusted domain (persistent). Schedules a persist. */
+  grantTrustedDomain(agentId: string, domain: string): void {
+    if (!agentId || !domain) return;
+    const state = this.ensureState(agentId);
+    if (state.trustedDomains.has(domain)) return; // already granted
+    state.trustedDomains.add(domain);
+    log.info(`T3 grant: ${agentId} always trusts ${domain}`);
+    this.schedulePersist();
+  }
+
+  /** Grant T4 global window. `minutes` must be 30 or 60. */
+  grantGlobalWindow(agentId: string, minutes: AllowedGlobalWindowMinutes): void {
+    if (!agentId) return;
+    if (!ALLOWED_GLOBAL_WINDOW_MINUTES.includes(minutes)) return;
+    const state = this.ensureState(agentId);
+    state.globalWindow = {
+      expiresAt: Date.now() + minutes * 60 * 1000,
+      minutes,
+    };
+    log.info(`T4 grant: ${agentId} global window ${minutes}min`);
+  }
+
+  revokeDomainWindow(agentId: string, domain: string): void {
+    const state = this.states.get(agentId);
+    if (!state) return;
+    if (state.perDomainWindows.delete(domain)) {
+      log.info(`T2 revoke: ${agentId} on ${domain}`);
+    }
+  }
+
+  revokeTrustedDomain(agentId: string, domain: string): void {
+    const state = this.states.get(agentId);
+    if (!state) return;
+    if (state.trustedDomains.delete(domain)) {
+      log.info(`T3 revoke: ${agentId} on ${domain}`);
+      this.schedulePersist();
+    }
+  }
+
+  revokeGlobalWindow(agentId: string): void {
+    const state = this.states.get(agentId);
+    if (!state || !state.globalWindow) return;
+    state.globalWindow = null;
+    log.info(`T4 revoke: ${agentId} global window`);
+  }
+
+  revokeAll(agentId: string): void {
+    const state = this.states.get(agentId);
+    if (!state) return;
+    state.perDomainWindows.clear();
+    const hadTrusted = state.trustedDomains.size > 0;
+    state.trustedDomains.clear();
+    state.globalWindow = null;
+    log.info(`revokeAll: ${agentId}`);
+    if (hadTrusted) this.schedulePersist();
+  }
+
+  /**
+   * Rate-limit check for agent-initiated grant requests
+   * (tandem_request_trusted_domain / tandem_request_global_window).
+   * Records the timestamp on success so next call within cooldown fails.
+   */
+  canRequestGrant(agentId: string): { ok: true } | { ok: false; retryAfterMs: number } {
+    const state = this.ensureState(agentId);
+    const now = Date.now();
+    if (state.lastGrantRequestAt !== null) {
+      const elapsed = now - state.lastGrantRequestAt;
+      if (elapsed < GRANT_REQUEST_COOLDOWN_MS) {
+        return { ok: false, retryAfterMs: GRANT_REQUEST_COOLDOWN_MS - elapsed };
+      }
+    }
+    state.lastGrantRequestAt = now;
+    return { ok: true };
+  }
+
+  /** Snapshot for UI consumption (expired windows are filtered out). */
+  snapshot(agentId: string): AgentTrustSnapshot {
+    const state = this.states.get(agentId);
+    if (!state) {
+      return {
+        agentId,
+        trustedDomains: [],
+        perDomainWindows: [],
+        globalWindow: null,
+      };
+    }
+
+    const now = Date.now();
+
+    const perDomainWindows: AgentTrustSnapshot['perDomainWindows'] = [];
+    for (const [domain, win] of state.perDomainWindows) {
+      if (win.expiresAt <= now) continue;
+      perDomainWindows.push({
+        domain,
+        expiresAt: win.expiresAt,
+        remainingMs: win.expiresAt - now,
+        durationLabel: win.durationLabel,
+      });
+    }
+
+    let globalWindow: AgentTrustSnapshot['globalWindow'] = null;
+    if (state.globalWindow && state.globalWindow.expiresAt > now) {
+      globalWindow = {
+        expiresAt: state.globalWindow.expiresAt,
+        remainingMs: state.globalWindow.expiresAt - now,
+        minutes: state.globalWindow.minutes,
+      };
+    }
+
+    return {
+      agentId,
+      trustedDomains: Array.from(state.trustedDomains).sort(),
+      perDomainWindows: perDomainWindows.sort((a, b) => a.domain.localeCompare(b.domain)),
+      globalWindow,
+    };
+  }
+
+  /** List all agentIds we've tracked (for UI aggregation). */
+  listAgentIds(): string[] {
+    return Array.from(this.states.keys()).sort();
+  }
+
+  /**
+   * Load persisted state from disk. Malformed JSON or missing file →
+   * empty state, no crash. Should be called at boot.
+   */
+  async load(): Promise<void> {
+    try {
+      const raw = await fs.readFile(this.storePath, 'utf8');
+      const parsed = JSON.parse(raw) as PersistedState;
+      if (!parsed || parsed.version !== PERSIST_VERSION || !parsed.agents) {
+        log.warn(`agent-trust.json has unknown shape; starting empty`);
+        return;
+      }
+      for (const [agentId, entry] of Object.entries(parsed.agents)) {
+        const state = this.ensureState(agentId);
+        if (Array.isArray(entry?.trustedDomains)) {
+          for (const d of entry.trustedDomains) {
+            if (typeof d === 'string') state.trustedDomains.add(d);
+          }
+        }
+      }
+      log.info(`loaded agent-trust state for ${this.states.size} agent(s) from ${this.storePath}`);
+    } catch (e) {
+      const err = e as NodeJS.ErrnoException;
+      if (err.code === 'ENOENT') {
+        log.info(`no existing agent-trust.json; starting empty`);
+        return;
+      }
+      log.warn(`agent-trust load failed:`, err.message);
+    }
+  }
+
+  /**
+   * Persist the T3 state to disk. If a persist is already in flight, wait
+   * for it to finish and THEN write again — because new mutations may
+   * have arrived during the previous write and we must not lose them.
+   * Writes with mode 0o600 (user-only read/write).
+   */
+  async persist(): Promise<void> {
+    // Wait for any in-flight write to finish. Don't early-return — the
+    // in-flight write snapshotted state at its own start, so subsequent
+    // mutations still need to be flushed.
+    if (this.persistInFlight) {
+      try { await this.persistInFlight; } catch { /* logged inside */ }
+    }
+    this.persistInFlight = this.doPersist().finally(() => {
+      this.persistInFlight = null;
+    });
+    await this.persistInFlight;
+  }
+
+  private async doPersist(): Promise<void> {
+    const agents: PersistedState['agents'] = {};
+    for (const [agentId, state] of this.states) {
+      // Only persist agents that have T3 state worth saving.
+      if (state.trustedDomains.size === 0) continue;
+      agents[agentId] = { trustedDomains: Array.from(state.trustedDomains).sort() };
+    }
+    const body: PersistedState = { version: PERSIST_VERSION, agents };
+    const dir = path.dirname(this.storePath);
+    try {
+      await fs.mkdir(dir, { recursive: true });
+      // Write atomically via temp + rename so a crash mid-write can't truncate.
+      const tmp = this.storePath + '.tmp';
+      await fs.writeFile(tmp, JSON.stringify(body, null, 2), { mode: 0o600 });
+      await fs.rename(tmp, this.storePath);
+    } catch (e) {
+      log.warn(`agent-trust persist failed:`, (e as Error).message);
+    }
+  }
+
+  private schedulePersist(): void {
+    // Fire and forget; errors logged inside doPersist.
+    this.persist().catch(() => { /* already logged */ });
+  }
+
+  private ensureState(agentId: string): AgentTrustState {
+    let state = this.states.get(agentId);
+    if (!state) {
+      state = {
+        agentId,
+        trustedDomains: new Set(),
+        perDomainWindows: new Map(),
+        globalWindow: null,
+        lastGrantRequestAt: null,
+      };
+      this.states.set(agentId, state);
+    }
+    return state;
+  }
+}

--- a/src/security/tests/agent-trust.test.ts
+++ b/src/security/tests/agent-trust.test.ts
@@ -1,0 +1,352 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  AgentTrustStore,
+  GRANT_REQUEST_COOLDOWN_MS,
+  domainKeyFromUrl,
+} from '../agent-trust';
+
+function tmpStorePath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tandem-agent-trust-'));
+  return path.join(dir, 'agent-trust.json');
+}
+
+describe('domainKeyFromUrl', () => {
+  it('extracts hostname from full URLs', () => {
+    expect(domainKeyFromUrl('https://www.funda.nl/zoeken')).toBe('www.funda.nl');
+    expect(domainKeyFromUrl('http://example.com/path?x=1')).toBe('example.com');
+  });
+
+  it('accepts bare hostnames', () => {
+    expect(domainKeyFromUrl('funda.nl')).toBe('funda.nl');
+    expect(domainKeyFromUrl('LinkedIn.com')).toBe('linkedin.com');
+  });
+
+  it('rejects non-http schemes', () => {
+    expect(domainKeyFromUrl('file:///etc/passwd')).toBe('');
+    expect(domainKeyFromUrl('javascript:alert(1)')).toBe('');
+    expect(domainKeyFromUrl('data:text/html,x')).toBe('');
+  });
+
+  it('rejects weird/invalid input', () => {
+    expect(domainKeyFromUrl('')).toBe('');
+    expect(domainKeyFromUrl('   ')).toBe('');
+    expect(domainKeyFromUrl('not a url')).toBe('');
+    expect(domainKeyFromUrl('has:colon')).toBe('');
+  });
+});
+
+describe('AgentTrustStore', () => {
+  let storePath: string;
+  let store: AgentTrustStore;
+
+  beforeEach(() => {
+    storePath = tmpStorePath();
+    store = new AgentTrustStore(storePath);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    try { fs.rmSync(path.dirname(storePath), { recursive: true, force: true }); } catch { /* ignore */ }
+  });
+
+  describe('initial state', () => {
+    it('returns false for any isApproved query', () => {
+      expect(store.isApproved('claude', 'funda.nl')).toBe(false);
+      expect(store.isApproved('claude', '')).toBe(false);
+      expect(store.isApproved('', 'funda.nl')).toBe(false);
+    });
+
+    it('snapshot of unknown agent returns empty', () => {
+      const snap = store.snapshot('claude');
+      expect(snap).toEqual({
+        agentId: 'claude',
+        trustedDomains: [],
+        perDomainWindows: [],
+        globalWindow: null,
+      });
+    });
+
+    it('listAgentIds is empty', () => {
+      expect(store.listAgentIds()).toEqual([]);
+    });
+  });
+
+  describe('T2 — per-domain windows', () => {
+    it('grant makes isApproved return true within the window', () => {
+      store.grantDomainWindow('claude', 'funda.nl', '15min');
+      expect(store.isApproved('claude', 'funda.nl')).toBe(true);
+    });
+
+    it('does not leak to other domains', () => {
+      store.grantDomainWindow('claude', 'funda.nl', '15min');
+      expect(store.isApproved('claude', 'coolblue.nl')).toBe(false);
+    });
+
+    it('does not leak to other agents', () => {
+      store.grantDomainWindow('claude', 'funda.nl', '15min');
+      expect(store.isApproved('kees', 'funda.nl')).toBe(false);
+    });
+
+    it('expires after duration', () => {
+      vi.useFakeTimers();
+      store.grantDomainWindow('claude', 'funda.nl', '15min');
+      expect(store.isApproved('claude', 'funda.nl')).toBe(true);
+      vi.advanceTimersByTime(15 * 60 * 1000 + 1);
+      expect(store.isApproved('claude', 'funda.nl')).toBe(false);
+    });
+
+    it('revoke makes it immediately false', () => {
+      store.grantDomainWindow('claude', 'funda.nl', '1hour');
+      store.revokeDomainWindow('claude', 'funda.nl');
+      expect(store.isApproved('claude', 'funda.nl')).toBe(false);
+    });
+
+    it('expired windows are filtered from snapshot', () => {
+      vi.useFakeTimers();
+      store.grantDomainWindow('claude', 'funda.nl', '15min');
+      vi.advanceTimersByTime(16 * 60 * 1000);
+      const snap = store.snapshot('claude');
+      expect(snap.perDomainWindows).toHaveLength(0);
+    });
+  });
+
+  describe('T3 — trusted domains (persistent)', () => {
+    it('grant makes isApproved true indefinitely', () => {
+      store.grantTrustedDomain('claude', 'linkedin.com');
+      expect(store.isApproved('claude', 'linkedin.com')).toBe(true);
+    });
+
+    it('is per-agent', () => {
+      store.grantTrustedDomain('claude', 'linkedin.com');
+      expect(store.isApproved('kees', 'linkedin.com')).toBe(false);
+    });
+
+    it('revoke removes it', () => {
+      store.grantTrustedDomain('claude', 'linkedin.com');
+      store.revokeTrustedDomain('claude', 'linkedin.com');
+      expect(store.isApproved('claude', 'linkedin.com')).toBe(false);
+    });
+
+    it('persists across load cycle', async () => {
+      store.grantTrustedDomain('claude', 'linkedin.com');
+      store.grantTrustedDomain('claude', 'funda.nl');
+      await store.persist();
+
+      const fresh = new AgentTrustStore(storePath);
+      await fresh.load();
+      expect(fresh.isApproved('claude', 'linkedin.com')).toBe(true);
+      expect(fresh.isApproved('claude', 'funda.nl')).toBe(true);
+      expect(fresh.snapshot('claude').trustedDomains).toEqual(['funda.nl', 'linkedin.com']);
+    });
+
+    it('persists revocation', async () => {
+      store.grantTrustedDomain('claude', 'linkedin.com');
+      await store.persist();
+      store.revokeTrustedDomain('claude', 'linkedin.com');
+      await store.persist();
+
+      const fresh = new AgentTrustStore(storePath);
+      await fresh.load();
+      expect(fresh.isApproved('claude', 'linkedin.com')).toBe(false);
+    });
+
+    it('writes persist file with mode 0o600', async () => {
+      store.grantTrustedDomain('claude', 'linkedin.com');
+      await store.persist();
+      const stat = fs.statSync(storePath);
+      // mask off upper bits — on darwin stat may include other flags
+      expect(stat.mode & 0o777).toBe(0o600);
+    });
+
+    it('does not persist agents with empty trusted lists', async () => {
+      store.grantTrustedDomain('claude', 'linkedin.com');
+      store.grantTrustedDomain('kees', 'github.com');
+      await store.persist();
+      store.revokeTrustedDomain('kees', 'github.com');
+      await store.persist();
+
+      const raw = fs.readFileSync(storePath, 'utf8');
+      const parsed = JSON.parse(raw);
+      expect(Object.keys(parsed.agents)).toEqual(['claude']);
+    });
+  });
+
+  describe('T4 — global window', () => {
+    it('covers any domain while active', () => {
+      store.grantGlobalWindow('claude', 30);
+      expect(store.isApproved('claude', 'funda.nl')).toBe(true);
+      expect(store.isApproved('claude', 'literally-anything.example')).toBe(true);
+    });
+
+    it('is per-agent', () => {
+      store.grantGlobalWindow('claude', 30);
+      expect(store.isApproved('kees', 'funda.nl')).toBe(false);
+    });
+
+    it('only accepts 30 or 60 minutes', () => {
+      // @ts-expect-error -- testing runtime rejection of invalid input (15 not in allowed set)
+      store.grantGlobalWindow('claude', 15);
+      // @ts-expect-error -- testing runtime rejection of invalid input (120 not in allowed set)
+      store.grantGlobalWindow('claude', 120);
+      expect(store.isApproved('claude', 'funda.nl')).toBe(false);
+
+      store.grantGlobalWindow('claude', 60);
+      expect(store.isApproved('claude', 'funda.nl')).toBe(true);
+    });
+
+    it('expires after duration', () => {
+      vi.useFakeTimers();
+      store.grantGlobalWindow('claude', 30);
+      expect(store.isApproved('claude', 'any.com')).toBe(true);
+      vi.advanceTimersByTime(30 * 60 * 1000 + 1);
+      expect(store.isApproved('claude', 'any.com')).toBe(false);
+    });
+
+    it('revoke kills it', () => {
+      store.grantGlobalWindow('claude', 60);
+      store.revokeGlobalWindow('claude');
+      expect(store.isApproved('claude', 'any.com')).toBe(false);
+    });
+
+    it('expired global window is filtered from snapshot', () => {
+      vi.useFakeTimers();
+      store.grantGlobalWindow('claude', 30);
+      vi.advanceTimersByTime(31 * 60 * 1000);
+      expect(store.snapshot('claude').globalWindow).toBeNull();
+    });
+  });
+
+  describe('revokeAll', () => {
+    it('clears T2, T3, and T4 for the agent', async () => {
+      store.grantDomainWindow('claude', 'funda.nl', '15min');
+      store.grantTrustedDomain('claude', 'linkedin.com');
+      store.grantGlobalWindow('claude', 30);
+
+      store.revokeAll('claude');
+
+      expect(store.isApproved('claude', 'funda.nl')).toBe(false);
+      expect(store.isApproved('claude', 'linkedin.com')).toBe(false);
+      expect(store.isApproved('claude', 'any.com')).toBe(false);
+    });
+
+    it('does not affect other agents', () => {
+      store.grantTrustedDomain('claude', 'linkedin.com');
+      store.grantTrustedDomain('kees', 'github.com');
+
+      store.revokeAll('claude');
+
+      expect(store.isApproved('kees', 'github.com')).toBe(true);
+    });
+  });
+
+  describe('rate limiting (canRequestGrant)', () => {
+    it('first request succeeds', () => {
+      expect(store.canRequestGrant('claude')).toEqual({ ok: true });
+    });
+
+    it('second request within cooldown fails with retryAfterMs', () => {
+      store.canRequestGrant('claude');
+      const second = store.canRequestGrant('claude');
+      expect(second.ok).toBe(false);
+      if (!second.ok) {
+        expect(second.retryAfterMs).toBeGreaterThan(0);
+        expect(second.retryAfterMs).toBeLessThanOrEqual(GRANT_REQUEST_COOLDOWN_MS);
+      }
+    });
+
+    it('request after cooldown succeeds again', () => {
+      vi.useFakeTimers();
+      store.canRequestGrant('claude');
+      vi.advanceTimersByTime(GRANT_REQUEST_COOLDOWN_MS + 1);
+      expect(store.canRequestGrant('claude')).toEqual({ ok: true });
+    });
+
+    it('rate limit is per-agent', () => {
+      store.canRequestGrant('claude');
+      expect(store.canRequestGrant('kees')).toEqual({ ok: true });
+    });
+  });
+
+  describe('tier precedence', () => {
+    it('T4 covers a domain even without T3 or T2', () => {
+      store.grantGlobalWindow('claude', 30);
+      expect(store.isApproved('claude', 'somewhere.new')).toBe(true);
+    });
+
+    it('T3 covers a domain even without T2 or T4', () => {
+      store.grantTrustedDomain('claude', 'linkedin.com');
+      expect(store.isApproved('claude', 'linkedin.com')).toBe(true);
+    });
+
+    it('T2 works independent of T3/T4', () => {
+      store.grantDomainWindow('claude', 'funda.nl', '15min');
+      expect(store.isApproved('claude', 'funda.nl')).toBe(true);
+    });
+
+    it('revoking T3 does not remove T2 window for same domain', () => {
+      store.grantDomainWindow('claude', 'funda.nl', '15min');
+      store.grantTrustedDomain('claude', 'funda.nl');
+      store.revokeTrustedDomain('claude', 'funda.nl');
+      expect(store.isApproved('claude', 'funda.nl')).toBe(true); // T2 still active
+    });
+  });
+
+  describe('load — robustness', () => {
+    it('missing file leaves empty state without crashing', async () => {
+      const missingPath = path.join(os.tmpdir(), 'tandem-agent-trust-missing', 'no.json');
+      const fresh = new AgentTrustStore(missingPath);
+      await expect(fresh.load()).resolves.toBeUndefined();
+      expect(fresh.listAgentIds()).toEqual([]);
+    });
+
+    it('malformed JSON leaves empty state without crashing', async () => {
+      fs.mkdirSync(path.dirname(storePath), { recursive: true });
+      fs.writeFileSync(storePath, 'not valid json');
+      const fresh = new AgentTrustStore(storePath);
+      await expect(fresh.load()).resolves.toBeUndefined();
+      expect(fresh.listAgentIds()).toEqual([]);
+    });
+
+    it('wrong version leaves empty state', async () => {
+      fs.mkdirSync(path.dirname(storePath), { recursive: true });
+      fs.writeFileSync(storePath, JSON.stringify({ version: 99, agents: { claude: { trustedDomains: ['x.com'] } } }));
+      const fresh = new AgentTrustStore(storePath);
+      await fresh.load();
+      expect(fresh.isApproved('claude', 'x.com')).toBe(false);
+    });
+
+    it('strips non-string trustedDomains entries', async () => {
+      fs.mkdirSync(path.dirname(storePath), { recursive: true });
+      fs.writeFileSync(storePath, JSON.stringify({
+        version: 1,
+        agents: { claude: { trustedDomains: ['good.com', 42, null, 'other.com'] } },
+      }));
+      const fresh = new AgentTrustStore(storePath);
+      await fresh.load();
+      expect(fresh.snapshot('claude').trustedDomains).toEqual(['good.com', 'other.com']);
+    });
+  });
+
+  describe('snapshot shape', () => {
+    it('returns a sorted, non-expired view', () => {
+      vi.useFakeTimers();
+      store.grantTrustedDomain('claude', 'zeta.com');
+      store.grantTrustedDomain('claude', 'alpha.com');
+      store.grantDomainWindow('claude', 'beta.com', '15min');
+      store.grantGlobalWindow('claude', 30);
+
+      vi.advanceTimersByTime(1000);
+
+      const snap = store.snapshot('claude');
+      expect(snap.trustedDomains).toEqual(['alpha.com', 'zeta.com']);
+      expect(snap.perDomainWindows).toHaveLength(1);
+      expect(snap.perDomainWindows[0].domain).toBe('beta.com');
+      expect(snap.perDomainWindows[0].remainingMs).toBeGreaterThan(0);
+      expect(snap.globalWindow).not.toBeNull();
+      expect(snap.globalWindow?.minutes).toBe(30);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

The audit #34 fixes introduced per-call user-approval modals on \`/execute-js/confirm\`. Practical effect: when an agent builds an overlay on Funda or iterates a userscript on LinkedIn, the user sees a modal per call. Contradicts the trust-model (\"user + paired agents = team\") and makes the agent useless for iterative work.

At the same time there was an accidental asymmetry: \`/scripts/add\` and \`/styles/add\` required **no approval at all**, even though a persistent userscript is strictly more powerful than one-shot JS. Registering a script was a free bypass of the approval gate.

## Solution — four trust tiers

Each content-mutating endpoint checks the requesting agent's trust state before firing an approval modal:

| Tier | What | Source |
|---|---|---|
| **T1** Default | Modal every call | Current behavior, fallback |
| **T2** Per-domain window | Agent approved on one domain for 15min / 1h / session | User grants from approval modal (future UI) or direct POST |
| **T3** Trusted sites | Persistent allowlist per agent | User-managed or agent-requested w/ approval |
| **T4** Global window | Cross-site 30 or 60 min god-mode | Agent-requested only; rate-limited; auto-expires |

Check order: T4 → T3 → T2 → fall-through to T1 modal.

## Endpoints gated with the precheck

- \`POST /execute-js/confirm\` (MCP \`tandem_execute_js\`) — skips modal on T2/T3/T4 hit
- \`POST /scripts/add\` — **NEW gate** (fixes the asymmetry)
- \`POST /styles/add\` — **NEW gate** (fixes the asymmetry)

## NEVER skip modal (posture-weakening stays strict)

- \`POST /security/injection-override\`
- \`POST /security/guardian/mode\` (lowering)
- \`POST /security/domains/:domain/trust\` (raising)
- \`POST /security/outbound/whitelist\`

T3/T4 do NOT propagate to these. \`#34\` High-1 defenses intact.

## New surface

**HTTP routes** (\`src/api/routes/agent-trust.ts\`)
- \`GET /security/agent-trust\` — snapshot per agent
- \`POST /security/agent-trust/grant-{domain-window,trusted-domain,global-window}\` — user-initiated
- \`POST /security/agent-trust/revoke-{domain-window,trusted-domain,global-window,all}\`
- \`POST /security/agent-trust/request-{trusted-domain,global-window}\` — agent-initiated, user-approved

**MCP tools** (\`src/mcp/tools/agent-trust.ts\`)
- \`tandem_request_trusted_domain({ domain, rationale })\` — T3 agent request
- \`tandem_request_global_window({ minutes, rationale })\` — T4 (30|60 only)
- \`tandem_list_trust\` — snapshot for agent introspection

**Tool count 250 → 253.** All docs auto-updated via \`check-consistency\`.

## Persistence

\`AgentTrustStore\` (\`src/security/agent-trust.ts\`):
- \`trustedDomains: Set<string>\` (T3) → \`~/.tandem/agent-trust.json\` mode 0o600, atomic temp+rename
- \`perDomainWindows\` (T2) and \`globalWindow\` (T4) → in-memory, session-scoped
- \`lastGrantRequestAt\` → rate-limit cursor (1 request per 5 min per agent)

Per-agent isolation (Claude's trust ≠ Kees' trust). Malformed JSON → empty state, no crash.

## Tests

- **41 new unit tests** for \`AgentTrustStore\` — passthrough, T2/T3/T4 grants, expiry, revoke, persistence roundtrip, rate limiting, malformed JSON, per-agent isolation, tier precedence
- **Full suite**: 2803 passed, 39 skipped (no regressions)
- \`check-consistency\` green at 253 tools

## What's NOT in this PR (follow-up)

The shell UI extensions — extended approval modal with tier-choice radios (for T2 user-from-modal grants) and Settings → Connected Agents → Trust panel (user-direct T3 management). Deferred to keep this PR reviewable. Without them:
- T3/T4 work fully via MCP tools ✓
- T2 requires a direct HTTP POST (future UI will surface it) — or the user can use \`tandem_request_trusted_domain\` for the same site if they want persistent

The server-side gate + store are the dependency; the UI is purely additive.

## Verify

- [x] \`npm run verify\` green (2803 tests, check-consistency 253 tools)
- [x] \`grep \"injectionWarnings\" src/mcp\` unchanged (still works, trust tier doesn't affect scanner)
- [ ] Post-merge live test:
  - Request trusted-domain for funda.nl → modal → approve → iterate execute_js without further modals
  - Request global-window 30min → modal → approve → run scripts on any site for 30 min → expires, modal returns
  - Revoke via \`tandem_list_trust\` introspection → confirm state

## Context

- Design doc: \`docs/superpowers/agent-trust-tiers-design.md\` (cross-compacting-proof)
- Sequel to the agent-experience PRs #174, #175, #176, #177, #178 (punch-list from 2026-04-18 dogfooding)
- Addresses the UX-tension that emerged after audit #34 fixes (PRs #159–#168) — without weakening any of them