### PR TITLE
[codex] Windows support phase 1 platform adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 All notable changes to Tandem Browser will be documented in this file.
 
-## Unreleased
+## [v1.1.0] - 2026-05-04
+
+Windows support foundation. This release adds the platform adapter layer that
+later Windows phases will migrate into, while keeping current production call
+sites unchanged.
+
+### Added
+
+- **Platform adapter foundation** - added the typed `src/platform/` layer with
+  capability profiles, platform selection, Darwin wrappers, and Windows/Linux
+  stubs for future phased platform work without migrating production call sites.
 
 ### Documentation
 

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -31,7 +31,7 @@ The security layer exists because when an AI has access to your browser, your th
 Data stays local. Sessions are isolated. Nothing leaves the machine through Tandem Browser without going through a filter first.
 
 **GitHub:** `hydro13/tandem-browser`  
-**Current version:** `1.0.1`  
+**Current version:** `1.1.0`
 **Repository status:** Public developer preview  
 **Started:** February 11, 2026
 

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ contributors, not yet a polished mass-user release.
 - Secondary platform: Linux
 - Windows: validated as a remote agent host (VS Code + Claude Code over Tailscale)
 - Binaries: signed & notarized macOS Apple Silicon builds published on [GitHub Releases](https://github.com/hydro13/tandem-browser/releases), starting at v1.0.0
-- Current version: `1.0.1`
+- Current version: `1.1.0`
 - Package metadata: [package.json](package.json)
 
 ## Community

--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@ Last updated: April 21, 2026
 
 ## Current Snapshot
 
-- Current app version: `0.72.2`
+- Current app version: `1.1.0`
 - MCP server: 253 tools (full API parity + awareness)
 - The codebase scope is larger than this backlog summary and includes major subsystems such as `sidebar`, `workspaces`, `pinboards`, `sync`, `headless`, and `sessions`.
 - Scheduled browsing already exists in baseline form via `WatchManager` and the `/watch/*` API routes.

--- a/docs/index.html
+++ b/docs/index.html
@@ -163,8 +163,8 @@ footer a:hover{color:var(--text2)}
       "operatingSystem": "macOS (developer preview), Linux (pre-beta)",
       "description": "Tandem Browser is the open-source, local-first browser for AI agents — where the AI lives inside your real browser session, bring any model via MCP.",
       "url": "https://tandembrowser.org",
-      "downloadUrl": "https://github.com/hydro13/tandem-browser/releases/tag/v1.0.1",
-      "softwareVersion": "1.0.1",
+      "downloadUrl": "https://github.com/hydro13/tandem-browser/releases/tag/v1.1.0",
+      "softwareVersion": "1.1.0",
       "license": "https://opensource.org/licenses/MIT",
       "offers": {
         "@type": "Offer",
@@ -325,7 +325,7 @@ footer a:hover{color:var(--text2)}
 </header>
 
 <div class="hero">
-<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v1.0.1</div>
+<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v1.1.0</div>
 <p class="hero-lead">Tandem Browser is the <strong>open-source, local-first browser for AI agents</strong> — where the AI lives inside your real browser session, sharing your tabs, cookies, and DOM, ready to ask for your help the moment it gets stuck.</p>
 <h1>The browser becomes a <em>programmable workspace</em> where human intent and AI capability meet.</h1>
 <p>Tandem Browser is built around a simple shift: the AI is not a sidebar talking <em>about</em> your browser, it is <em>inside</em> it. Same tabs, same cookies, same logged-in sessions, same page you are looking at right now. Reading the accessibility tree, watching the network, writing live styles, handing back to you when something needs a human. It turns the web that already exists into something agents can actually operate on — no per-site API, no RPA rig, no screenshot loop. The real browser, as a shared human-AI symbiotic runtime.</p>
@@ -658,7 +658,7 @@ footer a:hover{color:var(--text2)}
 <section id="compare">
 <div class="section-label">Comparisons</div>
 <h2 class="section-title">Tandem Browser vs the alternatives</h2>
-<p style="font-size:.85rem;color:var(--text2);max-width:680px">Honest, balanced side-by-side comparisons with the other browsers and tools in this space. Tandem Browser is in development preview (v1.0.1) — these pages are upfront about that and where the alternatives have real advantages.</p>
+<p style="font-size:.85rem;color:var(--text2);max-width:680px">Honest, balanced side-by-side comparisons with the other browsers and tools in this space. Tandem Browser is in development preview (v1.1.0) — these pages are upfront about that and where the alternatives have real advantages.</p>
 <div class="audience-grid" style="margin-top:1.5rem">
 <a class="audience-card" href="/vs/comet" style="text-decoration:none"><h3>vs Comet</h3><p>Open-source, local-first vs Perplexity's polished managed product.</p></a>
 <a class="audience-card" href="/vs/dia" style="text-decoration:none"><h3>vs Dia</h3><p>Model-agnostic developer-facing vs design-led consumer browser.</p></a>

--- a/docs/vs/arc-search.html
+++ b/docs/vs/arc-search.html
@@ -57,7 +57,7 @@
 </div>
 
 <div class="preview-banner">
-<div class="preview-banner-inner"><strong>Note:</strong> Tandem Browser is in active development preview (v1.0.1). Arc Search is a polished, widely-praised consumer product. They are also genuinely different categories of tool — please factor both in.</div>
+<div class="preview-banner-inner"><strong>Note:</strong> Tandem Browser is in active development preview (v1.1.0). Arc Search is a polished, widely-praised consumer product. They are also genuinely different categories of tool — please factor both in.</div>
 </div>
 
 <section>

--- a/docs/vs/browser-use.html
+++ b/docs/vs/browser-use.html
@@ -57,7 +57,7 @@
 </div>
 
 <div class="preview-banner">
-<div class="preview-banner-inner"><strong>Note:</strong> Tandem Browser is in active development preview (v1.0.1). Browser Use is a mature, actively maintained library. Some differences below reflect category (browser vs library), not maturity — please weigh both.</div>
+<div class="preview-banner-inner"><strong>Note:</strong> Tandem Browser is in active development preview (v1.1.0). Browser Use is a mature, actively maintained library. Some differences below reflect category (browser vs library), not maturity — please weigh both.</div>
 </div>
 
 <section>

--- a/docs/vs/comet.html
+++ b/docs/vs/comet.html
@@ -57,7 +57,7 @@
 </div>
 
 <div class="preview-banner">
-<div class="preview-banner-inner"><strong>Note:</strong> Tandem Browser is in active development preview (v1.0.1). Comet is a production-grade, polished product. Some of the differences below reflect that maturity gap, not just architectural choice — please factor that in when deciding.</div>
+<div class="preview-banner-inner"><strong>Note:</strong> Tandem Browser is in active development preview (v1.1.0). Comet is a production-grade, polished product. Some of the differences below reflect that maturity gap, not just architectural choice — please factor that in when deciding.</div>
 </div>
 
 <section>

--- a/docs/vs/dia.html
+++ b/docs/vs/dia.html
@@ -57,7 +57,7 @@
 </div>
 
 <div class="preview-banner">
-<div class="preview-banner-inner"><strong>Note:</strong> Tandem Browser is in active development preview (v1.0.1). Dia is a production-grade, polished product. Some of the differences below reflect that maturity gap, not just architectural choice — please factor that in when deciding.</div>
+<div class="preview-banner-inner"><strong>Note:</strong> Tandem Browser is in active development preview (v1.1.0). Dia is a production-grade, polished product. Some of the differences below reflect that maturity gap, not just architectural choice — please factor that in when deciding.</div>
 </div>
 
 <section>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tandem-browser",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tandem-browser",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-browser",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Local-first Electron browser with a 253-tool MCP server, MCP/HTTP control surfaces, and built-in security controls",
   "main": "dist/main.js",
   "author": "Tandem Browser contributors",

--- a/src/platform/capabilities.ts
+++ b/src/platform/capabilities.ts
@@ -1,0 +1,135 @@
+import type { PlatformId } from './errors';
+
+export type CapabilityStatus = 'supported' | 'partial' | 'unsupported' | 'planned';
+
+export interface PlatformCapability {
+  status: CapabilityStatus;
+  notes: string;
+}
+
+export interface PlatformCapabilities {
+  appStartup: PlatformCapability;
+  signedInstaller: PlatformCapability;
+  autoUpdate: PlatformCapability;
+  windowChrome: PlatformCapability;
+  stealthUa: PlatformCapability;
+  chromeBookmarkHistoryImport: PlatformCapability;
+  chromeCookieImport: PlatformCapability;
+  nativeMessagingHostDetection: PlatformCapability;
+  voiceTranscription: PlatformCapability;
+  videoRecorderSystemAudio: PlatformCapability;
+  keyboardShortcutsLabels: PlatformCapability;
+  secretsAtRest: PlatformCapability;
+  userDataDirectory: PlatformCapability;
+}
+
+export interface PlatformSupportProfile {
+  platform: PlatformId;
+  tier: 'tier1-required' | 'tier1-target' | 'tier2-best-effort' | 'unsupported';
+  label: string;
+  notes: string;
+  capabilities: PlatformCapabilities;
+}
+
+const unsupportedCapability = (notes: string): PlatformCapability => ({
+  status: 'unsupported',
+  notes,
+});
+
+const CAPABILITY_PROFILES: Record<PlatformId, PlatformSupportProfile> = {
+  darwin: {
+    platform: 'darwin',
+    tier: 'tier1-required',
+    label: 'macOS Apple Silicon',
+    notes: 'Primary platform. Signed and notarized.',
+    capabilities: {
+      appStartup: { status: 'supported', notes: 'Source startup is supported on macOS.' },
+      signedInstaller: { status: 'supported', notes: 'Signed and notarized macOS installer is supported.' },
+      autoUpdate: { status: 'supported', notes: 'macOS auto-update is supported.' },
+      windowChrome: { status: 'supported', notes: 'Hidden inset titlebar with native macOS controls.' },
+      stealthUa: { status: 'supported', notes: 'Stealth UA currently presents a macOS Chrome persona.' },
+      chromeBookmarkHistoryImport: { status: 'supported', notes: 'Chrome bookmark and history paths are implemented.' },
+      chromeCookieImport: { status: 'partial', notes: 'Cookie import uses CDP or pre-exported JSON fallback.' },
+      nativeMessagingHostDetection: { status: 'supported', notes: 'macOS native messaging host directories are detected.' },
+      voiceTranscription: { status: 'supported', notes: 'Apple Speech binary and Whisper fallback are supported.' },
+      videoRecorderSystemAudio: { status: 'supported', notes: 'Video recorder with system audio is supported.' },
+      keyboardShortcutsLabels: { status: 'supported', notes: 'macOS shortcut behavior and labels are supported.' },
+      secretsAtRest: { status: 'supported', notes: 'Secrets at rest are supported on macOS.' },
+      userDataDirectory: { status: 'supported', notes: 'macOS user data path is supported.' },
+    },
+  },
+  win32: {
+    platform: 'win32',
+    tier: 'tier1-target',
+    label: 'Windows 11 x64',
+    notes: 'In active build-out; do not announce public Windows support yet.',
+    capabilities: {
+      appStartup: unsupportedCapability('Blocked by Unix-only start script until windows-support phase 2.'),
+      signedInstaller: unsupportedCapability('Windows installer planned in windows-support phases 13-14.'),
+      autoUpdate: unsupportedCapability('Windows update feed planned in windows-support phase 15.'),
+      windowChrome: unsupportedCapability('Windows custom titlebar planned in windows-support phase 6.'),
+      stealthUa: unsupportedCapability('Windows UA persona planned in windows-support phase 7.'),
+      chromeBookmarkHistoryImport: unsupportedCapability('Windows Chrome paths planned in windows-support phase 8.'),
+      chromeCookieImport: unsupportedCapability('Windows DPAPI decrypt evaluation planned in windows-support phase 8.'),
+      nativeMessagingHostDetection: { status: 'partial', notes: 'Filesystem fallback exists; registry reader planned in windows-support phase 9.' },
+      voiceTranscription: unsupportedCapability('Windows Whisper fallback planned in windows-support phase 10.'),
+      videoRecorderSystemAudio: unsupportedCapability('Windows WASAPI loopback planned in windows-support phase 11.'),
+      keyboardShortcutsLabels: { status: 'partial', notes: 'Cross-platform labels finalized in windows-support phase 12.' },
+      secretsAtRest: unsupportedCapability('Unified safeStorage adapter planned in windows-support phase 5.'),
+      userDataDirectory: unsupportedCapability('Windows APPDATA path planned in windows-support phase 4.'),
+    },
+  },
+  linux: {
+    platform: 'linux',
+    tier: 'tier2-best-effort',
+    label: 'Linux x64',
+    notes: 'Pre-beta. Functional but not a release blocker.',
+    capabilities: {
+      appStartup: { status: 'partial', notes: 'Linux source startup is pre-beta.' },
+      signedInstaller: unsupportedCapability('Linux installer is not currently supported.'),
+      autoUpdate: unsupportedCapability('Linux auto-update is not currently supported.'),
+      windowChrome: { status: 'supported', notes: 'Frameless custom titlebar is supported.' },
+      stealthUa: { status: 'partial', notes: 'Stealth UA does not yet fully match Linux host OS.' },
+      chromeBookmarkHistoryImport: { status: 'partial', notes: 'Linux Chrome path support exists with known gaps.' },
+      chromeCookieImport: { status: 'partial', notes: 'Linux cookie import remains partial.' },
+      nativeMessagingHostDetection: { status: 'supported', notes: 'Linux native messaging host directories are detected.' },
+      voiceTranscription: { status: 'partial', notes: 'Whisper fallback can work when installed.' },
+      videoRecorderSystemAudio: { status: 'partial', notes: 'Desktop audio capture gap remains for Linux.' },
+      keyboardShortcutsLabels: { status: 'supported', notes: 'Linux shortcut behavior and labels are supported.' },
+      secretsAtRest: { status: 'supported', notes: 'Secrets at rest are currently supported.' },
+      userDataDirectory: { status: 'supported', notes: 'Linux user data path is supported.' },
+    },
+  },
+  unsupported: {
+    platform: 'unsupported',
+    tier: 'unsupported',
+    label: 'Unsupported platform',
+    notes: 'Not maintained. May happen to work; no guarantees.',
+    capabilities: {
+      appStartup: unsupportedCapability('Unsupported platform.'),
+      signedInstaller: unsupportedCapability('Unsupported platform.'),
+      autoUpdate: unsupportedCapability('Unsupported platform.'),
+      windowChrome: unsupportedCapability('Unsupported platform.'),
+      stealthUa: unsupportedCapability('Unsupported platform.'),
+      chromeBookmarkHistoryImport: unsupportedCapability('Unsupported platform.'),
+      chromeCookieImport: unsupportedCapability('Unsupported platform.'),
+      nativeMessagingHostDetection: unsupportedCapability('Unsupported platform.'),
+      voiceTranscription: unsupportedCapability('Unsupported platform.'),
+      videoRecorderSystemAudio: unsupportedCapability('Unsupported platform.'),
+      keyboardShortcutsLabels: unsupportedCapability('Unsupported platform.'),
+      secretsAtRest: unsupportedCapability('Unsupported platform.'),
+      userDataDirectory: unsupportedCapability('Unsupported platform.'),
+    },
+  },
+};
+
+export function normalizePlatform(platform: NodeJS.Platform | string): PlatformId {
+  if (platform === 'darwin' || platform === 'win32' || platform === 'linux') {
+    return platform;
+  }
+  return 'unsupported';
+}
+
+export function getPlatformCapabilities(platform: NodeJS.Platform | string = process.platform): PlatformSupportProfile {
+  return CAPABILITY_PROFILES[normalizePlatform(platform)];
+}

--- a/src/platform/chrome-import/index.ts
+++ b/src/platform/chrome-import/index.ts
@@ -1,0 +1,38 @@
+import type * as ChromeImportModule from '../../import/chrome-importer';
+import path from 'path';
+import os from 'os';
+import { NotImplementedError, type PlatformId } from '../errors';
+import type { ChromeImportAdapter } from '../types';
+
+export function createDarwinChromeImportAdapter(): ChromeImportAdapter {
+  return {
+    createImporter: (configManager) => {
+      const { ChromeImporter } = require('../../import/chrome-importer') as typeof ChromeImportModule;
+      return new ChromeImporter(configManager);
+    },
+    getDefaultChromeBasePath: () => path.join(os.homedir(), 'Library', 'Application Support', 'Google', 'Chrome'),
+    getUnavailableStatus: (profilePath = '') => ({
+      chromeFound: false,
+      bookmarksFound: false,
+      historyFound: false,
+      cookiesFound: false,
+      profilePath,
+    }),
+  };
+}
+
+export function createUnsupportedChromeImportAdapter(platform: PlatformId): ChromeImportAdapter {
+  return {
+    createImporter: () => {
+      throw new NotImplementedError('Chrome import', platform, 'phase-8');
+    },
+    getDefaultChromeBasePath: () => '',
+    getUnavailableStatus: (profilePath = '') => ({
+      chromeFound: false,
+      bookmarksFound: false,
+      historyFound: false,
+      cookiesFound: false,
+      profilePath,
+    }),
+  };
+}

--- a/src/platform/errors.ts
+++ b/src/platform/errors.ts
@@ -1,0 +1,8 @@
+export class NotImplementedError extends Error {
+  constructor(feature: string, platform: PlatformId, phase: string) {
+    super(`${feature} on ${platform} is not implemented yet - see windows-support ${phase}.`);
+    this.name = 'NotImplementedError';
+  }
+}
+
+export type PlatformId = 'darwin' | 'win32' | 'linux' | 'unsupported';

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -1,0 +1,64 @@
+import { getPlatformCapabilities, normalizePlatform } from './capabilities';
+import type { PlatformId } from './errors';
+import { createDarwinChromeImportAdapter, createUnsupportedChromeImportAdapter } from './chrome-import';
+import { createDarwinNativeMessagingAdapter, createUnsupportedNativeMessagingAdapter } from './native-messaging';
+import { createDarwinPathsAdapter, createUnsupportedPathsAdapter } from './paths';
+import { createProcessAdapter } from './process';
+import { createDarwinSecretsAdapter, createUnsupportedSecretsAdapter } from './secrets';
+import { createDarwinStealthUaAdapter, createUnsupportedStealthUaAdapter } from './stealth-ua';
+import type { PlatformAdapter } from './types';
+import { createDarwinVideoAudioAdapter, createUnsupportedVideoAudioAdapter } from './video-audio';
+import { createDarwinVoiceAdapter, createUnsupportedVoiceAdapter } from './voice';
+import { createDarwinWindowChromeAdapter, createUnsupportedWindowChromeAdapter } from './window-chrome';
+
+export type { PlatformId } from './errors';
+export { NotImplementedError } from './errors';
+export type {
+  CapabilityStatus,
+  PlatformCapabilities,
+  PlatformCapability,
+  PlatformSupportProfile,
+} from './capabilities';
+export { getPlatformCapabilities, normalizePlatform } from './capabilities';
+export type { PlatformAdapter } from './types';
+
+function createDarwinPlatform(): PlatformAdapter {
+  const id: PlatformId = 'darwin';
+  return {
+    id,
+    capabilities: getPlatformCapabilities(id),
+    paths: createDarwinPathsAdapter(),
+    process: createProcessAdapter(id),
+    chromeImport: createDarwinChromeImportAdapter(),
+    nativeMessaging: createDarwinNativeMessagingAdapter(),
+    voice: createDarwinVoiceAdapter(),
+    videoAudio: createDarwinVideoAudioAdapter(),
+    windowChrome: createDarwinWindowChromeAdapter(),
+    stealthUa: createDarwinStealthUaAdapter(),
+    secrets: createDarwinSecretsAdapter(),
+  };
+}
+
+function createStubPlatform(id: PlatformId): PlatformAdapter {
+  return {
+    id,
+    capabilities: getPlatformCapabilities(id),
+    paths: createUnsupportedPathsAdapter(id),
+    process: createProcessAdapter(id),
+    chromeImport: createUnsupportedChromeImportAdapter(id),
+    nativeMessaging: createUnsupportedNativeMessagingAdapter(id),
+    voice: createUnsupportedVoiceAdapter(id),
+    videoAudio: createUnsupportedVideoAudioAdapter(id),
+    windowChrome: createUnsupportedWindowChromeAdapter(id),
+    stealthUa: createUnsupportedStealthUaAdapter(id),
+    secrets: createUnsupportedSecretsAdapter(id),
+  };
+}
+
+export function selectPlatform(platform: NodeJS.Platform | string = process.platform): PlatformAdapter {
+  const id = normalizePlatform(platform);
+  if (id === 'darwin') {
+    return createDarwinPlatform();
+  }
+  return createStubPlatform(id);
+}

--- a/src/platform/native-messaging/index.ts
+++ b/src/platform/native-messaging/index.ts
@@ -1,0 +1,20 @@
+import type * as NativeMessagingModule from '../../extensions/native-messaging';
+import { NotImplementedError, type PlatformId } from '../errors';
+import type { NativeMessagingAdapter } from '../types';
+
+export function createDarwinNativeMessagingAdapter(): NativeMessagingAdapter {
+  return {
+    createSetup: () => {
+      const { NativeMessagingSetup } = require('../../extensions/native-messaging') as typeof NativeMessagingModule;
+      return new NativeMessagingSetup();
+    },
+  };
+}
+
+export function createUnsupportedNativeMessagingAdapter(platform: PlatformId): NativeMessagingAdapter {
+  return {
+    createSetup: () => {
+      throw new NotImplementedError('NativeMessaging', platform, 'phase-9');
+    },
+  };
+}

--- a/src/platform/paths/index.ts
+++ b/src/platform/paths/index.ts
@@ -1,0 +1,27 @@
+import type * as PathsModule from '../../utils/paths';
+import { NotImplementedError, type PlatformId } from '../errors';
+import type { PathsAdapter } from '../types';
+
+export function createDarwinPathsAdapter(): PathsAdapter {
+  return {
+    tandemDir: (...subpath) => {
+      const { tandemDir } = require('../../utils/paths') as typeof PathsModule;
+      return tandemDir(...subpath);
+    },
+    ensureDir: (dir) => {
+      const { ensureDir } = require('../../utils/paths') as typeof PathsModule;
+      return ensureDir(dir);
+    },
+  };
+}
+
+export function createUnsupportedPathsAdapter(platform: PlatformId): PathsAdapter {
+  return {
+    tandemDir: () => {
+      throw new NotImplementedError('User data paths', platform, 'phase-4');
+    },
+    ensureDir: () => {
+      throw new NotImplementedError('User data paths', platform, 'phase-4');
+    },
+  };
+}

--- a/src/platform/process/index.ts
+++ b/src/platform/process/index.ts
@@ -1,0 +1,11 @@
+import type { PlatformId } from '../errors';
+import type { ProcessAdapter } from '../types';
+
+export function createProcessAdapter(platform: PlatformId): ProcessAdapter {
+  return {
+    platform,
+    isMacOS: () => platform === 'darwin',
+    isWindows: () => platform === 'win32',
+    isLinux: () => platform === 'linux',
+  };
+}

--- a/src/platform/secrets/index.ts
+++ b/src/platform/secrets/index.ts
@@ -1,0 +1,20 @@
+import type * as StealthManagerModule from '../../stealth/manager';
+import { NotImplementedError, type PlatformId } from '../errors';
+import type { SecretsAdapter } from '../types';
+
+export function createDarwinSecretsAdapter(): SecretsAdapter {
+  return {
+    loadOrCreateInstallSecret: () => {
+      const { loadOrCreateInstallSecret } = require('../../stealth/manager') as typeof StealthManagerModule;
+      return loadOrCreateInstallSecret();
+    },
+  };
+}
+
+export function createUnsupportedSecretsAdapter(platform: PlatformId): SecretsAdapter {
+  return {
+    loadOrCreateInstallSecret: () => {
+      throw new NotImplementedError('Secrets at rest', platform, 'phase-5');
+    },
+  };
+}

--- a/src/platform/stealth-ua/index.ts
+++ b/src/platform/stealth-ua/index.ts
@@ -1,0 +1,21 @@
+import { NotImplementedError, type PlatformId } from '../errors';
+import type { StealthUaAdapter } from '../types';
+
+export function createDarwinStealthUaAdapter(): StealthUaAdapter {
+  return {
+    getUserAgent: (chromeVersion = process.versions.chrome) =>
+      `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${chromeVersion} Safari/537.36`,
+    getClientHintsPlatform: () => 'macOS',
+  };
+}
+
+export function createUnsupportedStealthUaAdapter(platform: PlatformId): StealthUaAdapter {
+  return {
+    getUserAgent: () => {
+      throw new NotImplementedError('Stealth UA', platform, 'phase-7');
+    },
+    getClientHintsPlatform: () => {
+      throw new NotImplementedError('Stealth UA', platform, 'phase-7');
+    },
+  };
+}

--- a/src/platform/tests/platform.test.ts
+++ b/src/platform/tests/platform.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { NotImplementedError, getPlatformCapabilities, selectPlatform } from '..';
+
+describe('selectPlatform', () => {
+  it('returns the Darwin adapter', () => {
+    const platform = selectPlatform('darwin');
+
+    expect(platform.id).toBe('darwin');
+    expect(platform.process.isMacOS()).toBe(true);
+    expect(platform.capabilities.capabilities.appStartup.status).toBe('supported');
+    expect(platform.windowChrome.getBrowserWindowOptions()).toMatchObject({
+      titleBarStyle: 'hiddenInset',
+    });
+  });
+
+  it('returns the Windows stub adapter without throwing on capability reads', () => {
+    const platform = selectPlatform('win32');
+
+    expect(platform.id).toBe('win32');
+    expect(platform.process.isWindows()).toBe(true);
+    expect(platform.capabilities.capabilities.appStartup.status).toBe('unsupported');
+    expect(() => platform.chromeImport.getUnavailableStatus()).not.toThrow();
+    expect(() => platform.windowChrome.getBrowserWindowOptions()).toThrow(NotImplementedError);
+  });
+
+  it('returns the Linux stub adapter without throwing on capability reads', () => {
+    const platform = selectPlatform('linux');
+
+    expect(platform.id).toBe('linux');
+    expect(platform.process.isLinux()).toBe(true);
+    expect(platform.capabilities.capabilities.windowChrome.status).toBe('supported');
+    expect(() => platform.chromeImport.getUnavailableStatus()).not.toThrow();
+    expect(() => platform.secrets.loadOrCreateInstallSecret()).toThrow(NotImplementedError);
+  });
+
+  it('normalizes unknown platforms to an unsupported adapter', () => {
+    const platform = selectPlatform('freebsd');
+
+    expect(platform.id).toBe('unsupported');
+    expect(platform.capabilities.tier).toBe('unsupported');
+    expect(getPlatformCapabilities('freebsd').capabilities.appStartup.status).toBe('unsupported');
+  });
+});

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -1,0 +1,83 @@
+import type { Session } from 'electron';
+import type { ConfigManager } from '../config/manager';
+import type { ChromeImporter, ChromeImportStatus } from '../import/chrome-importer';
+import type {
+  NativeMessagingHost,
+  NativeMessagingHostAccessDecision,
+  NativeMessagingStatus,
+} from '../extensions/native-messaging';
+import type { PlatformId } from './errors';
+import type { PlatformSupportProfile } from './capabilities';
+
+export interface PathsAdapter {
+  tandemDir(...subpath: string[]): string;
+  ensureDir(dir: string): string;
+}
+
+export interface ProcessAdapter {
+  platform: PlatformId;
+  isMacOS(): boolean;
+  isWindows(): boolean;
+  isLinux(): boolean;
+}
+
+export interface ChromeImportAdapter {
+  createImporter(configManager?: ConfigManager): ChromeImporter;
+  getDefaultChromeBasePath(): string;
+  getUnavailableStatus(profilePath?: string): ChromeImportStatus;
+}
+
+export interface NativeMessagingAdapter {
+  createSetup(): {
+    getNativeMessagingDirs(): { path: string; exists: boolean }[];
+    detectHosts(): NativeMessagingHost[];
+    configure(session: Session): { configured: string[]; missing: string[] };
+    getStatus(): NativeMessagingStatus;
+    evaluateHostAccess(hostName: string, candidateExtensionIds: Array<string | null | undefined>): NativeMessagingHostAccessDecision;
+    isHostAvailable(extensionId: string): boolean;
+  };
+}
+
+export interface VoiceAdapter {
+  detectBackend(): 'apple' | 'whisper' | 'none';
+  transcribeAudio(audioBuffer: Buffer, language?: string): Promise<{ ok: boolean; text?: string; error?: string }>;
+}
+
+export interface VideoAudioAdapter {
+  createRecorder(): {
+    startRecording(mode: 'application' | 'region', region?: { x: number; y: number; width: number; height: number }): { ok: boolean; id?: string; error?: string };
+    writeChunk(data: Buffer): void;
+    stopRecording(): Promise<{ ok: boolean; recording?: unknown; error?: string }>;
+    isRecording(): boolean;
+    getStatus(): { recording: boolean; id?: string; duration?: number; mode?: string };
+    listRecordings(limit?: number): unknown[];
+    forceStop(): void;
+  };
+}
+
+export interface WindowChromeAdapter {
+  getBrowserWindowOptions(): Partial<Electron.BrowserWindowConstructorOptions>;
+}
+
+export interface StealthUaAdapter {
+  getUserAgent(chromeVersion?: string): string;
+  getClientHintsPlatform(): string;
+}
+
+export interface SecretsAdapter {
+  loadOrCreateInstallSecret(): string;
+}
+
+export interface PlatformAdapter {
+  id: PlatformId;
+  capabilities: PlatformSupportProfile;
+  paths: PathsAdapter;
+  process: ProcessAdapter;
+  chromeImport: ChromeImportAdapter;
+  nativeMessaging: NativeMessagingAdapter;
+  voice: VoiceAdapter;
+  videoAudio: VideoAudioAdapter;
+  windowChrome: WindowChromeAdapter;
+  stealthUa: StealthUaAdapter;
+  secrets: SecretsAdapter;
+}

--- a/src/platform/video-audio/index.ts
+++ b/src/platform/video-audio/index.ts
@@ -1,0 +1,20 @@
+import type * as VideoRecorderModule from '../../video/recorder';
+import { NotImplementedError, type PlatformId } from '../errors';
+import type { VideoAudioAdapter } from '../types';
+
+export function createDarwinVideoAudioAdapter(): VideoAudioAdapter {
+  return {
+    createRecorder: () => {
+      const { VideoRecorderManager } = require('../../video/recorder') as typeof VideoRecorderModule;
+      return new VideoRecorderManager();
+    },
+  };
+}
+
+export function createUnsupportedVideoAudioAdapter(platform: PlatformId): VideoAudioAdapter {
+  return {
+    createRecorder: () => {
+      throw new NotImplementedError('Video recorder system audio', platform, 'phase-11');
+    },
+  };
+}

--- a/src/platform/voice/index.ts
+++ b/src/platform/voice/index.ts
@@ -1,0 +1,25 @@
+import type * as SpeechTranscriberModule from '../../voice/speech-transcriber';
+import { NotImplementedError, type PlatformId } from '../errors';
+import type { VoiceAdapter } from '../types';
+
+export function createDarwinVoiceAdapter(): VoiceAdapter {
+  return {
+    detectBackend: () => {
+      const { detectBackend } = require('../../voice/speech-transcriber') as typeof SpeechTranscriberModule;
+      return detectBackend();
+    },
+    transcribeAudio: async (audioBuffer, language) => {
+      const { transcribeAudio } = require('../../voice/speech-transcriber') as typeof SpeechTranscriberModule;
+      return transcribeAudio(audioBuffer, language);
+    },
+  };
+}
+
+export function createUnsupportedVoiceAdapter(platform: PlatformId): VoiceAdapter {
+  return {
+    detectBackend: () => 'none',
+    transcribeAudio: async () => {
+      throw new NotImplementedError('Voice transcription', platform, 'phase-10');
+    },
+  };
+}

--- a/src/platform/window-chrome/index.ts
+++ b/src/platform/window-chrome/index.ts
@@ -1,0 +1,22 @@
+import { NotImplementedError, type PlatformId } from '../errors';
+import type { WindowChromeAdapter } from '../types';
+
+export function createDarwinWindowChromeAdapter(): WindowChromeAdapter {
+  return {
+    getBrowserWindowOptions: () => ({
+      titleBarStyle: 'hiddenInset',
+      trafficLightPosition: { x: 16, y: 10 },
+      vibrancy: 'under-window',
+      visualEffectState: 'active',
+      backgroundColor: '#00000000',
+    }),
+  };
+}
+
+export function createUnsupportedWindowChromeAdapter(platform: PlatformId): WindowChromeAdapter {
+  return {
+    getBrowserWindowOptions: () => {
+      throw new NotImplementedError('Window chrome', platform, platform === 'win32' ? 'phase-6' : 'phase-1');
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Adds the typed `src/platform/` adapter foundation for phased Windows support.
- Adds platform capability profiles, `selectPlatform()`, Darwin wrapper adapters, and Windows/Linux stubs that throw `NotImplementedError` only for feature methods.
- Bumps the project version to `1.1.0` and updates public version references for the `feat:` release.

## Why
Phase 1 creates the adapter layer without changing production call sites, so later Windows phases can migrate platform-specific behavior behind one typed boundary while preserving current macOS behavior.

## Validation
- `npm run verify` passed locally on Windows.
- 143 Vitest files passed.
- 2900 tests passed, 39 skipped.
- Consistency check passed at `v1.1.0` with 253 MCP tools.

## Platform impact
- macOS: no production call sites migrated; existing behavior should be unchanged.
- Windows: adds stubs and capability metadata only; no public Windows support announcement.
- Linux: adds stubs and capability metadata only; no runtime behavior change.

## Notes for review
Private Windows support planning docs remain local-only and ignored by git.