### PR TITLE
v1.0.1: Cloudflare human mode phase 3 — security gating on challenge tabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ native/speech/tandem-speech
 
 # Implementation plans (private, local only)
 docs/superpowers/
+
+# Local Claude Code settings and worktrees
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to Tandem Browser will be documented in this file.
 
+## [v1.0.1] - 2026-04-21
+
+Cloudflare human mode — phase 3. Challenge-sensitive tabs now run with reduced security instrumentation so Turnstile and the Cloudflare interstitial see a stock Chromium surface, while non-Cloudflare tabs keep the full security stack. Phases 4 (human handoff) and 5 (conservative resume after `cf_clearance`) are on hold.
+
+### Added
+
+- **`CloudflarePolicyManager`** — new tab/origin-scoped policy store that classifies tabs as challenge-sensitive based on URL, response headers (`cf_clearance`), DOM selectors, and interstitial title snippets. Exposes a `getStealthDispositionForUrl` decision function (`full` | `early` | `skip`) for the stealth preload.
+- **Shared Cloudflare utilities** (`src/utils/cloudflare.ts`) — challenge-host/path detection, no-touch partition prefix helpers, and the canonical list of challenge DOM selectors reused by `HeadlessManager` and the main-process probe.
+- **Early stealth script variant** — minimal navigator/UA patches without canvas, audio, or timing noise. Injected into cross-origin Turnstile iframes so stealth fingerprint perturbation no longer trips Cloudflare's challenge.
+
+### Changed
+
+- **Security gating on challenge-sensitive tabs** — `SecurityManager` now refuses to attach ScriptGuard main-world monitors and blocks `BehaviorMonitor` resource polling on tabs the policy manager flags as challenge-sensitive. Live policy flips trigger an immediate de-escalation on the affected tab. Normal non-Cloudflare tabs keep the existing instrumentation path.
+- **Stealth preload is mode-aware** — the per-frame preload now performs a synchronous IPC (`tandem:cloudflare-policy-sync`) to the main process before injecting, and chooses between `early` (Turnstile OOPIFs) and `full` (everything else) based on the returned disposition. Google auth and `file://` frames are still skipped entirely.
+- **DevTools attach logs include the `webContents` id** — every CDP attach, security-domain enable, and already-attached message now carries `wc <id>`, which makes diagnosing OOPIF-specific Cloudflare attach races possible from logs alone.
+
+### Fixed
+
+- **Stealth crash inside Cloudflare Turnstile OOPIFs** — the full stealth script is no longer injected into `challenges.cloudflare.com` sub-frames; those frames now receive only the early variant, which resolves the V8 crash observed during Turnstile challenges.
+
 ## [v1.0.0] - 2026-04-20
 
 First binary release of Tandem Browser — signed and notarized for macOS Apple Silicon. This release also brings full Cloudflare/Turnstile stealth compatibility, agent trust tiers that reduce approval friction for legitimate agent work, and a raft of shell, SEO, and documentation improvements.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -31,7 +31,7 @@ The security layer exists because when an AI has access to your browser, your th
 Data stays local. Sessions are isolated. Nothing leaves the machine through Tandem Browser without going through a filter first.
 
 **GitHub:** `hydro13/tandem-browser`  
-**Current version:** `1.0.0`  
+**Current version:** `1.0.1`  
 **Repository status:** Public developer preview  
 **Started:** February 11, 2026
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ For the longer version, see [docs/tandem-browser-vs-webmcp.md](docs/tandem-brows
 
 **macOS Apple Silicon (M1+)** — download the signed and notarized binary:
 
-**[Download Tandem Browser v1.0.0 →](https://github.com/hydro13/tandem-browser/releases/tag/v1.0.0)**
+**[Download Tandem Browser v1.0.1 →](https://github.com/hydro13/tandem-browser/releases/tag/v1.0.1)**
 
 1. Open the `.dmg`, drag Tandem Browser to Applications, launch it
 2. Open **Settings → Connected Agents** and scroll to *Connect your AI to Tandem*
@@ -173,7 +173,7 @@ macOS is the primary platform. Linux works. Windows is validated as a remote age
 
 Depending on what you want to do:
 
-- **Install Tandem** -> [Download v1.0.0](https://github.com/hydro13/tandem-browser/releases/tag/v1.0.0) (macOS) or follow Quick Start above
+- **Install Tandem** -> [Download v1.0.1](https://github.com/hydro13/tandem-browser/releases/tag/v1.0.1) (macOS) or follow Quick Start above
 - **Connect an agent** -> see [Connect Your AI Agent](#connect-your-ai-agent)
 - **Explore the API and docs** -> browse [docs/](docs/) and [docs/INDEX.md](docs/INDEX.md)
 - **See the product story and website** -> visit [tandembrowser.org](https://tandembrowser.org)
@@ -359,7 +359,7 @@ contributors, not yet a polished mass-user release.
 - Secondary platform: Linux
 - Windows: validated as a remote agent host (VS Code + Claude Code over Tailscale)
 - Binaries: not published yet (source-only)
-- Current version: `1.0.0`
+- Current version: `1.0.1`
 - Package metadata: [package.json](package.json)
 
 ## Community

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@
 > Historical release summaries belong in `CHANGELOG.md`.
 > Architecture and product context belong in `PROJECT.md`.
 
-Last updated: April 16, 2026
+Last updated: April 21, 2026
 
 ## Purpose
 
@@ -49,6 +49,7 @@ Last updated: April 16, 2026
 
 ### Codebase Hygiene
 
+- [ ] Finish Cloudflare human mode phases 4-5 so challenge-sensitive tabs pause cleanly for the human and resume conservatively after `cf_clearance`; phase 3 now gates ScriptGuard and resource monitoring on Cloudflare tabs
 - [x] Make Wingman `openclaw` mode gateway-first for sends, sign a real OpenClaw device identity for the WebSocket handshake, and persist gateway replies into Tandem chat history so stock Tandem no longer depends on a local OpenClaw tandem-chat skill
 - [x] Split `src/main.ts` bootstrap and teardown wiring into dedicated `src/bootstrap/` modules so manager composition stops growing in one file
 - [x] Extract the largest shell surfaces out of `shell/index.html` and `shell/css/main.css` so sidebar logic, modal helpers, and stylesheet sections stop living in single inline or monolithic files

--- a/docs/index.html
+++ b/docs/index.html
@@ -163,8 +163,8 @@ footer a:hover{color:var(--text2)}
       "operatingSystem": "macOS (developer preview), Linux (pre-beta)",
       "description": "Tandem Browser is the open-source, local-first browser for AI agents — where the AI lives inside your real browser session, bring any model via MCP.",
       "url": "https://tandembrowser.org",
-      "downloadUrl": "https://github.com/hydro13/tandem-browser/releases/tag/v1.0.0",
-      "softwareVersion": "1.0.0",
+      "downloadUrl": "https://github.com/hydro13/tandem-browser/releases/tag/v1.0.1",
+      "softwareVersion": "1.0.1",
       "license": "https://opensource.org/licenses/MIT",
       "offers": {
         "@type": "Offer",
@@ -325,7 +325,7 @@ footer a:hover{color:var(--text2)}
 </header>
 
 <div class="hero">
-<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v1.0.0</div>
+<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v1.0.1</div>
 <p class="hero-lead">Tandem Browser is the <strong>open-source, local-first browser for AI agents</strong> — where the AI lives inside your real browser session, sharing your tabs, cookies, and DOM, ready to ask for your help the moment it gets stuck.</p>
 <h1>The browser becomes a <em>programmable workspace</em> where human intent and AI capability meet.</h1>
 <p>Tandem Browser is built around a simple shift: the AI is not a sidebar talking <em>about</em> your browser, it is <em>inside</em> it. Same tabs, same cookies, same logged-in sessions, same page you are looking at right now. Reading the accessibility tree, watching the network, writing live styles, handing back to you when something needs a human. It turns the web that already exists into something agents can actually operate on — no per-site API, no RPA rig, no screenshot loop. The real browser, as a shared human-AI symbiotic runtime.</p>
@@ -587,7 +587,7 @@ footer a:hover{color:var(--text2)}
 <div class="step-num">1</div>
 <div class="step-content">
 <h3>Download and install</h3>
-<p><a href="https://github.com/hydro13/tandem-browser/releases/tag/v1.0.0" style="font-weight:600">Download Tandem Browser v1.0.0 &rarr;</a></p>
+<p><a href="https://github.com/hydro13/tandem-browser/releases/tag/v1.0.1" style="font-weight:600">Download Tandem Browser v1.0.1 &rarr;</a></p>
 <p style="margin-top:.4rem">macOS Apple Silicon (M1+). Signed and notarized — Gatekeeper accepts it without any override.</p>
 <p style="font-size:.72rem;color:var(--text3);margin-top:.5rem">Linux pre-beta and Windows support are on the roadmap. For now, build from source on those platforms.</p>
 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tandem-browser",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tandem-browser",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-browser",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Local-first Electron browser with a 253-tool MCP server, MCP/HTTP control surfaces, and built-in security controls",
   "main": "dist/main.js",
   "author": "Tandem Browser contributors",

--- a/src/api/routes/misc.ts
+++ b/src/api/routes/misc.ts
@@ -67,6 +67,7 @@ export function registerMiscRoutes(router: Router, ctx: RouteContext): void {
         activeTab: tab.id,
         tabs: ctx.tabManager.count,
         version: (() => { try { return app.getVersion(); } catch { return undefined; } })(),
+        cloudflare: ctx.cloudflarePolicyManager.getTabPolicy(tab.webContentsId),
         viewport,
       });
     } catch (e) {

--- a/src/api/tests/helpers.ts
+++ b/src/api/tests/helpers.ts
@@ -3,6 +3,7 @@ import express from 'express';
 import type { Router } from 'express';
 import type { RouteContext } from '../context';
 import { AgentTrustStore } from '../../security/agent-trust';
+import { CloudflarePolicyManager } from '../../cloudflare/policy-manager';
 
 /**
  * Creates a mock WebContents object with common methods stubbed.
@@ -42,6 +43,7 @@ export function createMockWebContents(id = 1) {
  */
 export function createMockContext(): RouteContext {
   const mockWC = createMockWebContents(1);
+  const cloudflarePolicyManager = new CloudflarePolicyManager();
 
   const win = {
     webContents: mockWC,
@@ -693,6 +695,7 @@ export function createMockContext(): RouteContext {
     // at ~/.tandem/agent-trust.json — tests that care should inject their
     // own path via new AgentTrustStore(path)).
     agentTrust: new AgentTrustStore(),
+    cloudflarePolicyManager,
   };
 
   return ctx;

--- a/src/api/tests/routes/misc.test.ts
+++ b/src/api/tests/routes/misc.test.ts
@@ -132,8 +132,31 @@ describe('misc routes', () => {
       expect(res.status).toBe(200);
       expect(res.body.ready).toBe(true);
       expect(res.body.loading).toBe(false);
+      expect(res.body.cloudflare).toBeNull();
       expect(res.body.viewport).toBeDefined();
       expect(res.body.viewport.innerWidth).toBe(1280);
+    });
+
+    it('returns the active tab cloudflare policy when one exists', async () => {
+      const mockWC = createMockWebContents(4);
+      mockWC.executeJavaScript.mockResolvedValue(JSON.stringify({
+        innerWidth: 1280,
+        innerHeight: 720,
+        scrollTop: 0,
+        scrollHeight: 2000,
+        clientHeight: 720,
+        screenWidth: 1920,
+        screenHeight: 1080,
+      }));
+      mockGetActiveWC.mockResolvedValue(mockWC as any);
+      ctx.cloudflarePolicyManager.onMainFrameNavigation(100, 'https://example.com/login');
+      ctx.cloudflarePolicyManager.markChallengeDetected(100, 'https://challenges.cloudflare.com/turnstile/v0/b/api.js', 'test');
+
+      const res = await request(app).get('/status');
+
+      expect(res.status).toBe(200);
+      expect(res.body.cloudflare.mode).toBe('challenge_detected');
+      expect(res.body.cloudflare.challengeDetected).toBe(true);
     });
 
     it('returns ready:true without viewport when executeJavaScript fails', async () => {

--- a/src/bootstrap/runtime.ts
+++ b/src/bootstrap/runtime.ts
@@ -59,12 +59,14 @@ import { WorkflowEngine } from '../workflow/engine';
 import { WorkspaceManager } from '../workspaces/manager';
 import { ClipboardManager } from '../clipboard/manager';
 import { PairingManager } from '../pairing/manager';
+import type { CloudflarePolicyManager } from '../cloudflare/policy-manager';
 import { DEFAULT_PARTITION } from '../utils/constants';
 import type { RuntimeManagers } from './types';
 
 interface InitializeRuntimeOptions {
   win: BrowserWindow;
   dispatcher: RequestDispatcher | null;
+  cloudflarePolicyManager: CloudflarePolicyManager;
   pendingContextMenuWebContents: WebContents[];
   pendingSecurityCoverageWebContentsIds: number[];
   canUseWindow: (win: BrowserWindow | null) => win is BrowserWindow;
@@ -178,7 +180,15 @@ async function configureNativeMessagingHostDirectories(log: Logger): Promise<voi
 }
 
 export async function initializeRuntimeManagers(opts: InitializeRuntimeOptions): Promise<RuntimeManagers> {
-  const { win, dispatcher, pendingContextMenuWebContents, pendingSecurityCoverageWebContentsIds, canUseWindow, log } = opts;
+  const {
+    win,
+    dispatcher,
+    cloudflarePolicyManager,
+    pendingContextMenuWebContents,
+    pendingSecurityCoverageWebContentsIds,
+    canUseWindow,
+    log,
+  } = opts;
   const runtime: RuntimeManagers = {} as RuntimeManagers;
 
   runtime.configManager = new ConfigManager();
@@ -252,6 +262,7 @@ export async function initializeRuntimeManagers(opts: InitializeRuntimeOptions):
   runtime.loginManager = new LoginManager();
   runtime.clipboardManager = new ClipboardManager();
   runtime.pairingManager = new PairingManager();
+  runtime.cloudflarePolicyManager = cloudflarePolicyManager;
   runtime.sessionRestoreManager = new SessionRestoreManager(runtime.syncManager);
 
   runtime.workspaceManager.setMainWindow(win);
@@ -355,6 +366,7 @@ export async function initializeRuntimeManagers(opts: InitializeRuntimeOptions):
     dispatcher: dispatcher ?? undefined,
     devToolsManager: runtime.devToolsManager,
     session: ses,
+    cloudflarePolicyManager: runtime.cloudflarePolicyManager,
   });
   runtime.securityManager.onContainmentIncident = (incident: SecurityContainmentIncident) => {
     if (!canUseWindow(win)) {
@@ -461,6 +473,7 @@ export function createManagerRegistry(runtime: RuntimeManagers): ManagerRegistry
     clipboardManager: runtime.clipboardManager,
     pairingManager: runtime.pairingManager,
     agentTrust: runtime.agentTrust,
+    cloudflarePolicyManager: runtime.cloudflarePolicyManager,
   };
 }
 

--- a/src/bootstrap/types.ts
+++ b/src/bootstrap/types.ts
@@ -49,6 +49,7 @@ import type { LoginManager } from '../auth/login-manager';
 import type { ClipboardManager } from '../clipboard/manager';
 import type { GooglePhotosManager } from '../integrations/google-photos';
 import type { PairingManager } from '../pairing/manager';
+import type { CloudflarePolicyManager } from '../cloudflare/policy-manager';
 
 export interface RuntimeManagers {
   configManager: ConfigManager;
@@ -102,6 +103,7 @@ export interface RuntimeManagers {
   clipboardManager: ClipboardManager;
   pairingManager: PairingManager;
   agentTrust: AgentTrustStore;
+  cloudflarePolicyManager: CloudflarePolicyManager;
 }
 
 export interface PendingTabRegister {

--- a/src/cloudflare/policy-manager.ts
+++ b/src/cloudflare/policy-manager.ts
@@ -1,0 +1,259 @@
+import { EventEmitter } from 'events';
+import { getOriginFromUrl, isCloudflareChallengeUrl } from '../utils/cloudflare';
+
+export type CloudflarePolicyMode = 'normal' | 'challenge_detected' | 'human_required' | 'post_clearance';
+
+export interface CloudflareTabPolicy {
+  webContentsId: number;
+  mode: CloudflarePolicyMode;
+  currentUrl: string | null;
+  currentOrigin: string | null;
+  challengeDetected: boolean;
+  clearanceSeen: boolean;
+  lastSignal: string | null;
+  lastUpdatedAt: number;
+}
+
+export interface CloudflareOriginPolicy {
+  origin: string;
+  challengeSeen: boolean;
+  clearanceSeen: boolean;
+  conservativeMode: boolean;
+  lastSignal: string | null;
+  lastUpdatedAt: number;
+}
+
+export interface CloudflarePolicyEvent {
+  webContentsId: number | null;
+  url: string | null;
+  origin: string | null;
+  signal: string;
+  mode: CloudflarePolicyMode | null;
+}
+
+function cloneTabPolicy(policy: CloudflareTabPolicy): CloudflareTabPolicy {
+  return { ...policy };
+}
+
+function cloneOriginPolicy(policy: CloudflareOriginPolicy): CloudflareOriginPolicy {
+  return { ...policy };
+}
+
+/**
+ * CloudflarePolicyManager — tab/origin-scoped Cloudflare challenge state.
+ *
+ * Phase 1 only records state. Later phases will consume this state to gate
+ * stealth, security instrumentation, and human handoff behavior.
+ */
+export class CloudflarePolicyManager extends EventEmitter {
+  private readonly tabPolicies = new Map<number, CloudflareTabPolicy>();
+  private readonly originPolicies = new Map<string, CloudflareOriginPolicy>();
+
+  onMainFrameNavigation(webContentsId: number, url: string): CloudflareTabPolicy {
+    const now = Date.now();
+    const currentOrigin = getOriginFromUrl(url);
+    const existing = this.tabPolicies.get(webContentsId);
+    const originPolicy = currentOrigin ? this.originPolicies.get(currentOrigin) ?? null : null;
+    const mode = existing?.mode === 'human_required'
+      ? 'human_required'
+      : originPolicy?.challengeSeen
+        ? (originPolicy.clearanceSeen ? 'post_clearance' : 'challenge_detected')
+        : 'normal';
+
+    const next: CloudflareTabPolicy = {
+      webContentsId,
+      mode,
+      currentUrl: url,
+      currentOrigin,
+      challengeDetected: originPolicy?.challengeSeen ?? existing?.challengeDetected ?? false,
+      clearanceSeen: originPolicy?.clearanceSeen ?? existing?.clearanceSeen ?? false,
+      lastSignal: existing?.lastSignal ?? null,
+      lastUpdatedAt: now,
+    };
+
+    this.tabPolicies.set(webContentsId, next);
+    this.emit('tab-policy-changed', cloneTabPolicy(next));
+    return cloneTabPolicy(next);
+  }
+
+  markChallengeDetected(webContentsId: number | null, url: string | null, signal: string): void {
+    const now = Date.now();
+    const current = typeof webContentsId === 'number'
+      ? this.tabPolicies.get(webContentsId) ?? this.onMainFrameNavigation(webContentsId, url ?? 'about:blank')
+      : null;
+    const policyOrigin = current?.currentOrigin ?? (url ? getOriginFromUrl(url) : null);
+    const targetOrigin = policyOrigin ?? null;
+
+    if (targetOrigin) {
+      const nextOrigin: CloudflareOriginPolicy = {
+        origin: targetOrigin,
+        challengeSeen: true,
+        clearanceSeen: this.originPolicies.get(targetOrigin)?.clearanceSeen ?? false,
+        conservativeMode: true,
+        lastSignal: signal,
+        lastUpdatedAt: now,
+      };
+      this.originPolicies.set(targetOrigin, nextOrigin);
+      this.emit('origin-policy-changed', cloneOriginPolicy(nextOrigin));
+    }
+
+    if (typeof webContentsId === 'number') {
+      const nextTab: CloudflareTabPolicy = {
+        webContentsId,
+        mode: current?.mode === 'human_required' ? 'human_required' : 'challenge_detected',
+        currentUrl: current?.currentUrl ?? url,
+        currentOrigin: targetOrigin,
+        challengeDetected: true,
+        clearanceSeen: current?.clearanceSeen ?? false,
+        lastSignal: signal,
+        lastUpdatedAt: now,
+      };
+      this.tabPolicies.set(webContentsId, nextTab);
+      this.emit('tab-policy-changed', cloneTabPolicy(nextTab));
+      this.emit('challenge-detected', {
+        webContentsId,
+        url,
+        origin: targetOrigin,
+        signal,
+        mode: nextTab.mode,
+      } satisfies CloudflarePolicyEvent);
+      return;
+    }
+
+    this.emit('challenge-detected', {
+      webContentsId: null,
+      url,
+      origin: targetOrigin,
+      signal,
+      mode: null,
+    } satisfies CloudflarePolicyEvent);
+  }
+
+  markClearanceSeen(webContentsId: number | null, url: string | null, signal: string): void {
+    const now = Date.now();
+    const current = typeof webContentsId === 'number' ? this.tabPolicies.get(webContentsId) ?? null : null;
+    const targetOrigin = current?.currentOrigin ?? (url ? getOriginFromUrl(url) : null);
+
+    if (targetOrigin) {
+      const existingOrigin = this.originPolicies.get(targetOrigin);
+      const nextOrigin: CloudflareOriginPolicy = {
+        origin: targetOrigin,
+        challengeSeen: existingOrigin?.challengeSeen ?? true,
+        clearanceSeen: true,
+        conservativeMode: true,
+        lastSignal: signal,
+        lastUpdatedAt: now,
+      };
+      this.originPolicies.set(targetOrigin, nextOrigin);
+      this.emit('origin-policy-changed', cloneOriginPolicy(nextOrigin));
+    }
+
+    if (typeof webContentsId === 'number' && current) {
+      const nextMode: CloudflarePolicyMode = current.mode === 'human_required' ? 'human_required' : 'post_clearance';
+      const nextTab: CloudflareTabPolicy = {
+        ...current,
+        mode: nextMode,
+        clearanceSeen: true,
+        lastSignal: signal,
+        lastUpdatedAt: now,
+      };
+      this.tabPolicies.set(webContentsId, nextTab);
+      this.emit('tab-policy-changed', cloneTabPolicy(nextTab));
+      this.emit('clearance-seen', {
+        webContentsId,
+        url: current.currentUrl ?? url,
+        origin: targetOrigin,
+        signal,
+        mode: nextTab.mode,
+      } satisfies CloudflarePolicyEvent);
+      return;
+    }
+
+    this.emit('clearance-seen', {
+      webContentsId,
+      url,
+      origin: targetOrigin,
+      signal,
+      mode: null,
+    } satisfies CloudflarePolicyEvent);
+  }
+
+  noteHumanRequired(webContentsId: number, signal: string): void {
+    const current = this.tabPolicies.get(webContentsId);
+    if (!current) return;
+    const nextTab: CloudflareTabPolicy = {
+      ...current,
+      mode: 'human_required',
+      lastSignal: signal,
+      lastUpdatedAt: Date.now(),
+    };
+    this.tabPolicies.set(webContentsId, nextTab);
+    this.emit('tab-policy-changed', cloneTabPolicy(nextTab));
+  }
+
+  noteResumed(webContentsId: number, signal: string): void {
+    const current = this.tabPolicies.get(webContentsId);
+    if (!current) return;
+    const nextTab: CloudflareTabPolicy = {
+      ...current,
+      mode: current.clearanceSeen ? 'post_clearance' : 'challenge_detected',
+      lastSignal: signal,
+      lastUpdatedAt: Date.now(),
+    };
+    this.tabPolicies.set(webContentsId, nextTab);
+    this.emit('tab-policy-changed', cloneTabPolicy(nextTab));
+  }
+
+  isChallengeSensitiveTab(webContentsId: number): boolean {
+    const policy = this.tabPolicies.get(webContentsId);
+    if (!policy) {
+      return false;
+    }
+
+    if (policy.mode !== 'normal' || policy.challengeDetected || policy.clearanceSeen) {
+      return true;
+    }
+
+    return policy.currentOrigin
+      ? this.originPolicies.get(policy.currentOrigin)?.conservativeMode ?? false
+      : false;
+  }
+
+  getStealthDispositionForUrl(rawValue: string): 'full' | 'early' {
+    if (isCloudflareChallengeUrl(rawValue)) {
+      return 'early';
+    }
+
+    const origin = getOriginFromUrl(rawValue);
+    if (!origin) {
+      return 'full';
+    }
+
+    return this.originPolicies.get(origin)?.conservativeMode ? 'early' : 'full';
+  }
+
+  getTabPolicy(webContentsId: number): CloudflareTabPolicy | null {
+    const policy = this.tabPolicies.get(webContentsId);
+    return policy ? cloneTabPolicy(policy) : null;
+  }
+
+  getOriginPolicy(origin: string): CloudflareOriginPolicy | null {
+    const policy = this.originPolicies.get(origin);
+    return policy ? cloneOriginPolicy(policy) : null;
+  }
+
+  onTabClosed(webContentsId: number): void {
+    this.tabPolicies.delete(webContentsId);
+  }
+
+  /**
+   * Phase 1 convenience: consume a raw URL signal and classify it when it is a
+   * known Cloudflare challenge URL.
+   */
+  recordUrlSignal(webContentsId: number | null, url: string | null, signal: string): void {
+    if (!url || !isCloudflareChallengeUrl(url)) {
+      return;
+    }
+    this.markChallengeDetected(webContentsId, url, signal);
+  }
+}

--- a/src/cloudflare/tests/policy-manager.test.ts
+++ b/src/cloudflare/tests/policy-manager.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { CloudflarePolicyManager } from '../policy-manager';
+
+describe('CloudflarePolicyManager', () => {
+  it('tracks a main-frame navigation as normal by default', () => {
+    const manager = new CloudflarePolicyManager();
+    const policy = manager.onMainFrameNavigation(11, 'https://example.com/login');
+
+    expect(policy.mode).toBe('normal');
+    expect(policy.currentOrigin).toBe('https://example.com');
+    expect(manager.isChallengeSensitiveTab(11)).toBe(false);
+  });
+
+  it('marks the site origin when a Cloudflare subframe challenge is detected', () => {
+    const manager = new CloudflarePolicyManager();
+    manager.onMainFrameNavigation(11, 'https://example.com/login');
+    manager.markChallengeDetected(11, 'https://challenges.cloudflare.com/turnstile/v0/b/api.js', 'frame:url');
+
+    const tabPolicy = manager.getTabPolicy(11);
+    const originPolicy = manager.getOriginPolicy('https://example.com');
+
+    expect(tabPolicy?.mode).toBe('challenge_detected');
+    expect(tabPolicy?.currentOrigin).toBe('https://example.com');
+    expect(originPolicy?.challengeSeen).toBe(true);
+    expect(originPolicy?.conservativeMode).toBe(true);
+    expect(manager.isChallengeSensitiveTab(11)).toBe(true);
+  });
+
+  it('marks clearance and carries post-clearance state forward on navigation', () => {
+    const manager = new CloudflarePolicyManager();
+    manager.onMainFrameNavigation(11, 'https://example.com/login');
+    manager.markChallengeDetected(11, 'https://challenges.cloudflare.com/turnstile/v0/b/api.js', 'frame:url');
+    manager.markClearanceSeen(11, 'https://example.com/login', 'set-cookie');
+
+    expect(manager.getTabPolicy(11)?.mode).toBe('post_clearance');
+    expect(manager.getOriginPolicy('https://example.com')?.clearanceSeen).toBe(true);
+
+    const laterPolicy = manager.onMainFrameNavigation(11, 'https://example.com/account');
+    expect(laterPolicy.mode).toBe('post_clearance');
+    expect(manager.isChallengeSensitiveTab(11)).toBe(true);
+  });
+
+  it('recordUrlSignal classifies known challenge URLs', () => {
+    const manager = new CloudflarePolicyManager();
+    manager.recordUrlSignal(22, 'https://example.com/cdn-cgi/challenge-platform/h/b/orchestrate/managed/v1', 'headers:url');
+
+    expect(manager.getTabPolicy(22)?.mode).toBe('challenge_detected');
+  });
+
+  it('returns early stealth disposition for conservative origins', () => {
+    const manager = new CloudflarePolicyManager();
+    manager.onMainFrameNavigation(11, 'https://example.com/login');
+    manager.markChallengeDetected(11, 'https://challenges.cloudflare.com/turnstile/v0/b/api.js', 'frame:url');
+
+    expect(manager.getStealthDispositionForUrl('https://example.com/account')).toBe('early');
+    expect(manager.getStealthDispositionForUrl('https://another.example/account')).toBe('full');
+  });
+
+  it('drops tab state on close without losing origin memory', () => {
+    const manager = new CloudflarePolicyManager();
+    manager.onMainFrameNavigation(11, 'https://example.com/login');
+    manager.markChallengeDetected(11, 'https://challenges.cloudflare.com/turnstile/v0/b/api.js', 'frame:url');
+
+    manager.onTabClosed(11);
+
+    expect(manager.getTabPolicy(11)).toBeNull();
+    expect(manager.getOriginPolicy('https://example.com')?.challengeSeen).toBe(true);
+  });
+});

--- a/src/devtools/manager.ts
+++ b/src/devtools/manager.ts
@@ -131,9 +131,9 @@ export class DevToolsManager {
     try {
       await wc.debugger.sendCommand('Debugger.enable');
       await wc.debugger.sendCommand('Performance.enable');
-      log.info('Security domains enabled (Debugger, Performance)');
+      log.info(`Security domains enabled (Debugger, Performance) for wc ${wc.id}`);
     } catch (e) {
-      log.warn('Security domain enable failed:', e instanceof Error ? e.message : e);
+      log.warn(`Security domain enable failed for wc ${wc.id}:`, e instanceof Error ? e.message : e);
     }
   }
 
@@ -174,6 +174,7 @@ export class DevToolsManager {
     const wc = webContents.fromId(wcId);
     if (!wc || wc.isDestroyed()) return null;
 
+    log.debug(`attachToTab request for wc ${wcId} (makePrimary=${opts?.makePrimary ?? true})`);
     return this.attach(wc, { makePrimary: opts?.makePrimary ?? true });
   }
 
@@ -386,9 +387,9 @@ export class DevToolsManager {
       const msg = e instanceof Error ? e.message : String(e);
       if (msg.toLowerCase().includes('already attached')) {
         // DevTools is open or another component attached first — share the session.
-        log.info('⚠️ CDP debugger already attached — sharing session');
+        log.info(`⚠️ CDP debugger already attached for wc ${wc.id} — sharing session`);
       } else {
-        log.warn('❌ CDP attach failed:', msg);
+        log.warn(`❌ CDP attach failed for wc ${wc.id}:`, msg);
         return null;
       }
     }

--- a/src/headless/manager.ts
+++ b/src/headless/manager.ts
@@ -2,6 +2,7 @@ import { BrowserWindow, session } from 'electron';
 import { StealthManager } from '../stealth/manager';
 import { wingmanAlert } from '../notifications/alert';
 import { createLogger } from '../utils/logger';
+import { CLOUDFLARE_CHALLENGE_SELECTORS } from '../utils/cloudflare';
 
 const log = createLogger('HeadlessManager');
 
@@ -21,10 +22,7 @@ const CAPTCHA_SELECTORS = [
   '.h-captcha',
   '#captcha',
   '[class*="captcha"]',
-  'iframe[src*="challenges.cloudflare.com"]',
-  '#challenge-running',
-  '#challenge-form',
-  '.cf-browser-verification',
+  ...CLOUDFLARE_CHALLENGE_SELECTORS,
 ];
 
 // ─── Types ──────────────────────────────────────────────────────────

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,8 +45,22 @@ import type { PendingTabRegister, RuntimeManagers } from './bootstrap/types';
 import { isGoogleAuthUrl, shouldSkipStealth, pathnameMatchesPrefix, tryParseUrl, urlHasProtocol, hostnameMatches } from './utils/security';
 import { readConfigFileSync } from './config/io';
 import { resolveInitialTheme, buildThemeAdditionalArg, toNativeThemeSource, type ResolvedTheme } from './theme/resolver';
+import { CloudflarePolicyManager } from './cloudflare/policy-manager';
+import {
+  CLOUDFLARE_CHALLENGE_SELECTORS,
+  getCloudflareNoTouchPartition,
+  isCloudflareChallengeUrl,
+  isCloudflareNoTouchPartition,
+  responseHeadersContainCfClearance,
+} from './utils/cloudflare';
 
 const log = createLogger('Main');
+const CLOUDFLARE_POLICY_SYNC_CHANNEL = 'tandem:cloudflare-policy-sync';
+const CLOUDFLARE_INTERSTITIAL_TITLE_SNIPPETS = [
+  'just a moment',
+  'attention required',
+  'please wait',
+];
 
 const IS_DEV = process.argv.includes('--dev');
 
@@ -54,6 +68,10 @@ let mainWindow: BrowserWindow | null = null;
 let api: TandemAPI | null = null;
 let runtime: RuntimeManagers | null = null;
 let dispatcher: RequestDispatcher | null = null;
+let cloudflarePolicyManager: CloudflarePolicyManager | null = null;
+const earlyOopifStealthRegistered = new Set<number>();
+const cloudflareNoTouchPartitions = new Set<string>();
+const cloudflareNoTouchReroutes = new Set<number>();
 let cookieFlushTimer: ReturnType<typeof setInterval> | null = null;
 /** Queue webview webContents created before contextMenuManager is ready */
 const pendingContextMenuWebContents: WebContents[] = [];
@@ -68,6 +86,14 @@ function registerEarlyShellAuthIpc(): void {
     } catch {
       return '';
     }
+  });
+}
+
+function registerEarlyCloudflarePolicyIpc(): void {
+  ipcMain.removeAllListeners(CLOUDFLARE_POLICY_SYNC_CHANNEL);
+  ipcMain.on(CLOUDFLARE_POLICY_SYNC_CHANNEL, (event, rawUrl: string) => {
+    const url = typeof rawUrl === 'string' ? rawUrl : '';
+    event.returnValue = cloudflarePolicyManager?.getStealthDispositionForUrl(url) ?? 'full';
   });
 }
 
@@ -148,6 +174,11 @@ function clearStartApiIpcListeners(): void {
 }
 
 function queueSecurityCoverage(webContentsId: number): void {
+  if (cloudflarePolicyManager?.isChallengeSensitiveTab(webContentsId)) {
+    log.info(`☁️ Refusing security coverage queue for challenge-sensitive tab ${webContentsId}`);
+    return;
+  }
+
   if (runtime?.securityManager) {
     runtime.securityManager.onTabCreated(webContentsId).catch(e => log.warn('securityManager.onTabCreated failed:', e instanceof Error ? e.message : e));
     return;
@@ -156,6 +187,23 @@ function queueSecurityCoverage(webContentsId: number): void {
   if (!pendingSecurityCoverageWebContentsIds.includes(webContentsId)) {
     pendingSecurityCoverageWebContentsIds.push(webContentsId);
   }
+}
+
+function isCloudflareNoTouchWebContents(contents: WebContents): boolean {
+  const trackedPartition = runtime?.tabManager
+    .listTabs()
+    .find((tab) => tab.webContentsId === contents.id)?.partition ?? null;
+  if (trackedPartition && isCloudflareNoTouchPartition(trackedPartition)) {
+    return true;
+  }
+
+  for (const partition of cloudflareNoTouchPartitions) {
+    if (contents.session === session.fromPartition(partition)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function teardown(): void {
@@ -175,15 +223,182 @@ function teardown(): void {
   dispatcher = null;
 }
 
+async function probeCloudflareChallengeSurface(contents: WebContents): Promise<boolean> {
+  if (!cloudflarePolicyManager || contents.isDestroyed()) {
+    return false;
+  }
+
+  const title = contents.getTitle().trim().toLowerCase();
+  if (title && CLOUDFLARE_INTERSTITIAL_TITLE_SNIPPETS.some((snippet) => title.includes(snippet))) {
+    cloudflarePolicyManager.markChallengeDetected(contents.id, contents.getURL() || null, 'title:interstitial');
+    return true;
+  }
+
+  try {
+    const detected = await contents.executeJavaScript(`
+      (() => {
+        const selectors = ${JSON.stringify(CLOUDFLARE_CHALLENGE_SELECTORS)};
+        return selectors.some((selector) => !!document.querySelector(selector));
+      })()
+    `) as boolean;
+
+    if (detected) {
+      cloudflarePolicyManager.markChallengeDetected(contents.id, contents.getURL() || null, 'dom:selectors');
+      return true;
+    }
+  } catch {
+    // DOM probe is best-effort only.
+  }
+
+  return cloudflarePolicyManager.isChallengeSensitiveTab(contents.id);
+}
+
+async function registerEarlyOopifStealth(contents: WebContents, earlyScript: string): Promise<void> {
+  if (contents.isDestroyed()) return;
+  if (earlyOopifStealthRegistered.has(contents.id)) return;
+
+  const currentUrl = contents.getURL();
+  if (currentUrl && (isGoogleAuthUrl(currentUrl) || shouldSkipStealth(currentUrl))) {
+    return;
+  }
+  if (cloudflarePolicyManager?.isChallengeSensitiveTab(contents.id)) {
+    log.info(`☁️ Skipping CDP OOPIF early stealth attach for challenge-sensitive tab ${contents.id}`);
+    return;
+  }
+  if (isCloudflareNoTouchWebContents(contents)) {
+    log.info(`☁️ Skipping CDP OOPIF early stealth attach for no-touch tab ${contents.id}`);
+    return;
+  }
+
+  try {
+    if (!contents.debugger.isAttached()) {
+      contents.debugger.attach('1.3');
+    }
+    await contents.debugger.sendCommand('Page.addScriptToEvaluateOnNewDocument', {
+      source: earlyScript,
+    });
+    earlyOopifStealthRegistered.add(contents.id);
+    log.info(`🛡️ CDP OOPIF early stealth injection registered for wc ${contents.id}`);
+  } catch (e) {
+    if (!contents.isDestroyed() && contents.debugger.isAttached()) {
+      contents.debugger.sendCommand('Page.addScriptToEvaluateOnNewDocument', {
+        source: earlyScript,
+      }).then(() => {
+        earlyOopifStealthRegistered.add(contents.id);
+        log.info(`🛡️ CDP OOPIF early stealth injection registered via shared session for wc ${contents.id}`);
+      }).catch(e2 => log.warn(`CDP stealth shared-session failed for wc ${contents.id}:`, e2 instanceof Error ? e2.message : e2));
+    } else {
+      log.warn(`CDP OOPIF stealth attach failed for wc ${contents.id}:`, e instanceof Error ? e.message : e);
+    }
+  }
+}
+
+async function promoteTabToCloudflareNoTouchSession(webContentsId: number, preferredUrl: string | null): Promise<void> {
+  if (!runtime?.tabManager || !runtime.workspaceManager) {
+    return;
+  }
+  if (cloudflareNoTouchReroutes.has(webContentsId)) {
+    return;
+  }
+
+  const sourceTab = runtime.tabManager.listTabs().find((tab) => tab.webContentsId === webContentsId) ?? null;
+  if (!sourceTab) {
+    return;
+  }
+  if (isCloudflareNoTouchPartition(sourceTab.partition)) {
+    return;
+  }
+
+  const targetUrl = preferredUrl || sourceTab.url || null;
+  const targetPartition = targetUrl ? getCloudflareNoTouchPartition(targetUrl) : null;
+  if (!targetUrl || !targetPartition) {
+    return;
+  }
+
+  cloudflareNoTouchReroutes.add(webContentsId);
+  cloudflareNoTouchPartitions.add(targetPartition);
+
+  try {
+    const existingReplacement = runtime.tabManager.listTabs().find((tab) =>
+      tab.webContentsId !== webContentsId &&
+      tab.partition === targetPartition &&
+      tab.url === targetUrl
+    ) ?? null;
+
+    const workspaceId = runtime.workspaceManager.getWorkspaceIdForTab(webContentsId);
+
+    if (existingReplacement) {
+      if (workspaceId) {
+        runtime.workspaceManager.moveTab(existingReplacement.webContentsId, workspaceId);
+      }
+      await runtime.tabManager.focusTab(existingReplacement.id);
+      await runtime.tabManager.closeTab(sourceTab.id);
+      log.info(`☁️ Reused existing no-touch tab ${existingReplacement.webContentsId} for Cloudflare challenge on wc ${webContentsId}`);
+      return;
+    }
+
+    log.info(`☁️ Reopening Cloudflare tab ${webContentsId} in no-touch partition ${targetPartition}`);
+    const replacementTab = await runtime.tabManager.openTab(
+      targetUrl,
+      sourceTab.groupId ?? undefined,
+      sourceTab.source,
+      targetPartition,
+      true,
+    );
+
+    if (workspaceId) {
+      runtime.workspaceManager.moveTab(replacementTab.webContentsId, workspaceId);
+    }
+    if (sourceTab.pinned) {
+      runtime.tabManager.pinTab(replacementTab.id);
+    }
+    if (sourceTab.emoji) {
+      if (sourceTab.emojiFlash) {
+        runtime.tabManager.flashEmoji(replacementTab.id, sourceTab.emoji);
+      } else {
+        runtime.tabManager.setEmoji(replacementTab.id, sourceTab.emoji);
+      }
+    }
+
+    await runtime.tabManager.closeTab(sourceTab.id);
+  } catch (e) {
+    log.warn(`Cloudflare no-touch reroute failed for wc ${webContentsId}:`, e instanceof Error ? e.message : e);
+  } finally {
+    cloudflareNoTouchReroutes.delete(webContentsId);
+  }
+}
+
 async function createWindow(): Promise<BrowserWindow> {
   registerEarlyShellAuthIpc();
+  registerEarlyCloudflarePolicyIpc();
   registerEarlyTabRegisterIpc();
 
   const partition = DEFAULT_PARTITION;
   const ses = session.fromPartition(partition);
 
+  if (!cloudflarePolicyManager) {
+    cloudflarePolicyManager = new CloudflarePolicyManager();
+    cloudflarePolicyManager.on('challenge-detected', (event) => {
+      log.info(`☁️ Cloudflare challenge detected (${event.signal}) for ${event.origin ?? event.url ?? 'unknown origin'}`);
+      if (typeof event.webContentsId === 'number') {
+        runtime?.securityManager.onCloudflarePolicyChanged(event.webContentsId).catch(e => {
+          log.warn('securityManager.onCloudflarePolicyChanged failed:', e instanceof Error ? e.message : e);
+        });
+        void promoteTabToCloudflareNoTouchSession(event.webContentsId, event.url ?? null);
+      }
+    });
+    cloudflarePolicyManager.on('clearance-seen', (event) => {
+      log.info(`☁️ Cloudflare clearance seen (${event.signal}) for ${event.origin ?? event.url ?? 'unknown origin'}`);
+      if (typeof event.webContentsId === 'number') {
+        runtime?.securityManager.onCloudflarePolicyChanged(event.webContentsId).catch(e => {
+          log.warn('securityManager.onCloudflarePolicyChanged failed:', e instanceof Error ? e.message : e);
+        });
+      }
+    });
+  }
+
   const stealth = new StealthManager(ses, partition);
-  await stealth.apply();
+  await stealth.apply({ cloudflarePolicySyncChannel: CLOUDFLARE_POLICY_SYNC_CHANNEL });
 
   // Create RequestDispatcher — central hub for all webRequest hooks
   dispatcher = new RequestDispatcher(ses);
@@ -223,6 +438,10 @@ async function createWindow(): Promise<BrowserWindow> {
   // (e.g. cookies set via document.cookie or already present before the handler was attached)
   ses.cookies.on('changed', (_event, cookie, _cause, removed) => {
     if (removed) return;
+    if (cookie.name.toLowerCase() === 'cf_clearance') {
+      const cookieUrl = `https://${cookie.domain?.replace(/^\./, '') || 'unknown'}${cookie.path || '/'}`;
+      cloudflarePolicyManager?.markClearanceSeen(null, cookieUrl, 'cookies:changed');
+    }
     if (cookie.sameSite === 'no_restriction' && !cookie.secure) {
       const url = `https://${cookie.domain?.replace(/^\./, '') || 'unknown'}${cookie.path || '/'}`;
       ses.cookies.set({
@@ -282,6 +501,37 @@ async function createWindow(): Promise<BrowserWindow> {
     }
   });
 
+  dispatcher.registerHeadersReceived({
+    name: 'CloudflarePolicy',
+    priority: 80,
+    handler: (details, responseHeaders) => {
+      cloudflarePolicyManager?.recordUrlSignal(
+        typeof details.webContentsId === 'number' ? details.webContentsId : null,
+        details.url || null,
+        'headers:url',
+      );
+      if (responseHeadersContainCfClearance(responseHeaders)) {
+        cloudflarePolicyManager?.markClearanceSeen(
+          typeof details.webContentsId === 'number' ? details.webContentsId : null,
+          details.url || null,
+          'headers:set-cookie',
+        );
+      }
+      return responseHeaders;
+    }
+  });
+
+  dispatcher.registerBeforeRedirect({
+    name: 'CloudflareRedirectPolicy',
+    handler: (details) => {
+      cloudflarePolicyManager?.recordUrlSignal(
+        typeof details.webContentsId === 'number' ? details.webContentsId : null,
+        details.redirectURL || null,
+        'redirect:url',
+      );
+    }
+  });
+
   // Attach dispatcher — activates all hooks with current consumers
   dispatcher.attach();
 
@@ -309,55 +559,48 @@ async function createWindow(): Promise<BrowserWindow> {
     );
 
     if (contents.getType() === 'webview') {
-      // === CDP-based OOPIF stealth injection ===
-      // session.setPreloads() only executes in the WebContents *main* frame.
-      // Cross-origin subframes (OOPIFs) — e.g. Cloudflare's Turnstile iframe at
-      // challenges.cloudflare.com — run in separate renderer processes and never
-      // receive that preload. CDP's Page.addScriptToEvaluateOnNewDocument runs
-      // BEFORE any scripts in EVERY frame upon creation, including OOPIFs.
-      // This is the same mechanism Chromium uses internally for content scripts.
-      // We eagerly attach here (before the first navigation) so the registration
-      // is in place when the renderer processes are later spawned.
-      if (!isSidebarWebview) {
+      contents.on('did-navigate', (_event, url) => {
+        if (url && !url.startsWith('about:') && !url.startsWith('data:')) {
+          cloudflarePolicyManager?.onMainFrameNavigation(contents.id, url);
+          cloudflarePolicyManager?.recordUrlSignal(contents.id, url, 'main-frame:url');
+        }
+      });
+
+      contents.on('dom-ready', () => {
         void (async () => {
-          if (contents.isDestroyed()) return;
-          try {
-            if (!contents.debugger.isAttached()) {
-              contents.debugger.attach('1.3');
+          // Skip stealth injection on sites that detect and block stealth patches
+          const url = contents.getURL();
+          if (url && !url.startsWith('about:') && !url.startsWith('data:')) {
+            cloudflarePolicyManager?.onMainFrameNavigation(contents.id, url);
+            cloudflarePolicyManager?.recordUrlSignal(contents.id, url, 'dom-ready:url');
+          }
+          const noTouchPartition = isCloudflareNoTouchWebContents(contents);
+          const challengeSensitive = await probeCloudflareChallengeSurface(contents);
+          if (isGoogleAuthUrl(url) || shouldSkipStealth(url)) {
+            log.info('🔑 Skipping stealth for:', url.substring(0, 60));
+            return;
+          }
+          if (noTouchPartition) {
+            log.info(`☁️ No-touch partition active for tab ${contents.id}; skipping stealth and security hooks`);
+            return;
+          }
+          if (!challengeSensitive) {
+            if (!isSidebarWebview) {
+              await registerEarlyOopifStealth(contents, earlyScript);
             }
-            // Use the minimal early script (no canvas/audio/timing noise) so it is
-            // safe inside Cloudflare's sandboxed Turnstile OOPIF — the full stealth
-            // script's ctx.getImageData() call triggers GPU readback IPC that causes
-            // a V8 crash inside challenges.cloudflare.com renderer.
-            await contents.debugger.sendCommand('Page.addScriptToEvaluateOnNewDocument', {
-              source: earlyScript,
-            });
-            log.info('🛡️ CDP OOPIF early stealth injection registered');
-          } catch (e) {
-            // DevToolsManager may have already attached — try using its session
-            if (!contents.isDestroyed() && contents.debugger.isAttached()) {
-              contents.debugger.sendCommand('Page.addScriptToEvaluateOnNewDocument', {
-                source: earlyScript,
-              }).catch(e2 => log.warn('CDP stealth shared-session failed:', e2 instanceof Error ? e2.message : e2));
+            contents.executeJavaScript(stealthScript).catch((e) => log.warn('Stealth script injection failed:', e.message));
+          } else {
+            log.info(`☁️ Skipping full stealth for challenge-sensitive tab ${contents.id}`);
+          }
+
+          if (!isSidebarWebview) {
+            if (!challengeSensitive) {
+              queueSecurityCoverage(contents.id);
             } else {
-              log.warn('CDP OOPIF stealth attach failed:', e instanceof Error ? e.message : e);
+              log.info(`☁️ Skipping security coverage queue for challenge-sensitive tab ${contents.id}`);
             }
           }
         })();
-      }
-
-      contents.on('dom-ready', () => {
-        // Skip stealth injection on sites that detect and block stealth patches
-        const url = contents.getURL();
-        if (isGoogleAuthUrl(url) || shouldSkipStealth(url)) {
-          log.info('🔑 Skipping stealth for:', url.substring(0, 60));
-          return;
-        }
-        contents.executeJavaScript(stealthScript).catch((e) => log.warn('Stealth script injection failed:', e.message));
-
-        if (!isSidebarWebview) {
-          queueSecurityCoverage(contents.id);
-        }
       });
 
       // did-frame-navigate: late-injection fallback for same-origin subframes.
@@ -367,13 +610,24 @@ async function createWindow(): Promise<BrowserWindow> {
       contents.on('did-frame-navigate', (
         _event, url, _httpCode, _httpText, isMainFrame
       ) => {
+        const noTouchPartition = isCloudflareNoTouchWebContents(contents);
+        if (url && !url.startsWith('about:') && !url.startsWith('data:')) {
+          if (isMainFrame) {
+            cloudflarePolicyManager?.onMainFrameNavigation(contents.id, url);
+            cloudflarePolicyManager?.recordUrlSignal(contents.id, url, 'frame:main-url');
+          } else if (isCloudflareChallengeUrl(url)) {
+            cloudflarePolicyManager?.markChallengeDetected(contents.id, url, 'frame:subframe-url');
+          }
+        }
         if (isMainFrame) return; // main frame handled by dom-ready above
         if (!url || url.startsWith('about:') || url.startsWith('data:')) return;
         if (isGoogleAuthUrl(url)) return; // never touch Google auth iframes
+        if (noTouchPartition) return;
         // Skip Cloudflare challenge OOPIF — the full stealth script (canvas noise,
         // timing reduction) causes Turnstile to score the browser as bot. The minimal
         // CDP early script already runs there and patches userAgentData/webdriver.
         if (shouldSkipStealth(url)) return;
+        if (cloudflarePolicyManager?.isChallengeSensitiveTab(contents.id)) return;
 
         // Walk the frame tree and inject into every non-Google, non-challenge subframe
         const injectFrame = (frame: { url: string; frames: typeof frame[]; executeJavaScript: (s: string) => Promise<unknown> }) => {
@@ -413,10 +667,23 @@ async function createWindow(): Promise<BrowserWindow> {
 
       if (!isSidebarWebview) {
         contents.on('did-finish-load', () => {
-          runtime?.securityManager.onTabNavigated(contents.id).catch(e => log.warn('securityManager.onTabNavigated failed:', e instanceof Error ? e.message : e));
+          void (async () => {
+            if (isCloudflareNoTouchWebContents(contents)) {
+              log.info(`☁️ Skipping security onTabNavigated for no-touch tab ${contents.id}`);
+              return;
+            }
+            const challengeSensitive = await probeCloudflareChallengeSurface(contents);
+            if (challengeSensitive) {
+              log.info(`☁️ Skipping security onTabNavigated for challenge-sensitive tab ${contents.id}`);
+              return;
+            }
+            runtime?.securityManager.onTabNavigated(contents.id).catch(e => log.warn('securityManager.onTabNavigated failed:', e instanceof Error ? e.message : e));
+          })();
         });
 
         contents.on('destroyed', () => {
+          earlyOopifStealthRegistered.delete(contents.id);
+          cloudflarePolicyManager?.onTabClosed(contents.id);
           runtime?.securityManager.onTabClosed(contents.id);
         });
       }
@@ -608,6 +875,7 @@ async function startAPI(win: BrowserWindow): Promise<void> {
   runtime = await initializeRuntimeManagers({
     win,
     dispatcher,
+    cloudflarePolicyManager: cloudflarePolicyManager ?? new CloudflarePolicyManager(),
     pendingContextMenuWebContents,
     pendingSecurityCoverageWebContentsIds,
     canUseWindow,

--- a/src/main.ts
+++ b/src/main.ts
@@ -370,11 +370,15 @@ async function createWindow(): Promise<BrowserWindow> {
         if (isMainFrame) return; // main frame handled by dom-ready above
         if (!url || url.startsWith('about:') || url.startsWith('data:')) return;
         if (isGoogleAuthUrl(url)) return; // never touch Google auth iframes
+        // Skip Cloudflare challenge OOPIF — the full stealth script (canvas noise,
+        // timing reduction) causes Turnstile to score the browser as bot. The minimal
+        // CDP early script already runs there and patches userAgentData/webdriver.
+        if (shouldSkipStealth(url)) return;
 
-        // Walk the frame tree and inject into every non-Google subframe
+        // Walk the frame tree and inject into every non-Google, non-challenge subframe
         const injectFrame = (frame: { url: string; frames: typeof frame[]; executeJavaScript: (s: string) => Promise<unknown> }) => {
           const frameUrl = frame.url || '';
-          if (!isGoogleAuthUrl(frameUrl)) {
+          if (!isGoogleAuthUrl(frameUrl) && !shouldSkipStealth(frameUrl)) {
             frame.executeJavaScript(stealthScript)
               .catch(() => { /* frame may have navigated away or be restricted */ });
           }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -52,6 +52,7 @@ import type { PinboardManager } from './pinboards/manager';
 import type { ClipboardManager } from './clipboard/manager';
 import type { GooglePhotosManager } from './integrations/google-photos';
 import type { PairingManager } from './pairing/manager';
+import type { CloudflarePolicyManager } from './cloudflare/policy-manager';
 
 export interface ManagerRegistry {
   /** Tab lifecycle, grouping, metadata, and focus tracking. See src/tabs/manager.ts */
@@ -150,4 +151,6 @@ export interface ManagerRegistry {
   pairingManager: PairingManager;
   /** Per-agent trust tiers (T2 windows, T3 trusted domains, T4 global window) layered over approval gates. See src/security/agent-trust.ts */
   agentTrust: AgentTrustStore;
+  /** Tab/origin-scoped Cloudflare challenge policy state. See src/cloudflare/policy-manager.ts */
+  cloudflarePolicyManager: CloudflarePolicyManager;
 }

--- a/src/security/behavior-monitor.ts
+++ b/src/security/behavior-monitor.ts
@@ -62,6 +62,7 @@ export class BehaviorMonitor {
   private guardian: Guardian;
   private devToolsManager: DevToolsManager;
   private scriptGuard: ScriptGuard | null = null;
+  private shouldMonitorTab: ((wcId: number) => boolean) | null = null;
   private permissionLog: PermissionRecord[] = [];
   private tabStates: Map<number, BehaviorTabState> = new Map();
   onCriticalDetection: ((detection: BehaviorCriticalDetection) => void) | null = null;
@@ -75,6 +76,11 @@ export class BehaviorMonitor {
   /** Set ScriptGuard reference for WASM event correlation */
   setScriptGuard(scriptGuard: ScriptGuard): void {
     this.scriptGuard = scriptGuard;
+  }
+
+  /** Set a runtime gate for whether resource monitoring may run on a tab. */
+  setMonitoringGate(shouldMonitorTab: ((wcId: number) => boolean) | null): void {
+    this.shouldMonitorTab = shouldMonitorTab;
   }
 
   /**
@@ -156,6 +162,13 @@ export class BehaviorMonitor {
     if (!resolvedWcId) return;
 
     const state = this.getOrCreateTabState(resolvedWcId);
+
+    if (this.shouldMonitorTab && !this.shouldMonitorTab(resolvedWcId)) {
+      if (state.cpuCheckInterval) {
+        this.stopResourceMonitoring(resolvedWcId);
+      }
+      return;
+    }
 
     // Guard: if already running, don't restart (prevents double-start on repeated lifecycle calls)
     if (state.cpuCheckInterval) return;

--- a/src/security/script-guard.ts
+++ b/src/security/script-guard.ts
@@ -848,7 +848,7 @@ export class ScriptGuard {
       }
 
       state.monitorInjected = true;
-      log.info('Security monitors injected (main-world monitor + isolated-world bridge)');
+      log.info(`Security monitors injected (main-world monitor + isolated-world bridge) for wc ${resolvedWcId}`);
     } catch (e) {
       log.warn('Monitor injection failed:', e instanceof Error ? e.message : String(e));
     }

--- a/src/security/security-manager.ts
+++ b/src/security/security-manager.ts
@@ -15,6 +15,7 @@ import { ThreatIntel } from './threat-intel';
 import { BlocklistUpdater } from './blocklists/updater';
 import { AnalyzerManager } from './analyzer-manager';
 import { EventBurstAnalyzer } from './analyzers/example-analyzer';
+import type { CloudflarePolicyManager } from '../cloudflare/policy-manager';
 import type { PageMetrics} from './types';
 import { AnalysisConfidence, BLOCKLIST_REFRESH_INTERVALS_MS } from './types';
 import { createLogger } from '../utils/logger';
@@ -71,6 +72,7 @@ export class SecurityManager {
   private contentAnalyzer: ContentAnalyzer | null = null;
   private behaviorMonitor: BehaviorMonitor | null = null;
   private devToolsManager: DevToolsManager | null = null;
+  private cloudflarePolicyManager: CloudflarePolicyManager | null = null;
 
   // Phase 4: AI Gatekeeper Agent (initialized lazily via initGatekeeper)
   private gatekeeperWs: GatekeeperWebSocket | null = null;
@@ -191,12 +193,18 @@ export class SecurityManager {
     dispatcher?: RequestDispatcher;
     devToolsManager: DevToolsManager;
     session: Session;
+    cloudflarePolicyManager?: CloudflarePolicyManager;
   }): void {
     if (deps.dispatcher) {
       this.registerWith(deps.dispatcher);
     }
+    this.setCloudflarePolicyManager(deps.cloudflarePolicyManager ?? null);
     this.setDevToolsManager(deps.devToolsManager);
     this.setupPermissionHandler(deps.session);
+  }
+
+  setCloudflarePolicyManager(cloudflarePolicyManager: CloudflarePolicyManager | null): void {
+    this.cloudflarePolicyManager = cloudflarePolicyManager;
   }
 
   /** Register the Guardian's request interceptors with the network dispatcher. */
@@ -225,6 +233,7 @@ export class SecurityManager {
     });
     this.behaviorMonitor = new BehaviorMonitor(this.db, this.guardian, devToolsManager);
     this.behaviorMonitor.setScriptGuard(this.scriptGuard);
+    this.behaviorMonitor.setMonitoringGate((wcId) => !this.isChallengeSensitiveTab(wcId));
     this.behaviorMonitor.onCriticalDetection = (detection) => {
       void this.handleBehaviorCriticalDetection(detection);
     };
@@ -297,6 +306,24 @@ export class SecurityManager {
     this.devToolsManager?.detachFromTab(wcId);
     this.guardian.releaseWebContentsQuarantine(wcId);
     this.tabStates.delete(wcId);
+  }
+
+  /**
+   * Re-apply security coverage after Cloudflare policy changes on an attached tab.
+   * Challenge-sensitive tabs are reduced to minimal coverage, while other tabs
+   * keep the existing behavior.
+   */
+  async onCloudflarePolicyChanged(wcId: number): Promise<void> {
+    const state = this.getOrCreateTabState(wcId);
+    if (this.isChallengeSensitiveTab(wcId)) {
+      this.deescalateTabCoverage(wcId);
+      return;
+    }
+
+    await this.ensureTabCoverage(wcId, {
+      fullMonitoring: state.resourceMonitoringActive,
+      makePrimary: false,
+    });
   }
 
   /**
@@ -683,6 +710,11 @@ export class SecurityManager {
       state.lastUrl = wc.getURL();
       state.strictModePolicy = this.getStrictModeForUrl(state.lastUrl);
 
+      if (this.isChallengeSensitiveTab(wcId, state.lastUrl)) {
+        this.deescalateTabCoverage(wcId);
+        return;
+      }
+
       await this.devToolsManager.enableSecurityDomains(wcId);
 
       await this.scriptGuard?.injectMonitors(wcId);
@@ -699,6 +731,16 @@ export class SecurityManager {
     } catch (e) {
       log.warn('ensureTabCoverage error:', e instanceof Error ? e.message : String(e));
     }
+  }
+
+  private deescalateTabCoverage(wcId: number): void {
+    this.behaviorMonitor?.stopResourceMonitoring(wcId);
+    this.behaviorMonitor?.reset(wcId);
+    this.scriptGuard?.reset(wcId);
+
+    const state = this.getOrCreateTabState(wcId);
+    state.monitorsInjected = false;
+    state.resourceMonitoringActive = false;
   }
 
   private resetTabRuntime(wcId: number): void {
@@ -731,5 +773,21 @@ export class SecurityManager {
     } catch {
       return false;
     }
+  }
+
+  private isChallengeSensitiveTab(wcId: number, url?: string | null): boolean {
+    if (!this.cloudflarePolicyManager) {
+      return false;
+    }
+
+    if (this.cloudflarePolicyManager.isChallengeSensitiveTab(wcId)) {
+      return true;
+    }
+
+    if (!url) {
+      return false;
+    }
+
+    return this.cloudflarePolicyManager.getStealthDispositionForUrl(url) === 'early';
   }
 }

--- a/src/security/tests/security-manager-cloudflare.test.ts
+++ b/src/security/tests/security-manager-cloudflare.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SecurityManager } from '../security-manager';
+import { CloudflarePolicyManager } from '../../cloudflare/policy-manager';
+
+type MockWebContents = {
+  getURL: ReturnType<typeof vi.fn>;
+};
+
+function createSubject() {
+  const sm = Object.create(SecurityManager.prototype) as SecurityManager & Record<string, any>;
+  const cloudflarePolicyManager = new CloudflarePolicyManager();
+  const wc: MockWebContents = {
+    getURL: vi.fn().mockReturnValue('https://example.com/login'),
+  };
+  const devToolsManager = {
+    attachToTab: vi.fn().mockResolvedValue(wc),
+    enableSecurityDomains: vi.fn().mockResolvedValue(undefined),
+    detachFromTab: vi.fn(),
+  };
+  const scriptGuard = {
+    injectMonitors: vi.fn().mockResolvedValue(undefined),
+    hasMonitorsInjected: vi.fn().mockReturnValue(true),
+    reset: vi.fn(),
+    clearTab: vi.fn(),
+  };
+  const behaviorMonitor = {
+    startResourceMonitoring: vi.fn(),
+    isResourceMonitoringActive: vi.fn().mockReturnValue(true),
+    stopResourceMonitoring: vi.fn(),
+    reset: vi.fn(),
+    clearTab: vi.fn(),
+  };
+  const guardian = {
+    getModeForDomain: vi.fn().mockReturnValue('balanced'),
+    releaseWebContentsQuarantine: vi.fn(),
+  };
+
+  sm.devToolsManager = devToolsManager;
+  sm.cloudflarePolicyManager = cloudflarePolicyManager;
+  sm.scriptGuard = scriptGuard;
+  sm.behaviorMonitor = behaviorMonitor;
+  sm.guardian = guardian;
+  sm.tabStates = new Map();
+
+  return {
+    sm,
+    wc,
+    devToolsManager,
+    cloudflarePolicyManager,
+    scriptGuard,
+    behaviorMonitor,
+    guardian,
+  };
+}
+
+describe('SecurityManager Cloudflare gating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('skips monitor injection and resource monitoring on challenge-sensitive tabs', async () => {
+    const {
+      sm,
+      cloudflarePolicyManager,
+      devToolsManager,
+      scriptGuard,
+      behaviorMonitor,
+    } = createSubject();
+
+    cloudflarePolicyManager.onMainFrameNavigation(5, 'https://example.com/login');
+    cloudflarePolicyManager.markChallengeDetected(
+      5,
+      'https://challenges.cloudflare.com/turnstile/v0/b/api.js',
+      'test',
+    );
+
+    await sm['ensureTabCoverage'](5, { fullMonitoring: true, makePrimary: false });
+
+    expect(devToolsManager.attachToTab).toHaveBeenCalledWith(5, { makePrimary: false });
+    expect(devToolsManager.enableSecurityDomains).not.toHaveBeenCalled();
+    expect(scriptGuard.injectMonitors).not.toHaveBeenCalled();
+    expect(behaviorMonitor.startResourceMonitoring).not.toHaveBeenCalled();
+    expect(behaviorMonitor.stopResourceMonitoring).toHaveBeenCalledWith(5);
+    expect(scriptGuard.reset).toHaveBeenCalledWith(5);
+  });
+
+  it('de-escalates an existing tab when Cloudflare policy flips to challenge-sensitive', async () => {
+    const {
+      sm,
+      cloudflarePolicyManager,
+      scriptGuard,
+      behaviorMonitor,
+    } = createSubject();
+
+    sm['tabStates'].set(9, {
+      cdpAttached: true,
+      monitorsInjected: true,
+      resourceMonitoringActive: true,
+      strictModePolicy: false,
+      lastUrl: 'https://example.com/login',
+    });
+
+    cloudflarePolicyManager.onMainFrameNavigation(9, 'https://example.com/login');
+    cloudflarePolicyManager.markChallengeDetected(
+      9,
+      'https://challenges.cloudflare.com/turnstile/v0/b/api.js',
+      'headers:url',
+    );
+
+    await sm.onCloudflarePolicyChanged(9);
+
+    expect(behaviorMonitor.stopResourceMonitoring).toHaveBeenCalledWith(9);
+    expect(behaviorMonitor.reset).toHaveBeenCalledWith(9);
+    expect(scriptGuard.reset).toHaveBeenCalledWith(9);
+    expect(sm['tabStates'].get(9)).toMatchObject({
+      monitorsInjected: false,
+      resourceMonitoringActive: false,
+    });
+  });
+});

--- a/src/stealth/manager.ts
+++ b/src/stealth/manager.ts
@@ -93,7 +93,7 @@ export class StealthManager {
   // === 4. Public methods ===
 
   /** Apply stealth patches to the Electron session (User-Agent override). */
-  async apply(): Promise<void> {
+  async apply(options?: { cloudflarePolicySyncChannel?: string }): Promise<void> {
     // Set realistic User-Agent globally (LinkedIn etc. block "Electron" UA)
     // Google auth is excluded via the onBeforeSendHeaders handler in registerWith()
     this.session.setUserAgent(this.USER_AGENT);
@@ -104,7 +104,7 @@ export class StealthManager {
     // the top-level webContents only reaches the main frame; session.setPreloads()
     // runs the script in each renderer process (including OOPIF) BEFORE any page
     // scripts, so navigator.userAgentData and other APIs are patched early enough.
-    await this.writeAndRegisterPreload();
+    await this.writeAndRegisterPreload(options?.cloudflarePolicySyncChannel);
 
     log.info('🛡️ Stealth patches applied (advanced fingerprint protection active)');
   }
@@ -114,23 +114,45 @@ export class StealthManager {
    * The preload uses webFrame.executeJavaScriptInIsolatedWorld(0, ...) to
    * run the stealth patches in world 0 (the main/page world) before any page
    * scripts, for every frame including cross-origin iframes.
+   *
+   * Three cases:
+   *   • file:// or Google auth  → skip entirely (Tandem shell UI / OAuth)
+   *   • challenges.cloudflare.com → inject early script only (no canvas/audio/timing noise)
+   *   • everything else           → inject full stealth script
+   *
+   * Using the preload path (rather than CDP Page.addScriptToEvaluateOnNewDocument)
+   * is the only guaranteed way to reach cross-origin OOPIFs in Electron: the
+   * type:'frame' preload runs inside the OOPIF's own renderer process, before
+   * any of the frame's scripts. CDP's addScriptToEvaluateOnNewDocument may not
+   * propagate to cross-process iframes depending on the Electron / Chromium version.
    */
-  private async writeAndRegisterPreload(): Promise<void> {
+  private async writeAndRegisterPreload(cloudflarePolicySyncChannel?: string): Promise<void> {
     const stealthScript = StealthManager.getStealthScript(this.partitionSeed);
+    const earlyScript = StealthManager.getEarlyScript();
 
     // The preload runs in Electron's isolated renderer world.
     // executeJavaScriptInIsolatedWorld(0, ...) injects into world 0 = main page world,
     // running BEFORE the frame's own scripts because the preload executes first.
-    // We skip file:// (Tandem shell UI) and Google auth frames.
     const preloadContent = [
       `'use strict';`,
       `try {`,
       `  var _url = (typeof location !== 'undefined' && location.href) || '';`,
-      `  var _skip = _url.startsWith('file://') ||`,
-      `    /accounts\\.google\\.com|accounts-google\\.com|challenges\\.cloudflare\\.com/i.test(_url);`,
-      `  if (!_skip) {`,
-      `    var _wf = require('electron').webFrame;`,
-      `    _wf.executeJavaScriptInIsolatedWorld(0, [{ code: ${JSON.stringify(stealthScript)}, url: 'tandem://stealth' }]);`,
+      `  var _isFile      = _url.startsWith('file://');`,
+      `  var _isGoogleAuth = /accounts\\.google\\.com|accounts-google\\.com/i.test(_url);`,
+      `  var _isTurnstile  = /challenges\\.cloudflare\\.com/i.test(_url);`,
+      `  if (!_isFile && !_isGoogleAuth) {`,
+      `    var _electron = require('electron');`,
+      `    var _wf = _electron.webFrame;`,
+      `    var _mode = _isTurnstile ? 'early' : 'full';`,
+      cloudflarePolicySyncChannel
+        ? `    try { _mode = _electron.ipcRenderer.sendSync(${JSON.stringify(cloudflarePolicySyncChannel)}, _url) || _mode; } catch(e) { /* fall back to default mode */ }`
+        : `    /* no cloudflare policy sync channel configured */`,
+      `    if (_mode === 'early') {`,
+      `      // Minimal early patches only — no canvas/audio/timing noise that trips Turnstile`,
+      `      _wf.executeJavaScriptInIsolatedWorld(0, [{ code: ${JSON.stringify(earlyScript)}, url: 'tandem://stealth-early' }]);`,
+      `    } else if (_mode === 'full') {`,
+      `      _wf.executeJavaScriptInIsolatedWorld(0, [{ code: ${JSON.stringify(stealthScript)}, url: 'tandem://stealth' }]);`,
+      `    }`,
       `  }`,
       `} catch(e) { /* preload injection failed — ignored */ }`,
     ].join('\n');

--- a/src/stealth/manager.ts
+++ b/src/stealth/manager.ts
@@ -127,7 +127,7 @@ export class StealthManager {
       `try {`,
       `  var _url = (typeof location !== 'undefined' && location.href) || '';`,
       `  var _skip = _url.startsWith('file://') ||`,
-      `    /accounts\\.google\\.com|accounts-google\\.com/i.test(_url);`,
+      `    /accounts\\.google\\.com|accounts-google\\.com|challenges\\.cloudflare\\.com/i.test(_url);`,
       `  if (!_skip) {`,
       `    var _wf = require('electron').webFrame;`,
       `    _wf.executeJavaScriptInIsolatedWorld(0, [{ code: ${JSON.stringify(stealthScript)}, url: 'tandem://stealth' }]);`,

--- a/src/stealth/tests/manager.test.ts
+++ b/src/stealth/tests/manager.test.ts
@@ -16,11 +16,19 @@ vi.mock('fs', async () => {
     ...actual,
     default: {
       ...actual,
+      promises: {
+        ...((actual.default as { promises?: object } | undefined)?.promises ?? (actual as { promises?: object }).promises),
+        writeFile: vi.fn().mockResolvedValue(undefined),
+      },
       existsSync: vi.fn(),
       mkdirSync: vi.fn(),
       writeFileSync: vi.fn(),
       readFileSync: vi.fn(),
       chmodSync: vi.fn(),
+    },
+    promises: {
+      ...((actual as { promises?: object }).promises),
+      writeFile: vi.fn().mockResolvedValue(undefined),
     },
     existsSync: vi.fn(),
     mkdirSync: vi.fn(),
@@ -50,6 +58,7 @@ function makeMockSession() {
   return {
     getUserAgent: () => 'Electron/40',
     setUserAgent: vi.fn(),
+    registerPreloadScript: vi.fn(),
   } as unknown as Electron.Session;
 }
 
@@ -537,5 +546,33 @@ describe('getEarlyScript() — minimal OOPIF-safe stealth', () => {
     const script = StealthManager.getEarlyScript();
     // The test environment sets chrome to 132.0.6834.160 in beforeAll
     expect(script).toContain(process.versions.chrome);
+  });
+});
+
+describe('apply() — preload policy sync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('writes a preload that queries the cloudflare policy channel when configured', async () => {
+    const existing = 'd'.repeat(64);
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({ stealthInstallSecret: existing })
+    );
+
+    const session = makeMockSession() as unknown as {
+      setUserAgent: ReturnType<typeof vi.fn>;
+      registerPreloadScript: ReturnType<typeof vi.fn>;
+    };
+
+    const manager = new StealthManager(session as never, 'persist:tandem');
+    await manager.apply({ cloudflarePolicySyncChannel: 'tandem:cloudflare-policy-sync' });
+
+    expect(session.setUserAgent).toHaveBeenCalled();
+    expect(session.registerPreloadScript).toHaveBeenCalledTimes(1);
+    const writeCalls = vi.mocked(fs.promises.writeFile).mock.calls;
+    expect(writeCalls.length).toBeGreaterThan(0);
+    expect(String(writeCalls.at(-1)?.[1])).toContain('ipcRenderer.sendSync("tandem:cloudflare-policy-sync", _url)');
   });
 });

--- a/src/utils/cloudflare.ts
+++ b/src/utils/cloudflare.ts
@@ -1,0 +1,99 @@
+import crypto from 'crypto';
+
+const CLOUDFLARE_CHALLENGE_HOSTS = new Set([
+  'challenges.cloudflare.com',
+]);
+
+const CLOUDFLARE_CHALLENGE_PATH_PREFIXES = [
+  '/cdn-cgi/challenge-platform',
+];
+
+export const CLOUDFLARE_NO_TOUCH_PARTITION_PREFIX = 'persist:cf-human-';
+
+export const CLOUDFLARE_CHALLENGE_SELECTORS = [
+  'iframe[src*="challenges.cloudflare.com"]',
+  'script[src*="challenges.cloudflare.com/turnstile"]',
+  'script[src*="/cdn-cgi/challenge-platform/"]',
+  'input[name="cf-turnstile-response"]',
+  '#challenge-running',
+  '#challenge-form',
+  '.cf-browser-verification',
+  '.cf-challenge-running',
+] as const;
+
+function tryParseUrl(rawValue: string): URL | null {
+  try {
+    return new URL(rawValue);
+  } catch {
+    return null;
+  }
+}
+
+export function getOriginFromUrl(rawValue: string): string | null {
+  const parsed = tryParseUrl(rawValue);
+  return parsed?.origin ?? null;
+}
+
+export function getCloudflareNoTouchPartitionForOrigin(origin: string): string | null {
+  const normalizedOrigin = getOriginFromUrl(origin);
+  if (!normalizedOrigin) {
+    return null;
+  }
+
+  const suffix = crypto
+    .createHash('sha256')
+    .update(normalizedOrigin)
+    .digest('hex')
+    .slice(0, 16);
+  return `${CLOUDFLARE_NO_TOUCH_PARTITION_PREFIX}${suffix}`;
+}
+
+export function getCloudflareNoTouchPartition(rawValue: string): string | null {
+  const origin = getOriginFromUrl(rawValue);
+  if (!origin) {
+    return null;
+  }
+
+  return getCloudflareNoTouchPartitionForOrigin(origin);
+}
+
+export function isCloudflareNoTouchPartition(partition: string): boolean {
+  return partition.startsWith(CLOUDFLARE_NO_TOUCH_PARTITION_PREFIX);
+}
+
+export function isCloudflareChallengeHostname(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase();
+  return CLOUDFLARE_CHALLENGE_HOSTS.has(normalized);
+}
+
+export function isCloudflareChallengePath(pathname: string): boolean {
+  return CLOUDFLARE_CHALLENGE_PATH_PREFIXES.some((prefix) =>
+    pathname === prefix || pathname.startsWith(`${prefix}/`)
+  );
+}
+
+export function isCloudflareChallengeUrl(rawValue: string): boolean {
+  const parsed = tryParseUrl(rawValue);
+  if (!parsed || (parsed.protocol !== 'http:' && parsed.protocol !== 'https:')) {
+    return false;
+  }
+
+  return (
+    isCloudflareChallengeHostname(parsed.hostname) ||
+    isCloudflareChallengePath(parsed.pathname)
+  );
+}
+
+export function responseHeadersContainCfClearance(responseHeaders: Record<string, string[]>): boolean {
+  for (const [key, values] of Object.entries(responseHeaders)) {
+    if (key.toLowerCase() !== 'set-cookie' || !Array.isArray(values)) {
+      continue;
+    }
+
+    if (values.some((value) => typeof value === 'string' && /^cf_clearance=/i.test(value.trim()))) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -39,9 +39,25 @@ export function createLogger(namespace: string): Logger {
     LEVELS[level] >= LEVELS[minLevel()];
 
   return {
-    debug: (...args) => { if (shouldLog('debug')) console.debug(prefix, ...args); },
-    info:  (...args) => { if (shouldLog('info'))  console.info(prefix, ...args);  },
-    warn:  (...args) => { if (shouldLog('warn'))  console.warn(prefix, ...args);  },
-    error: (...args) => { if (shouldLog('error')) console.error(prefix, ...args); },
+    debug: (...args) => {
+      if (shouldLog('debug')) {
+        console.debug(prefix, ...args);
+      }
+    },
+    info: (...args) => {
+      if (shouldLog('info')) {
+        console.info(prefix, ...args);
+      }
+    },
+    warn: (...args) => {
+      if (shouldLog('warn')) {
+        console.warn(prefix, ...args);
+      }
+    },
+    error: (...args) => {
+      if (shouldLog('error')) {
+        console.error(prefix, ...args);
+      }
+    },
   };
 }

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -152,6 +152,14 @@ export function isGoogleAuthUrl(rawValue: string): boolean {
 /**
  * Sites that actively detect stealth patches and break when injected.
  * These sites get no stealth injection — they run as a normal browser.
+ *
+ * challenges.cloudflare.com: Cloudflare Turnstile OOPIF. The full stealth
+ * script (canvas noise, audio noise, performance.now() precision reduction)
+ * causes Turnstile to score the browser as a bot:
+ *   - Canvas noise → hash differs from any known real Chrome fingerprint
+ *   - 100μs performance.now() precision → Firefox-like, not Chrome
+ * The minimal CDP early script still runs here (via Page.addScriptToEvaluateOnNewDocument)
+ * and patches userAgentData/webdriver — that's sufficient for Turnstile.
  */
 const STEALTH_SKIP_HOSTS = new Set([
   'x.com',
@@ -159,6 +167,7 @@ const STEALTH_SKIP_HOSTS = new Set([
   'abs.twimg.com',
   'zhipin.com',
   'login.zhipin.com',
+  'challenges.cloudflare.com',
 ]);
 
 export function shouldSkipStealth(rawValue: string): boolean {

--- a/src/utils/tests/cloudflare.test.ts
+++ b/src/utils/tests/cloudflare.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CLOUDFLARE_CHALLENGE_SELECTORS,
+  CLOUDFLARE_NO_TOUCH_PARTITION_PREFIX,
+  getCloudflareNoTouchPartition,
+  getCloudflareNoTouchPartitionForOrigin,
+  getOriginFromUrl,
+  isCloudflareChallengePath,
+  isCloudflareChallengeUrl,
+  isCloudflareNoTouchPartition,
+  responseHeadersContainCfClearance,
+} from '../cloudflare';
+
+describe('cloudflare utils', () => {
+  it('detects challenge host URLs', () => {
+    expect(isCloudflareChallengeUrl('https://challenges.cloudflare.com/turnstile/v0/api.js')).toBe(true);
+  });
+
+  it('detects challenge platform paths on site origins', () => {
+    expect(isCloudflareChallengePath('/cdn-cgi/challenge-platform/h/b/orchestrate/managed/v1')).toBe(true);
+    expect(isCloudflareChallengeUrl('https://example.com/cdn-cgi/challenge-platform/h/b/orchestrate/managed/v1')).toBe(true);
+  });
+
+  it('ignores unrelated URLs', () => {
+    expect(isCloudflareChallengeUrl('https://example.com/login')).toBe(false);
+  });
+
+  it('extracts origins from absolute URLs', () => {
+    expect(getOriginFromUrl('https://example.com/path?q=1')).toBe('https://example.com');
+  });
+
+  it('derives a stable Cloudflare no-touch partition from an origin', () => {
+    const direct = getCloudflareNoTouchPartitionForOrigin('https://example.com');
+    const fromUrl = getCloudflareNoTouchPartition('https://example.com/login?x=1');
+
+    expect(direct).toBeTruthy();
+    expect(direct).toBe(fromUrl);
+    expect(direct).toMatch(new RegExp(`^${CLOUDFLARE_NO_TOUCH_PARTITION_PREFIX}[a-f0-9]{16}$`));
+  });
+
+  it('recognizes Cloudflare no-touch partitions', () => {
+    const partition = getCloudflareNoTouchPartition('https://claude.ai');
+
+    expect(partition).toBeTruthy();
+    expect(isCloudflareNoTouchPartition(partition!)).toBe(true);
+    expect(isCloudflareNoTouchPartition('persist:tandem')).toBe(false);
+  });
+
+  it('detects cf_clearance set-cookie headers', () => {
+    expect(responseHeadersContainCfClearance({
+      'set-cookie': ['cf_clearance=test; Path=/; HttpOnly'],
+    })).toBe(true);
+  });
+
+  it('ignores headers without cf_clearance', () => {
+    expect(responseHeadersContainCfClearance({
+      'set-cookie': ['session=abc; Path=/; HttpOnly'],
+    })).toBe(false);
+  });
+
+  it('exposes the selector list used for DOM probes', () => {
+    expect(CLOUDFLARE_CHALLENGE_SELECTORS).toContain('iframe[src*="challenges.cloudflare.com"]');
+  });
+});


### PR DESCRIPTION
## Summary

- **Cloudflare human mode — phase 3.** Challenge-sensitive tabs now run with reduced security instrumentation so Turnstile and the Cloudflare interstitial see a stock Chromium surface, while non-Cloudflare tabs keep the full security stack.
- New `CloudflarePolicyManager` classifies tabs based on URL, response headers (`cf_clearance`), DOM selectors, and interstitial title snippets; the stealth preload does a sync IPC into that manager to pick `early` vs `full` stealth per frame.
- `SecurityManager` refuses ScriptGuard main-world injection on challenge-sensitive tabs, `BehaviorMonitor` resource polling is gated off, and live policy flips trigger an immediate de-escalation.
- Version bump **1.0.0 → 1.0.1** (`package.json`, `PROJECT.md`, `README.md`). CHANGELOG updated. `.gitignore` now excludes `.claude/` (local Claude Code settings/worktrees).

Phases 4 (human handoff) and 5 (conservative resume after `cf_clearance`) are intentionally on hold for this release.

## What's in here

Commits on top of `main`:
- `fix(stealth): skip full stealth script in Cloudflare Turnstile OOPIF`
- `feat(cloudflare): phase 3 human mode — policy manager and security gating`
- `chore: bump version to 1.0.1 and gitignore .claude/`

Notable files:
- **New** — `src/cloudflare/policy-manager.ts` (+ tests), `src/utils/cloudflare.ts` (+ tests), `src/security/tests/security-manager-cloudflare.test.ts`
- **Changed** — `src/security/security-manager.ts`, `src/security/behavior-monitor.ts`, `src/stealth/manager.ts` (+ tests), `src/main.ts` (+313/-45 orchestration), `src/bootstrap/runtime.ts`, `src/bootstrap/types.ts`, `src/registry.ts`, `src/api/routes/misc.ts` (exposes CF policy in `/status`), `src/headless/manager.ts` (uses shared selectors), `src/devtools/manager.ts` (logs now include `wc <id>` for OOPIF diagnosis)

## Test plan

- [x] `npm test` — green locally (vitest full run)
- [x] `npm run lint` — green locally (eslint)
- [x] New tests: `src/cloudflare/tests/policy-manager.test.ts`, `src/utils/tests/cloudflare.test.ts`, `src/security/tests/security-manager-cloudflare.test.ts`, stealth manager tests updated, misc route test covers the new `/status.cloudflare` field
- [x] Smoke test in a running Tandem build: hit a Cloudflare-gated page, confirm Turnstile loads without V8 crash and without security instrumentation attaching to the challenge tab
- [x] Verify non-Cloudflare tabs still get full ScriptGuard + BehaviorMonitor coverage