### PR TITLE
[codex] Windows support phase 2 startup scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Tandem Browser will be documented in this file.
 
+## Unreleased
+
+### Changed
+
+- **Startup scripts** - replaced the Unix-only `npm start` shell preflight with
+  a Node launcher that compiles, clears stale local API port listeners per
+  platform, preserves the macOS Electron quarantine cleanup, and starts Electron
+  without changing the public platform support status.
+
 ## [v1.1.0] - 2026-05-04
 
 Windows support foundation. This release adds the platform adapter layer that

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "local-first"
   ],
   "scripts": {
-    "dev": "tsc && npm run bundle:preload && npx electron .",
-    "start": "xattr -cr node_modules/electron/dist/Electron.app 2>/dev/null; npm run compile && node scripts/run-electron.js",
+    "dev": "node scripts/start.js",
+    "start": "node scripts/start.js",
     "compile": "tsc && npm run bundle:preload",
     "watch": "tsc -w",
     "build": "tsc && npm run bundle:preload && electron-builder",

--- a/scripts/run-electron.js
+++ b/scripts/run-electron.js
@@ -1,114 +1,29 @@
+#!/usr/bin/env node
 /**
- * Run Electron from within VSCode (or any Electron-based environment)
- * 
- * VSCode sets ELECTRON_RUN_AS_NODE=true which causes Electron to run
- * as Node.js instead of a proper Electron app. We remove these vars.
- * 
- * Copied from TotalRecall Browser V2.
+ * Compatibility wrapper for direct Electron launches.
+ *
+ * npm start uses scripts/start.js directly. This helper remains for developers
+ * who want to launch the already-compiled app without running npm run compile.
  */
 const { spawn } = require('child_process');
 const path = require('path');
 
-let electronPath;
-if (process.platform === 'darwin') {
-    electronPath = path.join(__dirname, '..', 'node_modules', 'electron', 'dist', 'Electron.app', 'Contents', 'MacOS', 'Electron');
-} else if (process.platform === 'win32') {
-    electronPath = path.join(__dirname, '..', 'node_modules', 'electron', 'dist', 'electron.exe');
-} else {
-    electronPath = path.join(__dirname, '..', 'node_modules', 'electron', 'dist', 'electron');
-}
+const root = path.join(__dirname, '..');
+const startScript = path.join(__dirname, 'start.js');
 
-const appPath = path.join(__dirname, '..');
-
-// Clean environment — remove Electron-related variables from parent VSCode process
-const cleanEnv = { ...process.env };
-delete cleanEnv.ELECTRON_RUN_AS_NODE;
-delete cleanEnv.ATOM_SHELL_INTERNAL_RUN_AS_NODE;
-
-// macOS: clear quarantine flags (Gatekeeper kills unsigned Electron with SIGKILL)
-if (process.platform === 'darwin') {
-    const { execSync } = require('child_process');
-    const electronApp = path.join(__dirname, '..', 'node_modules', 'electron', 'dist', 'Electron.app');
-    try {
-        execSync(`xattr -cr "${electronApp}"`, { stdio: 'ignore' });
-        console.log('[run-electron] Cleared macOS quarantine flags');
-    } catch (e) {
-        // xattr may fail if already clean — that's fine
-    }
-}
-
-// Kill any leftover process on port 8765
-try {
-    const { execSync } = require('child_process');
-    const pids = execSync('/usr/sbin/lsof -ti :8765 2>/dev/null', { encoding: 'utf8' }).trim();
-    if (pids) {
-        execSync(`kill -9 ${pids.split('\n').join(' ')}`, { stdio: 'ignore' });
-        console.log('[run-electron] Killed leftover process on port 8765');
-    }
-} catch (e) {
-    // No process on port — good
-}
-
-// Clear stale Service Worker ScriptCache when extension source files are newer.
-// Electron caches compiled V8 bytecode; if the cache is stale, source patches
-// are silently ignored and old (pre-patch) bytecode runs instead.
-try {
-    const fs = require('fs');
-    const os = require('os');
-    const swCacheDir = path.join(
-        os.homedir(),
-        'Library', 'Application Support', 'tandem-browser',
-        'Partitions', 'tandem', 'Service Worker', 'ScriptCache'
-    );
-    const extDir = path.join(os.homedir(), '.tandem', 'extensions');
-    if (fs.existsSync(swCacheDir) && fs.existsSync(extDir)) {
-        // Find the newest mtime among cache files
-        const cacheFiles = fs.readdirSync(swCacheDir).filter(f => f !== 'index-dir');
-        const cacheMtime = cacheFiles.reduce((max, f) => {
-            try { return Math.max(max, fs.statSync(path.join(swCacheDir, f)).mtimeMs); } catch { return max; }
-        }, 0);
-        // Find the newest mtime among extension source files (bg.js, manifest, etc.)
-        let extMtime = 0;
-        const walkDir = (dir) => {
-            try {
-                for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-                    const full = path.join(dir, entry.name);
-                    if (entry.isDirectory()) { walkDir(full); }
-                    else { try { extMtime = Math.max(extMtime, fs.statSync(full).mtimeMs); } catch {} }
-                }
-            } catch {}
-        };
-        walkDir(extDir);
-        // Always clear cache — polyfill is injected in-memory (no file mtime change)
-        // so we can't reliably detect polyfill version changes via mtime alone.
-        let cleared = 0;
-        for (const f of cacheFiles) {
-            try { fs.unlinkSync(path.join(swCacheDir, f)); cleared++; } catch {}
-        }
-        if (cleared > 0) {
-            console.log(`[run-electron] Cleared ${cleared} SW bytecode cache file(s) (always-clear for polyfill freshness)`);
-        }
-    }
-} catch (e) {
-    // Non-fatal — cache will just be used as-is
-}
-
-console.log('[run-electron] Starting Tandem Browser...');
-
-const child = spawn(electronPath, ['.'], {
-    stdio: 'inherit',
-    cwd: appPath,
-    env: cleanEnv,
-    shell: false
+const child = spawn(process.execPath, [startScript, '--skip-compile'], {
+  cwd: root,
+  stdio: 'inherit',
+  shell: false
 });
 
-child.on('error', (err) => {
-    console.error('[run-electron] Failed to start:', err);
-    process.exit(1);
+child.on('error', (error) => {
+  console.error('[run-electron] Failed to start:', error);
+  process.exit(1);
 });
 
 child.on('close', (code) => {
-    process.exit(code || 0);
+  process.exit(code || 0);
 });
 
 process.on('SIGINT', () => child.kill('SIGINT'));

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -14,9 +14,41 @@ const root = path.join(__dirname, '..');
 const apiPort = '8765';
 const skipCompile = process.argv.includes('--skip-compile');
 
-function execFileQuiet(command, args, options = {}) {
+function runXattrClear(electronApp) {
   return new Promise((resolve) => {
-    execFile(command, args, options, (error, stdout, stderr) => {
+    execFile('xattr', ['-cr', electronApp], { cwd: root }, (error, stdout, stderr) => {
+      resolve({ error, stdout: stdout || '', stderr: stderr || '' });
+    });
+  });
+}
+
+function runLsofPortLookup() {
+  return new Promise((resolve) => {
+    execFile('lsof', ['-ti', `:${apiPort}`], { cwd: root }, (error, stdout, stderr) => {
+      resolve({ error, stdout: stdout || '', stderr: stderr || '' });
+    });
+  });
+}
+
+function runKillPids(pids) {
+  return new Promise((resolve) => {
+    execFile('kill', ['-9', ...pids], { cwd: root }, (error, stdout, stderr) => {
+      resolve({ error, stdout: stdout || '', stderr: stderr || '' });
+    });
+  });
+}
+
+function runNetstat() {
+  return new Promise((resolve) => {
+    execFile('netstat.exe', ['-ano'], { cwd: root }, (error, stdout, stderr) => {
+      resolve({ error, stdout: stdout || '', stderr: stderr || '' });
+    });
+  });
+}
+
+function runTaskkill(pid) {
+  return new Promise((resolve) => {
+    execFile('taskkill.exe', ['/PID', pid, '/F'], { cwd: root }, (error, stdout, stderr) => {
       resolve({ error, stdout: stdout || '', stderr: stderr || '' });
     });
   });
@@ -59,17 +91,14 @@ async function clearMacOSQuarantine() {
   if (process.platform !== 'darwin') return;
 
   const electronApp = path.join(root, 'node_modules', 'electron', 'dist', 'Electron.app');
-  const result = await execFileQuiet('xattr', ['-cr', electronApp]);
+  const result = await runXattrClear(electronApp);
   if (!result.error) {
     console.log('[start] Cleared macOS quarantine flags');
   }
 }
 
 async function killUnixPortProcess() {
-  const lsofPath = process.platform === 'darwin' && fs.existsSync('/usr/sbin/lsof')
-    ? '/usr/sbin/lsof'
-    : 'lsof';
-  const result = await execFileQuiet(lsofPath, ['-ti', `:${apiPort}`], { cwd: root });
+  const result = await runLsofPortLookup();
   const pids = result.stdout
     .split(/\r?\n/)
     .map((pid) => pid.trim())
@@ -77,7 +106,7 @@ async function killUnixPortProcess() {
 
   if (pids.length === 0) return;
 
-  await execFileQuiet('kill', ['-9', ...pids], { cwd: root });
+  await runKillPids(pids);
   console.log(`[start] Killed leftover process(es) on port ${apiPort}: ${pids.join(', ')}`);
 }
 
@@ -100,18 +129,13 @@ function parseWindowsNetstatPids(output) {
 }
 
 async function killWindowsPortProcess() {
-  const result = await execFileQuiet('cmd.exe', [
-    '/d',
-    '/s',
-    '/c',
-    `netstat -ano | findstr :${apiPort}`
-  ], { cwd: root });
+  const result = await runNetstat();
   const pids = parseWindowsNetstatPids(result.stdout);
 
   if (pids.length === 0) return;
 
   for (const pid of pids) {
-    await execFileQuiet('taskkill.exe', ['/PID', pid, '/F'], { cwd: root });
+    await runTaskkill(pid);
   }
   console.log(`[start] Killed leftover process(es) on port ${apiPort}: ${pids.join(', ')}`);
 }

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+/**
+ * Cross-platform startup launcher for Tandem Browser.
+ *
+ * This folds the previous npm start shell preflight and Electron spawn helper
+ * into one Node entrypoint so startup works from macOS, Windows, and Linux.
+ */
+const { execFile, spawn } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+const apiPort = '8765';
+const skipCompile = process.argv.includes('--skip-compile');
+
+function execFileQuiet(command, args, options = {}) {
+  return new Promise((resolve) => {
+    execFile(command, args, options, (error, stdout, stderr) => {
+      resolve({ error, stdout: stdout || '', stderr: stderr || '' });
+    });
+  });
+}
+
+function runCommand(command, args, label) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: root,
+      stdio: 'inherit',
+      shell: false
+    });
+
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`${label} exited with code ${code}`));
+    });
+  });
+}
+
+async function runCompile() {
+  if (skipCompile) {
+    console.log('[start] Skipping compile');
+    return;
+  }
+
+  const npmCommand = process.platform === 'win32' ? 'cmd.exe' : 'npm';
+  const npmArgs = process.platform === 'win32'
+    ? ['/d', '/s', '/c', 'npm run compile']
+    : ['run', 'compile'];
+  console.log('[start] Compiling TypeScript and preload bundle...');
+  await runCommand(npmCommand, npmArgs, 'npm run compile');
+}
+
+async function clearMacOSQuarantine() {
+  if (process.platform !== 'darwin') return;
+
+  const electronApp = path.join(root, 'node_modules', 'electron', 'dist', 'Electron.app');
+  const result = await execFileQuiet('xattr', ['-cr', electronApp]);
+  if (!result.error) {
+    console.log('[start] Cleared macOS quarantine flags');
+  }
+}
+
+async function killUnixPortProcess() {
+  const lsofPath = process.platform === 'darwin' && fs.existsSync('/usr/sbin/lsof')
+    ? '/usr/sbin/lsof'
+    : 'lsof';
+  const result = await execFileQuiet(lsofPath, ['-ti', `:${apiPort}`], { cwd: root });
+  const pids = result.stdout
+    .split(/\r?\n/)
+    .map((pid) => pid.trim())
+    .filter(Boolean);
+
+  if (pids.length === 0) return;
+
+  await execFileQuiet('kill', ['-9', ...pids], { cwd: root });
+  console.log(`[start] Killed leftover process(es) on port ${apiPort}: ${pids.join(', ')}`);
+}
+
+function parseWindowsNetstatPids(output) {
+  const pids = new Set();
+
+  for (const line of output.split(/\r?\n/)) {
+    const normalized = line.trim().replace(/\s+/g, ' ');
+    if (!normalized || !normalized.includes(`:${apiPort}`)) continue;
+
+    const parts = normalized.split(' ');
+    const pid = parts[parts.length - 1];
+    const state = parts.length >= 4 ? parts[parts.length - 2] : '';
+    if (state === 'LISTENING' && /^\d+$/.test(pid)) {
+      pids.add(pid);
+    }
+  }
+
+  return [...pids];
+}
+
+async function killWindowsPortProcess() {
+  const result = await execFileQuiet('cmd.exe', [
+    '/d',
+    '/s',
+    '/c',
+    `netstat -ano | findstr :${apiPort}`
+  ], { cwd: root });
+  const pids = parseWindowsNetstatPids(result.stdout);
+
+  if (pids.length === 0) return;
+
+  for (const pid of pids) {
+    await execFileQuiet('taskkill.exe', ['/PID', pid, '/F'], { cwd: root });
+  }
+  console.log(`[start] Killed leftover process(es) on port ${apiPort}: ${pids.join(', ')}`);
+}
+
+async function cleanupApiPort() {
+  if (process.platform === 'win32') {
+    await killWindowsPortProcess();
+    return;
+  }
+
+  if (process.platform === 'darwin' || process.platform === 'linux') {
+    await killUnixPortProcess();
+  }
+}
+
+function clearServiceWorkerScriptCache() {
+  try {
+    const swCacheDir = path.join(
+      os.homedir(),
+      'Library',
+      'Application Support',
+      'tandem-browser',
+      'Partitions',
+      'tandem',
+      'Service Worker',
+      'ScriptCache'
+    );
+    const extDir = path.join(os.homedir(), '.tandem', 'extensions');
+    if (!fs.existsSync(swCacheDir) || !fs.existsSync(extDir)) return;
+
+    const cacheFiles = fs.readdirSync(swCacheDir).filter((file) => file !== 'index-dir');
+    let cleared = 0;
+    for (const file of cacheFiles) {
+      try {
+        fs.unlinkSync(path.join(swCacheDir, file));
+        cleared++;
+      } catch {}
+    }
+
+    if (cleared > 0) {
+      console.log(`[start] Cleared ${cleared} SW bytecode cache file(s)`);
+    }
+  } catch {}
+}
+
+function electronExecutablePath() {
+  if (process.platform === 'darwin') {
+    return path.join(root, 'node_modules', 'electron', 'dist', 'Electron.app', 'Contents', 'MacOS', 'Electron');
+  }
+
+  if (process.platform === 'win32') {
+    return path.join(root, 'node_modules', 'electron', 'dist', 'electron.exe');
+  }
+
+  return path.join(root, 'node_modules', 'electron', 'dist', 'electron');
+}
+
+function startElectron() {
+  const cleanEnv = { ...process.env };
+  delete cleanEnv.ELECTRON_RUN_AS_NODE;
+  delete cleanEnv.ATOM_SHELL_INTERNAL_RUN_AS_NODE;
+
+  console.log('[start] Starting Tandem Browser...');
+  const child = spawn(electronExecutablePath(), ['.'], {
+    stdio: 'inherit',
+    cwd: root,
+    env: cleanEnv,
+    shell: false
+  });
+
+  child.on('error', (error) => {
+    console.error('[start] Failed to start:', error);
+    process.exit(1);
+  });
+
+  child.on('close', (code) => {
+    process.exit(code || 0);
+  });
+
+  process.on('SIGINT', () => child.kill('SIGINT'));
+  process.on('SIGTERM', () => child.kill('SIGTERM'));
+}
+
+async function main() {
+  await runCompile();
+  await clearMacOSQuarantine();
+  await cleanupApiPort();
+  clearServiceWorkerScriptCache();
+  startElectron();
+}
+
+main().catch((error) => {
+  console.error('[start] Startup failed:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Adds `scripts/start.js` as the cross-platform startup launcher for Tandem Browser.
- Updates `npm start` and `npm run dev` to use the Node launcher instead of Unix shell preflight syntax.
- Keeps `scripts/run-electron.js` as a compatibility wrapper for launching the already-compiled app via `scripts/start.js --skip-compile`.

## Why
Phase 2 removes the Unix-only `npm start` assumptions so startup can be handled consistently on macOS, Windows, and Linux. The launcher preserves the existing macOS quarantine cleanup, clears stale port `8765` listeners per platform, compiles before launch by default, and starts Electron with the same environment cleanup as before.

## Validation
- `npm run verify` passed locally on Windows.
- 143 Vitest files passed.
- 2900 tests passed, 39 skipped.
- `node --check scripts/start.js` passed.
- `node --check scripts/run-electron.js` passed.

## Platform impact
- macOS: intended to preserve the existing quarantine cleanup and Electron spawn behavior. Manual `npm start` on macOS still needs confirmation before merge.
- Windows: startup launcher now uses `cmd.exe`, `netstat`, and `taskkill` for compile and stale API-port cleanup.
- Linux: startup launcher uses `lsof` and `kill` for stale API-port cleanup.

## Scope control
- No `src/` or `shell/` changes.
- No Phase 3 CI matrix changes.
- No public Windows support announcement.