### PR TITLE
[codex] Windows support phase 3 CI matrix

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -6,7 +6,13 @@ on:
 
 jobs:
   verify:
-    runs-on: ubuntu-latest
+    name: Verify (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.os != 'macos-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - name: Check out repository
@@ -27,9 +33,11 @@ jobs:
         run: npm run verify
 
       - name: Generate coverage report
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: npx vitest run --coverage
 
       - name: Upload coverage to Codecov
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: codecov/codecov-action@v4
         with:
           files: coverage/lcov.info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Tandem Browser will be documented in this file.
 
 ### Changed
 
+- **CI verification matrix** - `npm run verify` now runs on Ubuntu, macOS, and
+  Windows in GitHub Actions, with fail-fast disabled, Linux-only coverage
+  upload, and only macOS blocking while Linux remains secondary and Windows is
+  still being built out.
 - **Startup scripts** - replaced the Unix-only `npm start` shell preflight with
   a Node launcher that compiles, clears stale local API port listeners per
   platform, preserves the macOS Electron quarantine cleanup, and starts Electron


### PR DESCRIPTION
## Summary
- Updates `.github/workflows/verify.yml` to run `npm run verify` on Ubuntu, macOS, and Windows.
- Disables matrix fail-fast so one OS failure does not cancel the other verification jobs.
- Keeps only macOS blocking; Ubuntu/Linux and Windows are best-effort/non-blocking.
- Keeps coverage generation and Codecov upload on Ubuntu only.

## Why
Phase 3 gives us visibility into macOS, Linux, and Windows verification while keeping the current priority clear: macOS must stay green, Windows is still being built, and Linux is secondary for now.

## Validation
- `actionlint .github/workflows/verify.yml` passed with no output.
- `npm run verify` passed locally on Windows.
- 143 Vitest files passed.
- 2900 tests passed, 39 skipped.
- Consistency check passed at `v1.1.0` with 253 MCP tools.

## Platform impact
- macOS: required/blocking verify matrix entry.
- Windows: verify matrix entry, best-effort/continue-on-error while Windows support is being built.
- Linux: verify matrix entry, best-effort/continue-on-error because Linux is secondary to macOS and Windows for this track.

## Manual repository setting note
After merge, branch protection should require only the macOS verify check for this matrix. Ubuntu/Linux and Windows should remain optional until explicitly promoted later.

## Scope control
- No release workflow changes.
- No CodeQL workflow changes.
- No runtime code changes.
- No public Windows support announcement.