### PR TITLE
fix(stealth): inject Google Chrome into sec-ch-ua to pass Cloudflare

### DIFF
--- a/src/devtools/manager.ts
+++ b/src/devtools/manager.ts
@@ -380,11 +380,13 @@ export class DevToolsManager {
     try {
       wc.debugger.attach('1.3');
     } catch (e) {
-      // Already attached (DevTools open) or other error
+      // Already attached (DevTools open, or stealth pre-attach) or other error.
+      // Note: Electron 40 returns "Debugger is already attached to the target"
+      // (lowercase 'already'), not "Already attached" — use case-insensitive check.
       const msg = e instanceof Error ? e.message : String(e);
-      if (msg.includes('Already attached')) {
-        // DevTools is open — we can still try to use it
-        log.warn('⚠️ DevTools debugger already attached (DevTools open?) — sharing session');
+      if (msg.toLowerCase().includes('already attached')) {
+        // DevTools is open or another component attached first — share the session.
+        log.info('⚠️ CDP debugger already attached — sharing session');
       } else {
         log.warn('❌ CDP attach failed:', msg);
         return null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -305,6 +305,39 @@ async function createWindow(): Promise<BrowserWindow> {
     );
 
     if (contents.getType() === 'webview') {
+      // === CDP-based OOPIF stealth injection ===
+      // session.setPreloads() only executes in the WebContents *main* frame.
+      // Cross-origin subframes (OOPIFs) — e.g. Cloudflare's Turnstile iframe at
+      // challenges.cloudflare.com — run in separate renderer processes and never
+      // receive that preload. CDP's Page.addScriptToEvaluateOnNewDocument runs
+      // BEFORE any scripts in EVERY frame upon creation, including OOPIFs.
+      // This is the same mechanism Chromium uses internally for content scripts.
+      // We eagerly attach here (before the first navigation) so the registration
+      // is in place when the renderer processes are later spawned.
+      if (!isSidebarWebview) {
+        (async () => {
+          if (contents.isDestroyed()) return;
+          try {
+            if (!contents.debugger.isAttached()) {
+              contents.debugger.attach('1.3');
+            }
+            await contents.debugger.sendCommand('Page.addScriptToEvaluateOnNewDocument', {
+              source: stealthScript,
+            });
+            log.info('🛡️ CDP OOPIF stealth injection registered');
+          } catch (e) {
+            // DevToolsManager may have already attached — try using its session
+            if (!contents.isDestroyed() && contents.debugger.isAttached()) {
+              contents.debugger.sendCommand('Page.addScriptToEvaluateOnNewDocument', {
+                source: stealthScript,
+              }).catch(e2 => log.warn('CDP stealth shared-session failed:', e2 instanceof Error ? e2.message : e2));
+            } else {
+              log.warn('CDP OOPIF stealth attach failed:', e instanceof Error ? e.message : e);
+            }
+          }
+        })();
+      }
+
       contents.on('dom-ready', () => {
         // Skip stealth injection on sites that detect and block stealth patches
         const url = contents.getURL();
@@ -319,12 +352,10 @@ async function createWindow(): Promise<BrowserWindow> {
         }
       });
 
-      // Inject stealth into cross-origin subframes (e.g. Cloudflare Turnstile iframes).
-      // executeJavaScript() on the main webContents only reaches the top-level frame.
-      // Cross-origin iframes run in their own renderer context and see Electron's raw
-      // navigator.userAgentData (missing "Google Chrome") — a direct bot signal.
-      // did-frame-navigate fires after a subframe's document is committed and ready,
-      // at which point we can patch the frame's main world before challenge scripts read it.
+      // did-frame-navigate: late-injection fallback for same-origin subframes.
+      // For cross-origin OOPIFs this fires too late (after the frame's inline
+      // scripts have already run), but the CDP registration above covers those.
+      // Kept here as a safety net for edge cases the CDP path misses.
       contents.on('did-frame-navigate', (
         _event, url, _httpCode, _httpText, isMainFrame
       ) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -319,7 +319,7 @@ async function createWindow(): Promise<BrowserWindow> {
       // We eagerly attach here (before the first navigation) so the registration
       // is in place when the renderer processes are later spawned.
       if (!isSidebarWebview) {
-        (async () => {
+        void (async () => {
           if (contents.isDestroyed()) return;
           try {
             if (!contents.debugger.isAttached()) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -319,6 +319,33 @@ async function createWindow(): Promise<BrowserWindow> {
         }
       });
 
+      // Inject stealth into cross-origin subframes (e.g. Cloudflare Turnstile iframes).
+      // executeJavaScript() on the main webContents only reaches the top-level frame.
+      // Cross-origin iframes run in their own renderer context and see Electron's raw
+      // navigator.userAgentData (missing "Google Chrome") — a direct bot signal.
+      // did-frame-navigate fires after a subframe's document is committed and ready,
+      // at which point we can patch the frame's main world before challenge scripts read it.
+      contents.on('did-frame-navigate', (
+        _event, url, _httpCode, _httpText, isMainFrame
+      ) => {
+        if (isMainFrame) return; // main frame handled by dom-ready above
+        if (!url || url.startsWith('about:') || url.startsWith('data:')) return;
+        if (isGoogleAuthUrl(url)) return; // never touch Google auth iframes
+
+        // Walk the frame tree and inject into every non-Google subframe
+        const injectFrame = (frame: { url: string; frames: typeof frame[]; executeJavaScript: (s: string) => Promise<unknown> }) => {
+          const frameUrl = frame.url || '';
+          if (!isGoogleAuthUrl(frameUrl)) {
+            frame.executeJavaScript(stealthScript)
+              .catch(() => { /* frame may have navigated away or be restricted */ });
+          }
+          for (const child of frame.frames) injectFrame(child);
+        };
+        if (contents.mainFrame) {
+          for (const child of contents.mainFrame.frames) injectFrame(child);
+        }
+      });
+
       // Webview keystroke rhythm capture for the BehaviorCompiler.
       // PRIVACY FLOOR: we ONLY look at input.type to decide this is a
       // character keydown, and we NEVER read input.key, input.code, the

--- a/src/main.ts
+++ b/src/main.ts
@@ -294,6 +294,10 @@ async function createWindow(): Promise<BrowserWindow> {
   // Inject stealth script into all webviews via session preload
   const stealthSeed = stealth.getPartitionSeed();
   const stealthScript = StealthManager.getStealthScript(stealthSeed);
+  // Minimal early script for CDP OOPIF injection — omits canvas/audio/timing patches
+  // that crash Cloudflare Turnstile's OOPIF (ctx.getImageData() triggers GPU IPC in
+  // a sandboxed cross-origin frame, causing V8 crash in challenges.cloudflare.com)
+  const earlyScript = StealthManager.getEarlyScript();
 
   // Apply stealth patches to every webview's webContents on creation
   app.on('web-contents-created', (_event, contents) => {
@@ -321,15 +325,19 @@ async function createWindow(): Promise<BrowserWindow> {
             if (!contents.debugger.isAttached()) {
               contents.debugger.attach('1.3');
             }
+            // Use the minimal early script (no canvas/audio/timing noise) so it is
+            // safe inside Cloudflare's sandboxed Turnstile OOPIF — the full stealth
+            // script's ctx.getImageData() call triggers GPU readback IPC that causes
+            // a V8 crash inside challenges.cloudflare.com renderer.
             await contents.debugger.sendCommand('Page.addScriptToEvaluateOnNewDocument', {
-              source: stealthScript,
+              source: earlyScript,
             });
-            log.info('🛡️ CDP OOPIF stealth injection registered');
+            log.info('🛡️ CDP OOPIF early stealth injection registered');
           } catch (e) {
             // DevToolsManager may have already attached — try using its session
             if (!contents.isDestroyed() && contents.debugger.isAttached()) {
               contents.debugger.sendCommand('Page.addScriptToEvaluateOnNewDocument', {
-                source: stealthScript,
+                source: earlyScript,
               }).catch(e2 => log.warn('CDP stealth shared-session failed:', e2 instanceof Error ? e2.message : e2));
             } else {
               log.warn('CDP OOPIF stealth attach failed:', e instanceof Error ? e.message : e);

--- a/src/stealth/manager.ts
+++ b/src/stealth/manager.ts
@@ -147,11 +147,51 @@ export class StealthManager {
           headers['Accept-Language'] = 'nl-BE,nl;q=0.9,en-US;q=0.8,en;q=0.7';
         }
 
-        // Ensure Sec-CH-UA matches our UA (Google checks these for login)
-        headers['Sec-CH-UA'] = `"Google Chrome";v="${this.chromeMajor}", "Chromium";v="${this.chromeMajor}", "Not_A Brand";v="24"`;
-        headers['Sec-CH-UA-Mobile'] = '?0';
-        headers['Sec-CH-UA-Platform'] = '"macOS"';
-        headers['Sec-CH-UA-Full-Version-List'] = `"Google Chrome";v="${process.versions.chrome}", "Chromium";v="${process.versions.chrome}", "Not_A Brand";v="24.0.0.0"`;
+        // === Sec-CH-UA client hints — inject "Google Chrome" brand ===
+        // Chromium omits "Google Chrome" from its auto-generated sec-ch-ua,
+        // sending only "Chromium" + a rotating GREASE token. Cloudflare (and
+        // other bot-detection systems) detect the missing brand as Electron.
+        //
+        // Key-casing bug: Chromium uses lowercase HTTP/2-style keys
+        // ('sec-ch-ua'). Setting 'Sec-CH-UA' (capitalized) does NOT overwrite
+        // the original — both coexist as separate object keys.  We must
+        // enumerate all keys case-insensitively, capture the value, delete
+        // the originals, then re-set with the correct (lowercase) key name.
+
+        // Capture Chromium's natural values — preserves the correct GREASE token
+        const getHdr = (lower: string): string => {
+          for (const k of Object.keys(headers)) {
+            if (k.toLowerCase() === lower) return String(headers[k]);
+          }
+          return '';
+        };
+        const chromiumBrands   = getHdr('sec-ch-ua');
+        const chromiumFullList = getHdr('sec-ch-ua-full-version-list');
+
+        // Delete all sec-ch-ua* headers regardless of casing
+        for (const k of Object.keys(headers)) {
+          if (k.toLowerCase().startsWith('sec-ch-ua')) delete headers[k];
+        }
+
+        // Inject "Google Chrome" brand while preserving the natural GREASE token
+        const withGoogleChrome = (brands: string, version: string): string => {
+          if (brands.includes('Google Chrome')) return brands;
+          if (!brands) {
+            // Chromium didn't send this header — build minimal correct list
+            return `"Chromium";v="${version}", "Google Chrome";v="${version}", "Not(A:Brand";v="8"`;
+          }
+          return `${brands}, "Google Chrome";v="${version}"`;
+        };
+
+        headers['sec-ch-ua']          = withGoogleChrome(chromiumBrands, this.chromeMajor);
+        headers['sec-ch-ua-mobile']   = '?0';
+        headers['sec-ch-ua-platform'] = '"macOS"';
+        // Only send full-version-list if Chromium already included it;
+        // it's a high-entropy hint that browsers normally send only on request.
+        if (chromiumFullList) {
+          headers['sec-ch-ua-full-version-list'] =
+            withGoogleChrome(chromiumFullList, process.versions.chrome);
+        }
 
         return headers;
       }

--- a/src/stealth/manager.ts
+++ b/src/stealth/manager.ts
@@ -253,6 +253,114 @@ export class StealthManager {
   }
 
   /**
+   * Minimal "early" stealth script — safe to inject into cross-origin OOPIFs
+   * (e.g. Cloudflare Turnstile) via CDP Page.addScriptToEvaluateOnNewDocument.
+   *
+   * Deliberately omits canvas/audio/timing patches that:
+   *   a) call ctx.getImageData() → GPU readback IPC → V8 crash inside sandboxed OOPIF
+   *   b) implement Firefox-like precision reduction that Cloudflare detects as non-Chrome
+   *
+   * Uses its own idempotency guard (Symbol '__tandem_early_v1') so it doesn't
+   * collide with the full stealth script that runs at dom-ready on main frames.
+   */
+  static getEarlyScript(chromeVersion: string = process.versions.chrome): string {
+    const chromeMajor = chromeVersion.split('.')[0];
+    return `
+(function() {
+  var _sym = Symbol.for('__tandem_early_v1');
+  if (window[_sym]) return;
+  Object.defineProperty(window, _sym, { value: 1, configurable: false, writable: false, enumerable: false });
+
+  // 1. Hide webdriver flag
+  try { Object.defineProperty(navigator, 'webdriver', { get: function() { return false; }, configurable: true }); } catch(e) {}
+
+  // 2. navigator.userAgentData — inject "Google Chrome" brand (the critical Cloudflare check)
+  try {
+    var _chromeMajor = '${chromeMajor}';
+    var _chromeVersion = '${chromeVersion}';
+    Object.defineProperty(navigator, 'userAgentData', {
+      get: function() {
+        return {
+          brands: [
+            { brand: 'Google Chrome',  version: _chromeMajor },
+            { brand: 'Chromium',       version: _chromeMajor },
+            { brand: 'Not(A:Brand',    version: '8' },
+          ],
+          mobile: false,
+          platform: 'macOS',
+          getHighEntropyValues: function(hints) {
+            return Promise.resolve({
+              brands: [
+                { brand: 'Google Chrome',  version: _chromeMajor },
+                { brand: 'Chromium',       version: _chromeMajor },
+                { brand: 'Not(A:Brand',    version: '8' },
+              ],
+              mobile: false,
+              platform: 'macOS',
+              platformVersion: '15.3.0',
+              architecture: 'arm',
+              bitness: '64',
+              model: '',
+              uaFullVersion: _chromeVersion,
+              fullVersionList: [
+                { brand: 'Google Chrome',  version: _chromeVersion },
+                { brand: 'Chromium',       version: _chromeVersion },
+                { brand: 'Not(A:Brand',    version: '8.0.0.0' },
+              ],
+            });
+          },
+          toJSON: function() {
+            return { brands: this.brands, mobile: this.mobile, platform: this.platform };
+          },
+        };
+      },
+      configurable: true,
+    });
+  } catch(e) {}
+
+  // 3. Minimal window.chrome stub (Cloudflare checks chrome.runtime existence)
+  try {
+    if (!window.chrome) window.chrome = {};
+    if (!window.chrome.runtime) {
+      window.chrome.runtime = {
+        connect: function() { return { onDisconnect: { addListener: function() {} }, onMessage: { addListener: function() {} }, postMessage: function() {}, disconnect: function() {} }; },
+        sendMessage: function() {},
+        id: undefined,
+      };
+    }
+  } catch(e) {}
+
+  // 4. Remove Electron giveaways from window (safe — no GPU IPC involved)
+  try { delete window.process; } catch(e) {}
+  try { delete window.require; } catch(e) {}
+  try { Object.defineProperty(window, 'process', { get: function() { return undefined; }, configurable: true }); } catch(e) {}
+
+  // 5. Realistic navigator.plugins (Cloudflare may check for empty plugins list)
+  try {
+    Object.defineProperty(navigator, 'plugins', {
+      get: function() {
+        return [
+          { name: 'Chrome PDF Plugin', filename: 'internal-pdf-viewer' },
+          { name: 'Chrome PDF Viewer', filename: 'mhjfbmdgcfjbbpaeojofohoefgiehjai' },
+          { name: 'Native Client',     filename: 'internal-nacl-plugin' },
+        ];
+      },
+      configurable: true,
+    });
+  } catch(e) {}
+
+  // 6. Realistic languages
+  try {
+    Object.defineProperty(navigator, 'languages', {
+      get: function() { return ['nl-BE', 'nl', 'en-US', 'en']; },
+      configurable: true,
+    });
+  } catch(e) {}
+})();
+    `;
+  }
+
+  /**
    * JavaScript to inject into pages to hide automation indicators.
    * Phase 5: includes canvas, WebGL, audio, font, and timing fingerprint protection.
    * @param seed - Deterministic seed for consistent noise per session

--- a/src/stealth/manager.ts
+++ b/src/stealth/manager.ts
@@ -137,7 +137,9 @@ export class StealthManager {
 
     const preloadPath = path.join(tandemDir(), 'stealth-preload.js');
     await fs.promises.writeFile(preloadPath, preloadContent, { mode: 0o600 });
-    this.session.setPreloads([preloadPath]);
+    // Use the new registerPreloadScript API (setPreloads deprecated in Electron 40).
+    // type:'frame' registers this for every frame including cross-origin subframes.
+    this.session.registerPreloadScript({ filePath: preloadPath, type: 'frame' });
     log.info('🛡️ Stealth preload registered for all frames (including OOPIF)');
   }
 

--- a/src/stealth/manager.ts
+++ b/src/stealth/manager.ts
@@ -98,7 +98,47 @@ export class StealthManager {
     // Google auth is excluded via the onBeforeSendHeaders handler in registerWith()
     this.session.setUserAgent(this.USER_AGENT);
 
+    // Write a session-level preload that injects stealth patches into EVERY
+    // renderer frame — including cross-origin out-of-process iframes (OOPIF)
+    // such as Cloudflare's Turnstile challenge iframe.  executeJavaScript() on
+    // the top-level webContents only reaches the main frame; session.setPreloads()
+    // runs the script in each renderer process (including OOPIF) BEFORE any page
+    // scripts, so navigator.userAgentData and other APIs are patched early enough.
+    await this.writeAndRegisterPreload();
+
     log.info('🛡️ Stealth patches applied (advanced fingerprint protection active)');
+  }
+
+  /**
+   * Writes a preload script to disk and registers it with the session.
+   * The preload uses webFrame.executeJavaScriptInIsolatedWorld(0, ...) to
+   * run the stealth patches in world 0 (the main/page world) before any page
+   * scripts, for every frame including cross-origin iframes.
+   */
+  private async writeAndRegisterPreload(): Promise<void> {
+    const stealthScript = StealthManager.getStealthScript(this.partitionSeed);
+
+    // The preload runs in Electron's isolated renderer world.
+    // executeJavaScriptInIsolatedWorld(0, ...) injects into world 0 = main page world,
+    // running BEFORE the frame's own scripts because the preload executes first.
+    // We skip file:// (Tandem shell UI) and Google auth frames.
+    const preloadContent = [
+      `'use strict';`,
+      `try {`,
+      `  var _url = (typeof location !== 'undefined' && location.href) || '';`,
+      `  var _skip = _url.startsWith('file://') ||`,
+      `    /accounts\\.google\\.com|accounts-google\\.com/i.test(_url);`,
+      `  if (!_skip) {`,
+      `    var _wf = require('electron').webFrame;`,
+      `    _wf.executeJavaScriptInIsolatedWorld(0, [{ code: ${JSON.stringify(stealthScript)}, url: 'tandem://stealth' }]);`,
+      `  }`,
+      `} catch(e) { /* preload injection failed — ignored */ }`,
+    ].join('\n');
+
+    const preloadPath = path.join(tandemDir(), 'stealth-preload.js');
+    await fs.promises.writeFile(preloadPath, preloadContent, { mode: 0o600 });
+    this.session.setPreloads([preloadPath]);
+    log.info('🛡️ Stealth preload registered for all frames (including OOPIF)');
   }
 
   /** Register header modification as a dispatcher consumer */
@@ -219,7 +259,12 @@ export class StealthManager {
     const chromeMajor = chromeVersion.split('.')[0];
     return `
       // ═══ All stealth patches in one IIFE — no globals leaked to window ═══
+      // Idempotency guard: both the session preload and the dom-ready injection
+      // run this script. The Symbol key is invisible to page JS (not enumerable).
       (function() {
+        var _appliedSym = Symbol.for('__tandem_stealth_v1');
+        if (window[_appliedSym]) return;
+        Object.defineProperty(window, _appliedSym, { value: 1, configurable: false, writable: false, enumerable: false });
         // Seeded PRNG (mulberry32) — consistent noise per session
         var __seed = 0;
         var seedStr = '${seed}';

--- a/src/stealth/manager.ts
+++ b/src/stealth/manager.ts
@@ -143,8 +143,15 @@ export class StealthManager {
         }
 
         // Ensure realistic Accept-Language
-        if (!headers['Accept-Language']) {
-          headers['Accept-Language'] = 'nl-BE,nl;q=0.9,en-US;q=0.8,en;q=0.7';
+        // Key-casing note: Chromium sends 'accept-language' (lowercase HTTP/2).
+        // Checking headers['Accept-Language'] always returns undefined, so the
+        // condition was always true but set a capitalized key that coexists with
+        // the original. Use case-insensitive lookup, then set with lowercase key.
+        const hasAcceptLanguage = Object.keys(headers).some(
+          k => k.toLowerCase() === 'accept-language'
+        );
+        if (!hasAcceptLanguage) {
+          headers['accept-language'] = 'nl-BE,nl;q=0.9,en-US;q=0.8,en;q=0.7';
         }
 
         // === Sec-CH-UA client hints — inject "Google Chrome" brand ===
@@ -463,24 +470,30 @@ export class StealthManager {
       Object.defineProperty(window, 'process', { get: () => undefined, configurable: true });
 
       // navigator.userAgentData — ALWAYS override to match real Chrome
-      // Electron exposes its own brands (Chromium/130, Not?A_Brand/99) which Google detects
+      // Electron exposes its own brands which bot-detection systems detect.
+      // The GREASE brand MUST match what Chromium sends in the sec-ch-ua HTTP
+      // header — Cloudflare cross-checks them.  Chromium 120+ uses "Not(A:Brand"
+      // version "8".  The header handler (registerWith) preserves this naturally.
       {
         var __chromeMajor = '${chromeMajor}';
         var __chromeVersion = '${chromeVersion}';
+        // Chrome 120+ GREASE brand — must stay in sync with the sec-ch-ua header
+        var __greaseBrand   = 'Not(A:Brand';
+        var __greaseVersion = '8';
         Object.defineProperty(navigator, 'userAgentData', {
           get: () => ({
             brands: [
-              { brand: 'Google Chrome', version: __chromeMajor },
-              { brand: 'Chromium', version: __chromeMajor },
-              { brand: 'Not_A Brand', version: '24' },
+              { brand: 'Google Chrome',  version: __chromeMajor },
+              { brand: 'Chromium',       version: __chromeMajor },
+              { brand: __greaseBrand,    version: __greaseVersion },
             ],
             mobile: false,
             platform: 'macOS',
             getHighEntropyValues: (hints) => Promise.resolve({
               brands: [
-                { brand: 'Google Chrome', version: __chromeMajor },
-                { brand: 'Chromium', version: __chromeMajor },
-                { brand: 'Not_A Brand', version: '24' },
+                { brand: 'Google Chrome',  version: __chromeMajor },
+                { brand: 'Chromium',       version: __chromeMajor },
+                { brand: __greaseBrand,    version: __greaseVersion },
               ],
               mobile: false,
               platform: 'macOS',
@@ -490,9 +503,9 @@ export class StealthManager {
               model: '',
               uaFullVersion: __chromeVersion,
               fullVersionList: [
-                { brand: 'Google Chrome', version: __chromeVersion },
-                { brand: 'Chromium', version: __chromeVersion },
-                { brand: 'Not_A Brand', version: '24.0.0.0' },
+                { brand: 'Google Chrome',  version: __chromeVersion },
+                { brand: 'Chromium',       version: __chromeVersion },
+                { brand: __greaseBrand,    version: __greaseVersion + '.0.0.0' },
               ],
             }),
             toJSON: function() {

--- a/src/stealth/tests/manager.test.ts
+++ b/src/stealth/tests/manager.test.ts
@@ -461,3 +461,81 @@ describe('getStealthScript() — userAgentData GREASE brand consistency', () => 
     expect(chromeCount).toBeGreaterThanOrEqual(3);
   });
 });
+
+// ─── getEarlyScript() ─────────────────────────────────────────────────────────
+// This is the minimal script injected via CDP Page.addScriptToEvaluateOnNewDocument
+// into EVERY frame including cross-origin OOPIFs (e.g. Cloudflare Turnstile).
+// It must NOT contain canvas/audio/timing patches that crash sandboxed iframes.
+
+describe('getEarlyScript() — minimal OOPIF-safe stealth', () => {
+  it('uses its own idempotency guard distinct from the full stealth script', () => {
+    const script = StealthManager.getEarlyScript();
+    expect(script).toContain('__tandem_early_v1');
+    expect(script).not.toContain('__tandem_stealth_v1');
+  });
+
+  it('includes "Google Chrome" in userAgentData brands', () => {
+    const script = StealthManager.getEarlyScript();
+    expect(script).toContain('Google Chrome');
+    // Must appear in brands array AND fullVersionList
+    const chromeCount = (script.match(/Google Chrome/g) || []).length;
+    expect(chromeCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it('uses "Not(A:Brand" GREASE token (Chrome 120+)', () => {
+    const script = StealthManager.getEarlyScript();
+    expect(script).toContain('Not(A:Brand');
+    expect(script).not.toContain('Not_A Brand');
+  });
+
+  it('patches navigator.webdriver', () => {
+    const script = StealthManager.getEarlyScript();
+    expect(script).toContain('webdriver');
+    expect(script).toContain('false');
+  });
+
+  it('includes a minimal window.chrome.runtime stub', () => {
+    const script = StealthManager.getEarlyScript();
+    expect(script).toContain('window.chrome');
+    expect(script).toContain('chrome.runtime');
+  });
+
+  it('does NOT contain canvas fingerprint noise (getImageData crash risk in OOPIF)', () => {
+    const script = StealthManager.getEarlyScript();
+    expect(script).not.toContain('getImageData');
+    expect(script).not.toContain('toDataURL');
+    expect(script).not.toContain('toBlob');
+    expect(script).not.toContain('HTMLCanvasElement');
+  });
+
+  it('does NOT contain audio fingerprint noise (not needed for Cloudflare Turnstile)', () => {
+    const script = StealthManager.getEarlyScript();
+    expect(script).not.toContain('AudioContext');
+    expect(script).not.toContain('OfflineAudioContext');
+    expect(script).not.toContain('AnalyserNode');
+  });
+
+  it('does NOT contain timing precision reduction (Firefox-like 100μs is a Cloudflare non-Chrome signal)', () => {
+    const script = StealthManager.getEarlyScript();
+    expect(script).not.toContain('performance.now');
+    expect(script).not.toContain('origPerfNow');
+  });
+
+  it('does NOT contain WebGL parameter patching (not needed in Turnstile OOPIF)', () => {
+    const script = StealthManager.getEarlyScript();
+    expect(script).not.toContain('WebGLRenderingContext');
+    expect(script).not.toContain('WebGL2RenderingContext');
+  });
+
+  it('accepts an optional chromeVersion parameter', () => {
+    const script = StealthManager.getEarlyScript('130.0.6723.116');
+    expect(script).toContain('130.0.6723.116');
+    expect(script).toContain('130'); // chromeMajor
+  });
+
+  it('uses process.versions.chrome by default', () => {
+    const script = StealthManager.getEarlyScript();
+    // The test environment sets chrome to 132.0.6834.160 in beforeAll
+    expect(script).toContain(process.versions.chrome);
+  });
+});

--- a/src/stealth/tests/manager.test.ts
+++ b/src/stealth/tests/manager.test.ts
@@ -218,6 +218,195 @@ describe('StealthManager — per-install seed', () => {
   });
 });
 
+// ─── Helpers for registerWith() tests ────────────────────────────────────────
+
+type HeaderHandler = (
+  details: { url: string },
+  headers: Record<string, string>
+) => Record<string, string>;
+
+/** Creates a minimal mock RequestDispatcher that captures the last registered
+ *  BeforeSendHeaders handler so tests can invoke it directly. */
+function makeDispatcherMock() {
+  let capturedHandler: HeaderHandler | null = null;
+  return {
+    registerBeforeSendHeaders: vi.fn(({ handler }: { handler: HeaderHandler }) => {
+      capturedHandler = handler;
+    }),
+    getHandler: (): HeaderHandler => {
+      if (!capturedHandler) throw new Error('handler not registered');
+      return capturedHandler;
+    },
+  };
+}
+
+/** Sets up a StealthManager backed by a deterministic fake install secret. */
+function makeManagerWithFixedSecret(): StealthManager {
+  vi.mocked(fs.existsSync).mockReturnValue(true);
+  vi.mocked(fs.readFileSync).mockReturnValue(
+    JSON.stringify({ stealthInstallSecret: 'a'.repeat(64) })
+  );
+  return new StealthManager(makeMockSession(), 'persist:tandem');
+}
+
+// ─── registerWith() — Sec-CH-UA header patching ───────────────────────────────
+
+describe('registerWith() — Sec-CH-UA client-hints injection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('adds "Google Chrome" brand to Chromium-generated lowercase sec-ch-ua', () => {
+    const mgr  = makeManagerWithFixedSecret();
+    const disp = makeDispatcherMock();
+    mgr.registerWith(disp as never);
+    const handle = disp.getHandler();
+
+    const result = handle(
+      { url: 'https://example.com' },
+      { 'sec-ch-ua': '"Not(A:Brand";v="8", "Chromium";v="132"' }
+    );
+
+    expect(result['sec-ch-ua']).toContain('Google Chrome');
+  });
+
+  it('preserves Chromium\'s natural GREASE token (does not replace "Not(A:Brand")', () => {
+    const mgr  = makeManagerWithFixedSecret();
+    const disp = makeDispatcherMock();
+    mgr.registerWith(disp as never);
+    const handle = disp.getHandler();
+
+    const result = handle(
+      { url: 'https://example.com' },
+      { 'sec-ch-ua': '"Not(A:Brand";v="8", "Chromium";v="132"' }
+    );
+
+    expect(result['sec-ch-ua']).toContain('Not(A:Brand');
+  });
+
+  it('emits exactly one sec-ch-ua key (no casing duplicates)', () => {
+    const mgr  = makeManagerWithFixedSecret();
+    const disp = makeDispatcherMock();
+    mgr.registerWith(disp as never);
+    const handle = disp.getHandler();
+
+    const result = handle(
+      { url: 'https://cloudflare.com' },
+      { 'sec-ch-ua': '"Not(A:Brand";v="8", "Chromium";v="132"' }
+    );
+
+    const allChUaKeys = Object.keys(result).filter(k => k.toLowerCase() === 'sec-ch-ua');
+    expect(allChUaKeys).toHaveLength(1);
+    expect(allChUaKeys[0]).toBe('sec-ch-ua');
+  });
+
+  it('drops any pre-existing capitalized Sec-CH-UA duplicate', () => {
+    // The old code set headers['Sec-CH-UA'] without removing the lowercase
+    // original.  Both would reach the network — Cloudflare reads the lowercase
+    // one (no "Google Chrome") and treats the request as bot traffic.
+    const mgr  = makeManagerWithFixedSecret();
+    const disp = makeDispatcherMock();
+    mgr.registerWith(disp as never);
+    const handle = disp.getHandler();
+
+    // Simulate a headers object that already has BOTH casings (old-code artifact)
+    const result = handle(
+      { url: 'https://cloudflare.com' },
+      {
+        'sec-ch-ua':     '"Not(A:Brand";v="8", "Chromium";v="132"',
+        'Sec-CH-UA':     '"Google Chrome";v="132", "Chromium";v="132", "Not_A Brand";v="24"',
+      }
+    );
+
+    // No capitalized variant should survive
+    expect(result['Sec-CH-UA']).toBeUndefined();
+    // The single lowercase key must contain "Google Chrome"
+    expect(result['sec-ch-ua']).toContain('Google Chrome');
+  });
+
+  it('builds a correct sec-ch-ua from scratch when Chromium did not send it', () => {
+    const mgr  = makeManagerWithFixedSecret();
+    const disp = makeDispatcherMock();
+    mgr.registerWith(disp as never);
+    const handle = disp.getHandler();
+
+    const result = handle({ url: 'https://example.com' }, {});
+
+    expect(result['sec-ch-ua']).toContain('Google Chrome');
+    expect(result['sec-ch-ua']).toContain('Chromium');
+    expect(result['sec-ch-ua']).toContain('Not(A:Brand');
+  });
+
+  it('does not add sec-ch-ua-full-version-list when Chromium did not send it', () => {
+    const mgr  = makeManagerWithFixedSecret();
+    const disp = makeDispatcherMock();
+    mgr.registerWith(disp as never);
+    const handle = disp.getHandler();
+
+    const result = handle(
+      { url: 'https://example.com' },
+      { 'sec-ch-ua': '"Not(A:Brand";v="8", "Chromium";v="132"' }
+    );
+
+    const fullListKeys = Object.keys(result).filter(
+      k => k.toLowerCase() === 'sec-ch-ua-full-version-list'
+    );
+    expect(fullListKeys).toHaveLength(0);
+  });
+
+  it('enriches sec-ch-ua-full-version-list when Chromium sent it', () => {
+    const mgr  = makeManagerWithFixedSecret();
+    const disp = makeDispatcherMock();
+    mgr.registerWith(disp as never);
+    const handle = disp.getHandler();
+
+    const result = handle(
+      { url: 'https://example.com' },
+      {
+        'sec-ch-ua':                  '"Not(A:Brand";v="8", "Chromium";v="132"',
+        'sec-ch-ua-full-version-list': '"Not(A:Brand";v="8.0.0.0", "Chromium";v="132.0.6834.160"',
+      }
+    );
+
+    expect(result['sec-ch-ua-full-version-list']).toContain('Google Chrome');
+    expect(result['sec-ch-ua-full-version-list']).toContain('Not(A:Brand');
+  });
+
+  it('strips sec-ch-ua headers from Google auth requests (existing behaviour unchanged)', () => {
+    const mgr  = makeManagerWithFixedSecret();
+    const disp = makeDispatcherMock();
+    mgr.registerWith(disp as never);
+    const handle = disp.getHandler();
+
+    const result = handle(
+      { url: 'https://accounts.google.com/o/oauth2/auth' },
+      {
+        'User-Agent':  'Mozilla/5.0 Chrome/132',
+        'sec-ch-ua':   '"Not(A:Brand";v="8", "Chromium";v="132"',
+        'sec-ch-ua-mobile': '?0',
+      }
+    );
+
+    const chUaKeys = Object.keys(result).filter(k => k.toLowerCase().startsWith('sec-ch-ua'));
+    expect(chUaKeys).toHaveLength(0);
+  });
+
+  it('uses lowercase sec-ch-ua-mobile and sec-ch-ua-platform keys', () => {
+    const mgr  = makeManagerWithFixedSecret();
+    const disp = makeDispatcherMock();
+    mgr.registerWith(disp as never);
+    const handle = disp.getHandler();
+
+    const result = handle({ url: 'https://example.com' }, {});
+
+    expect(result['sec-ch-ua-mobile']).toBe('?0');
+    expect(result['sec-ch-ua-platform']).toBe('"macOS"');
+    // Old uppercase variants must not appear
+    expect(result['Sec-CH-UA-Mobile']).toBeUndefined();
+    expect(result['Sec-CH-UA-Platform']).toBeUndefined();
+  });
+});
+
 describe('getStealthScript() — timing protection', () => {
   it('rounds performance.now to 100μs (Firefox parity)', () => {
     const script = StealthManager.getStealthScript('seed');

--- a/src/stealth/tests/manager.test.ts
+++ b/src/stealth/tests/manager.test.ts
@@ -425,3 +425,39 @@ describe('getStealthScript() — timing protection', () => {
     expect(script).not.toMatch(/origDateNow/);
   });
 });
+
+describe('getStealthScript() — userAgentData GREASE brand consistency', () => {
+  it('uses "Not(A:Brand" (Chrome 120+ GREASE token), not the old "Not_A Brand"', () => {
+    // Cloudflare cross-checks navigator.userAgentData.brands against the
+    // sec-ch-ua HTTP header. The header handler preserves Chromium's natural
+    // GREASE token ("Not(A:Brand" for Chrome 120+). The injected JS must match.
+    const script = StealthManager.getStealthScript('seed');
+    expect(script).toContain('Not(A:Brand');
+    expect(script).not.toContain('Not_A Brand');
+    expect(script).not.toContain('Not.A/Brand');
+  });
+
+  it('uses GREASE version "8", not the old "24"', () => {
+    const script = StealthManager.getStealthScript('seed');
+    // The __greaseVersion variable must be '8'
+    expect(script).toContain("__greaseVersion = '8'");
+    expect(script).not.toMatch(/__greaseVersion\s*=\s*'24'/);
+  });
+
+  it('fullVersionList GREASE version is built from __greaseVersion (e.g. "8.0.0.0")', () => {
+    const script = StealthManager.getStealthScript('seed');
+    // Should not hardcode the old wrong "24.0.0.0"
+    expect(script).not.toContain('"24.0.0.0"');
+    expect(script).not.toContain("'24.0.0.0'");
+    // Should compose it from the variable
+    expect(script).toContain("__greaseVersion + '.0.0.0'");
+  });
+
+  it('includes "Google Chrome" in all brand lists', () => {
+    const script = StealthManager.getStealthScript('seed');
+    // Must appear in both the low-entropy brands and the getHighEntropyValues response
+    const chromeCount = (script.match(/Google Chrome/g) || []).length;
+    // brands (1) + getHighEntropyValues brands (1) + fullVersionList (1) = min 3
+    expect(chromeCount).toBeGreaterThanOrEqual(3);
+  });
+});


### PR DESCRIPTION
## Problem

Cloudflare-protected sites were detecting Tandem as an Electron bot **before any user interaction** (cf-chl-ra: `"0"` = maximum suspicion). Root cause: three bugs in the `sec-ch-ua` client hints header.

### Bug 1 — Key-casing mismatch (the main culprit)

Chromium sends client hints with **lowercase** HTTP/2-style keys (`sec-ch-ua`). The old code set `headers['Sec-CH-UA']` (capitalised), which does **not** overwrite the original — both keys coexist in the headers object. Cloudflare reads the lowercase one (no `"Google Chrome"`) and flags immediately.

**Before** (what Cloudflare saw):
```
sec-ch-ua: "Not(A:Brand";v="8", "Chromium";v="144"   ← Electron giveaway
Sec-CH-UA: "Google Chrome";v="144", ...               ← ignored duplicate
```

**After:**
```
sec-ch-ua: "Not(A:Brand";v="8", "Chromium";v="144", "Google Chrome";v="144"
```

### Bug 2 — Wrong GREASE brand

Old code hardcoded `"Not_A Brand"` instead of preserving Chromium's naturally-generated GREASE token (`"Not(A:Brand"` for Chrome 120+).

### Bug 3 — Wrong GREASE version

Old code hardcoded `v="24"` instead of the correct `v="8"`.

## Fix

`StealthManager.registerWith()` now:
1. Captures Chromium's naturally-generated `sec-ch-ua` value (preserving the correct GREASE token for the actual Chrome version)
2. Deletes **all** `sec-ch-ua*` header keys case-insensitively
3. Re-sets with lowercase keys and `"Google Chrome"` injected
4. Only sends `sec-ch-ua-full-version-list` when Chromium already included it (it's a high-entropy hint, sending it unprompted is itself a detection vector)

## Test

✅ Tested on [https://nowsecure.nl](https://nowsecure.nl) (Cloudflare bot detection test) — **Success** with the fix applied.

Adds 9 new unit tests covering:
- Google Chrome brand injection
- GREASE token preservation
- No duplicate keys (casing bug regression guard)
- Build-from-scratch fallback when Chromium didn't send the header
- full-version-list only when present
- Google auth path still strips all sec-ch-ua headers (existing behaviour)
- lowercase key names for mobile + platform