### PR TITLE
feat: Windows user data paths

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -92,7 +92,8 @@ This keeps the dependency graph as a DAG with no circular imports.
 
 ### Where State Lives
 
-All persistent data is stored in `~/.tandem/`:
+Persistent data is stored via `tandemDir()`: `~/.tandem/` on macOS/Linux and
+`%APPDATA%\Tandem Browser\` on Windows.
 
 | Data | File/Directory | Manager |
 |------|---------------|---------|
@@ -117,7 +118,7 @@ All persistent data is stored in `~/.tandem/`:
 ### HTTP API (src/api/)
 
 Express server bound to `127.0.0.1:8765`. Bearer token auth from
-`~/.tandem/api-token`. 19 route files in `src/api/routes/`, all following:
+`tandemDir('api-token')`. 19 route files in `src/api/routes/`, all following:
 
 ```typescript
 export function registerXRoutes(router: Router, ctx: RouteContext): void {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to Tandem Browser will be documented in this file.
 
 ## Unreleased
 
+## [v1.2.0] - 2026-05-04
+
+Windows support Phase 4. Tandem's shared user-data helper now resolves through
+the platform adapter while preserving macOS and Linux legacy storage paths.
+
+### Added
+
+- **Windows user-data path adapter** - `tandemDir()` now delegates through
+  `src/platform/paths/`, keeping macOS/Linux on `~/.tandem` and resolving
+  Windows data under `%APPDATA%\Tandem Browser`.
+- **Path adapter tests** - added coverage proving the macOS legacy
+  `~/.tandem/api-token` path stays unchanged and Windows resolves through
+  `APPDATA/Tandem Browser`.
+
 ### Changed
 
 - **CI verification matrix** - `npm run verify` now runs on Ubuntu, macOS, and
@@ -14,6 +28,9 @@ All notable changes to Tandem Browser will be documented in this file.
   a Node launcher that compiles, clears stale local API port listeners per
   platform, preserves the macOS Electron quarantine cleanup, and starts Electron
   without changing the public platform support status.
+- **Local API token hints** - API and MCP code now use the platform data helper
+  for `api-token` lookups and messages, so macOS keeps `~/.tandem/api-token`
+  while Windows points local agents at the APPDATA-backed directory.
 
 ## [v1.1.0] - 2026-05-04
 

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -31,7 +31,7 @@ The security layer exists because when an AI has access to your browser, your th
 Data stays local. Sessions are isolated. Nothing leaves the machine through Tandem Browser without going through a filter first.
 
 **GitHub:** `hydro13/tandem-browser`  
-**Current version:** `1.1.0`
+**Current version:** `1.2.0`
 **Repository status:** Public developer preview  
 **Started:** February 11, 2026
 

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ contributors, not yet a polished mass-user release.
 - Secondary platform: Linux
 - Windows: validated as a remote agent host (VS Code + Claude Code over Tailscale)
 - Binaries: signed & notarized macOS Apple Silicon builds published on [GitHub Releases](https://github.com/hydro13/tandem-browser/releases), starting at v1.0.0
-- Current version: `1.1.0`
+- Current version: `1.2.0`
 - Package metadata: [package.json](package.json)
 
 ## Community

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@
 > Historical release summaries belong in `CHANGELOG.md`.
 > Architecture and product context belong in `PROJECT.md`.
 
-Last updated: April 21, 2026
+Last updated: May 4, 2026
 
 ## Purpose
 
@@ -14,7 +14,7 @@ Last updated: April 21, 2026
 
 ## Current Snapshot
 
-- Current app version: `1.1.0`
+- Current app version: `1.2.0`
 - MCP server: 253 tools (full API parity + awareness)
 - The codebase scope is larger than this backlog summary and includes major subsystems such as `sidebar`, `workspaces`, `pinboards`, `sync`, `headless`, and `sessions`.
 - Scheduled browsing already exists in baseline form via `WatchManager` and the `/watch/*` API routes.

--- a/docs/index.html
+++ b/docs/index.html
@@ -325,7 +325,7 @@ footer a:hover{color:var(--text2)}
 </header>
 
 <div class="hero">
-<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v1.1.0</div>
+<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v1.2.0</div>
 <p class="hero-lead">Tandem Browser is the <strong>open-source, local-first browser for AI agents</strong> — where the AI lives inside your real browser session, sharing your tabs, cookies, and DOM, ready to ask for your help the moment it gets stuck.</p>
 <h1>The browser becomes a <em>programmable workspace</em> where human intent and AI capability meet.</h1>
 <p>Tandem Browser is built around a simple shift: the AI is not a sidebar talking <em>about</em> your browser, it is <em>inside</em> it. Same tabs, same cookies, same logged-in sessions, same page you are looking at right now. Reading the accessibility tree, watching the network, writing live styles, handing back to you when something needs a human. It turns the web that already exists into something agents can actually operate on — no per-site API, no RPA rig, no screenshot loop. The real browser, as a shared human-AI symbiotic runtime.</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tandem-browser",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tandem-browser",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-browser",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Local-first Electron browser with a 253-tool MCP server, MCP/HTTP control surfaces, and built-in security controls",
   "main": "dist/main.js",
   "author": "Tandem Browser contributors",

--- a/src/agents/x-scout.ts
+++ b/src/agents/x-scout.ts
@@ -15,15 +15,16 @@
  * - Runs as a background task via Tandem API
  * - Uses humanized delays from Tandem's input system
  * - Reports via POST /chat
- * - Stores state in ~/.tandem/x-scout/
+ * - Stores state in the platform-specific Tandem data directory
  */
 
 import * as fs from 'fs';
 import * as path from 'path';
 import { API_PORT } from '../utils/constants';
+import { tandemDir } from '../utils/paths';
 
 const API = `http://localhost:${API_PORT}`;
-const SCOUT_DIR = path.join(process.env.HOME || '', '.tandem', 'x-scout');
+const SCOUT_DIR = tandemDir('x-scout');
 const STATE_FILE = path.join(SCOUT_DIR, 'state.json');
 const FINDINGS_FILE = path.join(SCOUT_DIR, 'findings.json');
 

--- a/src/api/routes/bootstrap.ts
+++ b/src/api/routes/bootstrap.ts
@@ -10,6 +10,7 @@
 import type { Router, Request, Response } from 'express';
 import { app } from 'electron';
 import type { RouteContext } from '../context';
+import { tandemDir } from '../../utils/paths';
 
 /** Capability families exposed by Tandem, grouped for agent discovery. */
 const CAPABILITY_FAMILIES = [
@@ -54,6 +55,7 @@ export function registerBootstrapRoutes(router: Router, _ctx: RouteContext): voi
   router.get('/agent', (req: Request, res: Response) => {
     const version = getVersion();
     const baseUrl = getBaseUrl(req);
+    const localTokenPath = tandemDir('api-token');
     res.type('text/markdown').send(`# Tandem Browser — Agent Bootstrap
 
 **Version:** ${version}
@@ -63,7 +65,7 @@ export function registerBootstrapRoutes(router: Router, _ctx: RouteContext): voi
 ## How to connect
 
 ### On the same machine as Tandem
-Read the local API token from \`~/.tandem/api-token\` and use it as:
+Read the local API token from \`${localTokenPath}\` and use it as:
 \`\`\`
 Authorization: Bearer <token>
 \`\`\`

--- a/src/api/routes/browser.ts
+++ b/src/api/routes/browser.ts
@@ -366,7 +366,7 @@ export function registerBrowserRoutes(router: Router, ctx: RouteContext): void {
       }
     } catch (e) {
       if (e instanceof Error && e.message === 'Path is outside the allowed directories') {
-        res.status(400).json({ error: 'Save path must be in ~/Desktop, ~/Downloads, or ~/.tandem' });
+        res.status(400).json({ error: `Save path must be in ~/Desktop, ~/Downloads, or ${tandemDir()}` });
         return;
       }
       handleRouteError(res, e);

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -78,7 +78,7 @@ interface ApiCallerInfo {
   extensionAccess?: ExtensionRouteAccessDecision | null;
 }
 
-/** Generate or load API auth token from ~/.tandem/api-token */
+/** Generate or load API auth token from the platform-specific Tandem data directory. */
 function getOrCreateAuthToken(): string {
   const baseDir = tandemDir();
   if (!fs.existsSync(baseDir)) fs.mkdirSync(baseDir, { recursive: true });
@@ -95,8 +95,12 @@ function getOrCreateAuthToken(): string {
 
   const token = crypto.randomBytes(32).toString('hex');
   fs.writeFileSync(tokenPath, token, { mode: 0o600 });
-  log.info('🔑 New API token generated → ~/.tandem/api-token');
+  log.info(`New API token generated at ${tokenPath}`);
   return token;
+}
+
+function getLocalApiTokenHint(): string {
+  return `Token is in ${tandemDir('api-token')}`;
 }
 
 /** Options object for TandemAPI constructor */
@@ -338,17 +342,17 @@ export class TandemAPI {
       return {
         allowed: false,
         caller,
-        reason: 'Unauthorized — query-string token auth was removed. Use Authorization: Bearer <token>. Token is in ~/.tandem/api-token',
+        reason: `Unauthorized — query-string token auth was removed. Use Authorization: Bearer <token>. ${getLocalApiTokenHint()}`,
         status: 401,
         extensionAccess: null,
       };
     }
 
     const reason = caller.kind === 'shell-internal'
-      ? 'Unauthorized — shell/file callers are no longer auto-trusted. Use Authorization: Bearer <token>. Token is in ~/.tandem/api-token'
+      ? `Unauthorized — shell/file callers are no longer auto-trusted. Use Authorization: Bearer <token>. ${getLocalApiTokenHint()}`
       : TRUSTED_EXTENSION_HTTP_PATHS.has(req.path)
         ? 'Unauthorized — this route is reserved for installed extension callers or bearer-token clients'
-        : 'Unauthorized — provide Authorization: Bearer <token>. Token is in ~/.tandem/api-token';
+        : `Unauthorized — provide Authorization: Bearer <token>. ${getLocalApiTokenHint()}`;
 
     return {
       allowed: false,

--- a/src/api/tests/routes/data.test.ts
+++ b/src/api/tests/routes/data.test.ts
@@ -14,10 +14,20 @@ vi.mock('fs', async () => {
       readdirSync: vi.fn().mockReturnValue([]),
       unlinkSync: vi.fn(),
       mkdirSync: vi.fn(),
+      promises: {
+        ...actual.promises,
+        readFile: vi.fn(),
+        writeFile: vi.fn(),
+      },
     },
     existsSync: vi.fn().mockReturnValue(false),
     readFileSync: vi.fn(),
     writeFileSync: vi.fn(),
+    promises: {
+      ...actual.promises,
+      readFile: vi.fn(),
+      writeFile: vi.fn(),
+    },
   };
 });
 
@@ -52,6 +62,7 @@ describe('Data Routes', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(fs.promises.writeFile).mockResolvedValue(undefined);
     ctx = createMockContext();
     app = createTestApp(registerDataRoutes, ctx);
   });

--- a/src/api/tests/routes/security.test.ts
+++ b/src/api/tests/routes/security.test.ts
@@ -14,6 +14,7 @@ vi.mock('../../../utils/logger', () => ({
 }));
 
 import { registerSecurityRoutes } from '../../../security/routes';
+import { tandemDir } from '../../../utils/paths';
 
 // ── Mock factory ────────────────────────────────────────────────
 
@@ -1123,7 +1124,7 @@ describe('security routes', () => {
       expect(res.status).toBe(200);
       expect(res.body).toEqual({
         secret: 'test-secret',
-        path: '~/.tandem/security/gatekeeper.secret',
+        path: tandemDir('security', 'gatekeeper.secret'),
       });
     });
 

--- a/src/config/tests/config.test.ts
+++ b/src/config/tests/config.test.ts
@@ -23,6 +23,7 @@ vi.mock('fs', async () => {
 
 import fs from 'fs';
 import { ConfigManager } from '../manager';
+import { tandemDir } from '../../utils/paths';
 
 describe('ConfigManager', () => {
   beforeEach(() => {
@@ -413,11 +414,11 @@ describe('ConfigManager', () => {
   });
 
   describe('directory creation', () => {
-    it('creates ~/.tandem directory if it does not exist', () => {
+    it('creates the platform-specific Tandem data directory if it does not exist', () => {
       vi.mocked(fs.existsSync).mockReturnValue(false);
       new ConfigManager();
       expect(fs.mkdirSync).toHaveBeenCalledWith(
-        expect.stringContaining('.tandem'),
+        tandemDir(),
         { recursive: true }
       );
     });

--- a/src/extensions/tests/extensions.test.ts
+++ b/src/extensions/tests/extensions.test.ts
@@ -9,7 +9,7 @@ import { nmProxy } from '../nm-proxy';
 import AdmZip from 'adm-zip';
 import fs from 'fs';
 import path from 'path';
-import os from 'os';
+import { tandemDir } from '../../utils/paths';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -364,7 +364,7 @@ describe('CRX Extraction', () => {
       .extractCrx(buffer, extensionId, format);
 
   beforeEach(() => {
-    tempDir = path.join(os.homedir(), '.tandem', 'extensions');
+    tempDir = tandemDir('extensions');
     if (!fs.existsSync(tempDir)) {
       fs.mkdirSync(tempDir, { recursive: true });
     }
@@ -548,7 +548,19 @@ describe('Chrome Importer', () => {
 
   it('isAlreadyImported returns false for non-existent extension', () => {
     const importer = new ChromeExtensionImporter();
-    expect(importer.isAlreadyImported('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaan')).toBe(false);
+    const chars = 'abcdefghijklmnop';
+    let extensionId = '';
+    const seedStart = Date.now();
+    for (let seed = seedStart; seed < seedStart + 64; seed++) {
+      const candidate = Array.from({ length: 32 }, (_value, index) => chars[(seed + index) % chars.length]).join('');
+      if (!fs.existsSync(path.join(tandemDir('extensions'), candidate))) {
+        extensionId = candidate;
+        break;
+      }
+    }
+
+    expect(extensionId).toMatch(/^[a-p]{32}$/);
+    expect(importer.isAlreadyImported(extensionId)).toBe(false);
   });
 
   it('supports different profile names', () => {
@@ -575,7 +587,7 @@ const RUN_NETWORK_TESTS = process.env.TANDEM_NETWORK_TESTS === 'true';
 describe.skipIf(!RUN_NETWORK_TESTS)('Extension Install Flow (network)', () => {
   const downloader = new CrxDownloader();
   const testExtId = 'gpmodmeblccallcadopbcoeoejepgpnb'; // JSON Formatter (small, fast)
-  const installPath = path.join(os.homedir(), '.tandem', 'extensions', testExtId);
+  const installPath = tandemDir('extensions', testExtId);
 
   afterAll(() => {
     // Clean up test download

--- a/src/import/chrome-importer.ts
+++ b/src/import/chrome-importer.ts
@@ -397,7 +397,7 @@ export class ChromeImporter {
       return {
         ok: false,
         count: 0,
-        error: 'Chrome cookies are encrypted. To import: (1) restart Chrome with --remote-debugging-port=9222, or (2) place decrypted cookies in ~/.tandem/chrome-cookies.json',
+        error: `Chrome cookies are encrypted. To import: (1) restart Chrome with --remote-debugging-port=9222, or (2) place decrypted cookies in ${path.join(this.tandemDir, 'chrome-cookies.json')}`,
       };
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);

--- a/src/integrations/tests/google-photos.test.ts
+++ b/src/integrations/tests/google-photos.test.ts
@@ -1,6 +1,4 @@
 import fs from 'fs';
-import os from 'os';
-import path from 'path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('fs', async () => {
@@ -24,9 +22,10 @@ vi.mock('fs', async () => {
 });
 
 import { GooglePhotosManager } from '../google-photos';
+import { tandemDir } from '../../utils/paths';
 
-const configPath = path.join(os.homedir(), '.tandem', 'google-photos.json');
-const authPath = path.join(os.homedir(), '.tandem', 'google-photos-auth.json');
+const configPath = tandemDir('google-photos.json');
+const authPath = tandemDir('google-photos-auth.json');
 
 describe('GooglePhotosManager', () => {
   const configManager = {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -3,6 +3,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import fs from 'node:fs';
 import path from 'node:path';
 import { API_PORT } from '../utils/constants';
+import { tandemDir } from '../utils/paths';
 import { registerAllTools, registerAllResources } from './register-all.js';
 
 // MCP uses stdio for protocol messages — ALL logging must go to stderr.
@@ -49,8 +50,7 @@ registerAllResources(server);
 function startEventListener(): void {
   const token = (() => {
     try {
-      const tokenPath = require('path').join(require('os').homedir(), '.tandem', 'api-token');
-      return require('fs').readFileSync(tokenPath, 'utf-8').trim();
+      return fs.readFileSync(tandemDir('api-token'), 'utf-8').trim();
     } catch { return ''; }
   })();
 

--- a/src/platform/capabilities.ts
+++ b/src/platform/capabilities.ts
@@ -76,7 +76,7 @@ const CAPABILITY_PROFILES: Record<PlatformId, PlatformSupportProfile> = {
       videoRecorderSystemAudio: unsupportedCapability('Windows WASAPI loopback planned in windows-support phase 11.'),
       keyboardShortcutsLabels: { status: 'partial', notes: 'Cross-platform labels finalized in windows-support phase 12.' },
       secretsAtRest: unsupportedCapability('Unified safeStorage adapter planned in windows-support phase 5.'),
-      userDataDirectory: unsupportedCapability('Windows APPDATA path planned in windows-support phase 4.'),
+      userDataDirectory: { status: 'supported', notes: 'Windows user data resolves to APPDATA/Tandem Browser.' },
     },
   },
   linux: {

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -2,7 +2,7 @@ import { getPlatformCapabilities, normalizePlatform } from './capabilities';
 import type { PlatformId } from './errors';
 import { createDarwinChromeImportAdapter, createUnsupportedChromeImportAdapter } from './chrome-import';
 import { createDarwinNativeMessagingAdapter, createUnsupportedNativeMessagingAdapter } from './native-messaging';
-import { createDarwinPathsAdapter, createUnsupportedPathsAdapter } from './paths';
+import { createDarwinPathsAdapter, createLinuxPathsAdapter, createUnsupportedPathsAdapter, createWindowsPathsAdapter } from './paths';
 import { createProcessAdapter } from './process';
 import { createDarwinSecretsAdapter, createUnsupportedSecretsAdapter } from './secrets';
 import { createDarwinStealthUaAdapter, createUnsupportedStealthUaAdapter } from './stealth-ua';
@@ -43,7 +43,11 @@ function createStubPlatform(id: PlatformId): PlatformAdapter {
   return {
     id,
     capabilities: getPlatformCapabilities(id),
-    paths: createUnsupportedPathsAdapter(id),
+    paths: id === 'win32'
+      ? createWindowsPathsAdapter()
+      : id === 'linux'
+        ? createLinuxPathsAdapter()
+        : createUnsupportedPathsAdapter(id),
     process: createProcessAdapter(id),
     chromeImport: createUnsupportedChromeImportAdapter(id),
     nativeMessaging: createUnsupportedNativeMessagingAdapter(id),

--- a/src/platform/paths/index.ts
+++ b/src/platform/paths/index.ts
@@ -1,18 +1,42 @@
-import type * as PathsModule from '../../utils/paths';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import { NotImplementedError, type PlatformId } from '../errors';
 import type { PathsAdapter } from '../types';
 
-export function createDarwinPathsAdapter(): PathsAdapter {
+const PRODUCT_DATA_DIR = 'Tandem Browser';
+
+function createNodePathsAdapter(resolveRoot: () => string): PathsAdapter {
   return {
-    tandemDir: (...subpath) => {
-      const { tandemDir } = require('../../utils/paths') as typeof PathsModule;
-      return tandemDir(...subpath);
-    },
+    tandemDir: (...subpath) => path.join(resolveRoot(), ...subpath),
     ensureDir: (dir) => {
-      const { ensureDir } = require('../../utils/paths') as typeof PathsModule;
-      return ensureDir(dir);
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+      return dir;
     },
   };
+}
+
+function legacyTandemRoot(): string {
+  return path.join(os.homedir(), '.tandem');
+}
+
+function windowsTandemRoot(): string {
+  const appData = process.env.APPDATA?.trim() || path.join(os.homedir(), 'AppData', 'Roaming');
+  return path.join(appData, PRODUCT_DATA_DIR);
+}
+
+export function createDarwinPathsAdapter(): PathsAdapter {
+  return createNodePathsAdapter(legacyTandemRoot);
+}
+
+export function createLinuxPathsAdapter(): PathsAdapter {
+  return createNodePathsAdapter(legacyTandemRoot);
+}
+
+export function createWindowsPathsAdapter(): PathsAdapter {
+  return createNodePathsAdapter(windowsTandemRoot);
 }
 
 export function createUnsupportedPathsAdapter(platform: PlatformId): PathsAdapter {

--- a/src/platform/tests/platform.test.ts
+++ b/src/platform/tests/platform.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from 'vitest';
+import os from 'os';
+import path from 'path';
 import { NotImplementedError, getPlatformCapabilities, selectPlatform } from '..';
 
 describe('selectPlatform', () => {
@@ -8,6 +10,7 @@ describe('selectPlatform', () => {
     expect(platform.id).toBe('darwin');
     expect(platform.process.isMacOS()).toBe(true);
     expect(platform.capabilities.capabilities.appStartup.status).toBe('supported');
+    expect(platform.paths.tandemDir('foo')).toBe(path.join(os.homedir(), '.tandem', 'foo'));
     expect(platform.windowChrome.getBrowserWindowOptions()).toMatchObject({
       titleBarStyle: 'hiddenInset',
     });
@@ -19,6 +22,7 @@ describe('selectPlatform', () => {
     expect(platform.id).toBe('win32');
     expect(platform.process.isWindows()).toBe(true);
     expect(platform.capabilities.capabilities.appStartup.status).toBe('unsupported');
+    expect(platform.capabilities.capabilities.userDataDirectory.status).toBe('supported');
     expect(() => platform.chromeImport.getUnavailableStatus()).not.toThrow();
     expect(() => platform.windowChrome.getBrowserWindowOptions()).toThrow(NotImplementedError);
   });
@@ -29,6 +33,7 @@ describe('selectPlatform', () => {
     expect(platform.id).toBe('linux');
     expect(platform.process.isLinux()).toBe(true);
     expect(platform.capabilities.capabilities.windowChrome.status).toBe('supported');
+    expect(platform.paths.tandemDir('foo')).toBe(path.join(os.homedir(), '.tandem', 'foo'));
     expect(() => platform.chromeImport.getUnavailableStatus()).not.toThrow();
     expect(() => platform.secrets.loadOrCreateInstallSecret()).toThrow(NotImplementedError);
   });
@@ -39,5 +44,23 @@ describe('selectPlatform', () => {
     expect(platform.id).toBe('unsupported');
     expect(platform.capabilities.tier).toBe('unsupported');
     expect(getPlatformCapabilities('freebsd').capabilities.appStartup.status).toBe('unsupported');
+  });
+
+  it('uses APPDATA/Tandem Browser for Windows user data paths', () => {
+    const originalAppData = process.env.APPDATA;
+    const appData = path.join(os.tmpdir(), 'tandem-appdata-test');
+    process.env.APPDATA = appData;
+
+    try {
+      const platform = selectPlatform('win32');
+
+      expect(platform.paths.tandemDir('foo')).toBe(path.join(appData, 'Tandem Browser', 'foo'));
+    } finally {
+      if (originalAppData === undefined) {
+        delete process.env.APPDATA;
+      } else {
+        process.env.APPDATA = originalAppData;
+      }
+    }
   });
 });

--- a/src/security/agent-trust.ts
+++ b/src/security/agent-trust.ts
@@ -24,8 +24,8 @@
 
 import { promises as fs } from 'fs';
 import * as path from 'path';
-import * as os from 'os';
 import { createLogger } from '../utils/logger';
+import { tandemDir } from '../utils/paths';
 
 const log = createLogger('AgentTrust');
 
@@ -115,7 +115,7 @@ export class AgentTrustStore {
   private persistInFlight: Promise<void> | null = null;
 
   constructor(storePath?: string) {
-    this.storePath = storePath ?? path.join(os.homedir(), '.tandem', 'agent-trust.json');
+    this.storePath = storePath ?? tandemDir('agent-trust.json');
   }
 
   /**

--- a/src/security/routes.ts
+++ b/src/security/routes.ts
@@ -3,6 +3,7 @@ import type { SecurityManager } from './security-manager';
 import type { GuardianMode, GatekeeperAction } from './types';
 import type { TaskManager } from '../agents/task-manager';
 import { createLogger } from '../utils/logger';
+import { tandemDir } from '../utils/paths';
 
 const log = createLogger('SecurityRoutes');
 
@@ -509,7 +510,7 @@ export function registerSecurityRoutes(
         res.status(503).json({ error: 'Gatekeeper not initialized' });
         return;
       }
-      res.json({ secret: gatekeeperWs.getSecret(), path: '~/.tandem/security/gatekeeper.secret' });
+      res.json({ secret: gatekeeperWs.getSecret(), path: tandemDir('security', 'gatekeeper.secret') });
     } catch (e) {
       res.status(500).json({ error: e instanceof Error ? e.message : String(e) });
     }

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,16 +1,11 @@
-import * as path from 'path';
-import * as os from 'os';
-import * as fs from 'fs';
+import { selectPlatform } from '../platform';
 
-/** Return absolute path under ~/.tandem/, e.g. tandemDir('extensions') → ~/.tandem/extensions */
+/** Return the platform-specific Tandem data path, e.g. `<userData>/extensions`. */
 export function tandemDir(...subpath: string[]): string {
-  return path.join(os.homedir(), '.tandem', ...subpath);
+  return selectPlatform().paths.tandemDir(...subpath);
 }
 
 /** Create directory if it doesn't exist (sync). Returns the path. */
 export function ensureDir(dir: string): string {
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
-  return dir;
+  return selectPlatform().paths.ensureDir(dir);
 }

--- a/src/utils/tests/utils.test.ts
+++ b/src/utils/tests/utils.test.ts
@@ -2,24 +2,31 @@ import { describe, it, expect, vi } from 'vitest';
 import path from 'path';
 import os from 'os';
 import { tandemDir, ensureDir } from '../paths';
+import { selectPlatform } from '../../platform';
 
 describe('tandemDir()', () => {
-  it('returns ~/.tandem with no arguments', () => {
-    expect(tandemDir()).toBe(path.join(os.homedir(), '.tandem'));
+  it('delegates the root path to the current platform adapter', () => {
+    expect(tandemDir()).toBe(selectPlatform().paths.tandemDir());
   });
 
-  it('appends a single subpath', () => {
-    expect(tandemDir('extensions')).toBe(path.join(os.homedir(), '.tandem', 'extensions'));
+  it('appends a single subpath through the current platform adapter', () => {
+    expect(tandemDir('extensions')).toBe(selectPlatform().paths.tandemDir('extensions'));
   });
 
   it('appends multiple subpath segments', () => {
     expect(tandemDir('security', 'blocklists')).toBe(
-      path.join(os.homedir(), '.tandem', 'security', 'blocklists')
+      selectPlatform().paths.tandemDir('security', 'blocklists')
     );
   });
 
   it('handles file names in subpath', () => {
-    expect(tandemDir('api-token')).toBe(path.join(os.homedir(), '.tandem', 'api-token'));
+    expect(tandemDir('api-token')).toBe(selectPlatform().paths.tandemDir('api-token'));
+  });
+
+  it('keeps the macOS legacy ~/.tandem api-token path pinned', () => {
+    expect(selectPlatform('darwin').paths.tandemDir('api-token')).toBe(
+      path.join(os.homedir(), '.tandem', 'api-token')
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- Route tandemDir() through the platform paths adapter without importing Electron app in shared helpers
- Keep macOS/Linux on ~/.tandem and resolve Windows data under %APPDATA%\Tandem Browser
- Update API/MCP token path hints, path-sensitive tests, version docs, and changelog for v1.2.0

## macOS safety
- Darwin paths adapter returns path.join(os.homedir(), '.tandem', ...subpath), preserving the existing ~/.tandem layout and ~/.tandem/api-token compatibility.
- Unit tests pin the macOS api-token path explicitly.

## Testing
- npm run verify

## Notes
- No Phase 5+ work included.
- No public Windows support announcement included.