### PR TITLE
docs: correct binary availability + vs-page version references

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ contributors, not yet a polished mass-user release.
 - Primary platform: macOS
 - Secondary platform: Linux
 - Windows: validated as a remote agent host (VS Code + Claude Code over Tailscale)
-- Binaries: not published yet (source-only)
+- Binaries: signed & notarized macOS Apple Silicon builds published on [GitHub Releases](https://github.com/hydro13/tandem-browser/releases), starting at v1.0.1
 - Current version: `1.0.1`
 - Package metadata: [package.json](package.json)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -658,7 +658,7 @@ footer a:hover{color:var(--text2)}
 <section id="compare">
 <div class="section-label">Comparisons</div>
 <h2 class="section-title">Tandem Browser vs the alternatives</h2>
-<p style="font-size:.85rem;color:var(--text2);max-width:680px">Honest, balanced side-by-side comparisons with the other browsers and tools in this space. Tandem Browser is in development preview (v0.75) — these pages are upfront about that and where the alternatives have real advantages.</p>
+<p style="font-size:.85rem;color:var(--text2);max-width:680px">Honest, balanced side-by-side comparisons with the other browsers and tools in this space. Tandem Browser is in development preview (v1.0.1) — these pages are upfront about that and where the alternatives have real advantages.</p>
 <div class="audience-grid" style="margin-top:1.5rem">
 <a class="audience-card" href="/vs/comet" style="text-decoration:none"><h3>vs Comet</h3><p>Open-source, local-first vs Perplexity's polished managed product.</p></a>
 <a class="audience-card" href="/vs/dia" style="text-decoration:none"><h3>vs Dia</h3><p>Model-agnostic developer-facing vs design-led consumer browser.</p></a>

--- a/docs/vs/arc-search.html
+++ b/docs/vs/arc-search.html
@@ -57,7 +57,7 @@
 </div>
 
 <div class="preview-banner">
-<div class="preview-banner-inner"><strong>Note:</strong> Tandem Browser is in active development preview (v0.75). Arc Search is a polished, widely-praised consumer product. They are also genuinely different categories of tool — please factor both in.</div>
+<div class="preview-banner-inner"><strong>Note:</strong> Tandem Browser is in active development preview (v1.0.1). Arc Search is a polished, widely-praised consumer product. They are also genuinely different categories of tool — please factor both in.</div>
 </div>
 
 <section>

--- a/docs/vs/browser-use.html
+++ b/docs/vs/browser-use.html
@@ -57,7 +57,7 @@
 </div>
 
 <div class="preview-banner">
-<div class="preview-banner-inner"><strong>Note:</strong> Tandem Browser is in active development preview (v0.75). Browser Use is a mature, actively maintained library. Some differences below reflect category (browser vs library), not maturity — please weigh both.</div>
+<div class="preview-banner-inner"><strong>Note:</strong> Tandem Browser is in active development preview (v1.0.1). Browser Use is a mature, actively maintained library. Some differences below reflect category (browser vs library), not maturity — please weigh both.</div>
 </div>
 
 <section>

--- a/docs/vs/comet.html
+++ b/docs/vs/comet.html
@@ -57,7 +57,7 @@
 </div>
 
 <div class="preview-banner">
-<div class="preview-banner-inner"><strong>Note:</strong> Tandem Browser is in active development preview (v0.75). Comet is a production-grade, polished product. Some of the differences below reflect that maturity gap, not just architectural choice — please factor that in when deciding.</div>
+<div class="preview-banner-inner"><strong>Note:</strong> Tandem Browser is in active development preview (v1.0.1). Comet is a production-grade, polished product. Some of the differences below reflect that maturity gap, not just architectural choice — please factor that in when deciding.</div>
 </div>
 
 <section>

--- a/docs/vs/dia.html
+++ b/docs/vs/dia.html
@@ -57,7 +57,7 @@
 </div>
 
 <div class="preview-banner">
-<div class="preview-banner-inner"><strong>Note:</strong> Tandem Browser is in active development preview (v0.75). Dia is a production-grade, polished product. Some of the differences below reflect that maturity gap, not just architectural choice — please factor that in when deciding.</div>
+<div class="preview-banner-inner"><strong>Note:</strong> Tandem Browser is in active development preview (v1.0.1). Dia is a production-grade, polished product. Some of the differences below reflect that maturity gap, not just architectural choice — please factor that in when deciding.</div>
 </div>
 
 <section>


### PR DESCRIPTION
## Summary

Fixes two documentation inconsistencies that were pointed out: the README claimed binaries weren't published (contradicting the Quick Start on the same page, which links to a v1.0.1 DMG), and the vs-pages plus the site landing page still said we were in preview at v0.75 — we've since shipped v1.0.1.

## What changed

- **README.md Status section** — replaced "Binaries: not published yet (source-only)" with a line noting signed & notarized macOS Apple Silicon builds on GitHub Releases starting at v1.0.1. Kept the other lines (primary/secondary platform, Windows remote-host note, current version, package.json pointer) as they were.
- **docs/vs/{comet,dia,browser-use,arc-search}.html** — bumped the "active development preview (v0.75)" preamble note to v1.0.1 in all four comparison pages. Surrounding framing and tables untouched.
- **docs/index.html** — same bump on the Comparisons section intro paragraph, which is what renders in the landing-page hero/FAQ area on tandembrowser.org.

## Grep sweep

Confirmed the remaining `0.75` hits in `docs/` are historical and should stay:
- `CHANGELOG.md`, `docs/changelog.html` — the v0.75.0 release entry
- `docs/api-current.md` — "New in v0.75.0" feature note
- `docs/archive/**`, `docs/superpowers/**` — archived / private plans
- `LGL_VISUAL_REFERENCE.md` — unrelated ("0.75 opacity")

## No CHANGELOG entry

Per the AGENTS.md commit-type table, `docs:` commits are changelog-exempt.

## Test plan

- [x] `npx tsc` — zero errors
- [x] `npx vitest run` — 142 test files, 2896 passed, 39 skipped
- [x] Grepped `docs/` for residual `0.75` references after edits
- [ ] Verify preview rendering on tandembrowser.org after deploy