### PR TITLE
feat: add safeStorage secret store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to Tandem Browser will be documented in this file.
 
 ## Unreleased
 
+## [v1.3.0] - 2026-05-04
+
+Windows support Phase 5. Tandem now has a safeStorage-backed secret-store
+adapter for Electron-owned secrets, while preserving the readable local
+`api-token` bootstrap file for MCP and HTTP clients.
+
+### Added
+
+- **Secret store adapter** (`src/security/secret-store/`) - added a small
+  filesystem-backed store with `get`, `set`, and `delete` operations using
+  Electron `safeStorage` for encrypted records.
+- **Plaintext initialization fallback** - when `safeStorage` is unavailable
+  during early initialization, the adapter can write an explicit
+  `plaintext-fallback-on-init` record instead of silently failing.
+- **Secret store tests** - added coverage for encrypted records, plaintext
+  fallback records, deletion, and key validation.
+
+### Changed
+
+- **Google Photos OAuth auth state** - migrated the Electron-owned
+  `google-photos-auth` secret to the new secret store, with legacy plaintext
+  readback and encrypted cleanup for existing installs.
+
+### Technical Details
+
+- Uses Electron `safeStorage.encryptString` and `safeStorage.decryptString`;
+  no `keytar` or new dependency was added.
+- `~/.tandem/api-token` remains plaintext and readable for local MCP/HTTP
+  bootstrap compatibility.
+
 ## [v1.2.0] - 2026-05-04
 
 Windows support Phase 4. Tandem's shared user-data helper now resolves through

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -31,7 +31,7 @@ The security layer exists because when an AI has access to your browser, your th
 Data stays local. Sessions are isolated. Nothing leaves the machine through Tandem Browser without going through a filter first.
 
 **GitHub:** `hydro13/tandem-browser`  
-**Current version:** `1.2.0`
+**Current version:** `1.3.0`
 **Repository status:** Public developer preview  
 **Started:** February 11, 2026
 

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ contributors, not yet a polished mass-user release.
 - Secondary platform: Linux
 - Windows: validated as a remote agent host (VS Code + Claude Code over Tailscale)
 - Binaries: signed & notarized macOS Apple Silicon builds published on [GitHub Releases](https://github.com/hydro13/tandem-browser/releases), starting at v1.0.0
-- Current version: `1.2.0`
+- Current version: `1.3.0`
 - Package metadata: [package.json](package.json)
 
 ## Community

--- a/TODO.md
+++ b/TODO.md
@@ -93,6 +93,9 @@ Last updated: May 4, 2026
 
 ## Recently Completed
 
+- [x] Windows support Phase 5: added the safeStorage-backed secret store with
+  encrypted and plaintext-initialization fallback records, plus Google Photos
+  OAuth auth migration while preserving the local `api-token` bootstrap file
 - [x] Version consistency sweep: package metadata, MCP server version reporting, README / PROJECT / landing-page version labels, and the consistency checker now stay aligned so startup and docs stop lagging behind the changelog
 - [x] Closed-panel Wingman handoff attention state: open handoffs now keep a durable toolbar/toggle cue with count, status-derived urgency, and a non-spammy delayed escalation state so "the agent still needs you" stays visible after the transient popup disappears
 - [x] Explicit human↔agent handoffs: durable handoff records with statuses (`needs_human`, `blocked`, `waiting_approval`, `ready_to_resume`, `completed_review`, `resolved`) now exist across HTTP API, MCP tools, live event surfaces, and the Wingman Activity inbox, with workspace/tab targeting and resolve/resume actions

--- a/docs/index.html
+++ b/docs/index.html
@@ -325,7 +325,7 @@ footer a:hover{color:var(--text2)}
 </header>
 
 <div class="hero">
-<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v1.2.0</div>
+<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v1.3.0</div>
 <p class="hero-lead">Tandem Browser is the <strong>open-source, local-first browser for AI agents</strong> — where the AI lives inside your real browser session, sharing your tabs, cookies, and DOM, ready to ask for your help the moment it gets stuck.</p>
 <h1>The browser becomes a <em>programmable workspace</em> where human intent and AI capability meet.</h1>
 <p>Tandem Browser is built around a simple shift: the AI is not a sidebar talking <em>about</em> your browser, it is <em>inside</em> it. Same tabs, same cookies, same logged-in sessions, same page you are looking at right now. Reading the accessibility tree, watching the network, writing live styles, handing back to you when something needs a human. It turns the web that already exists into something agents can actually operate on — no per-site API, no RPA rig, no screenshot loop. The real browser, as a shared human-AI symbiotic runtime.</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tandem-browser",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tandem-browser",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-browser",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Local-first Electron browser with a 253-tool MCP server, MCP/HTTP control surfaces, and built-in security controls",
   "main": "dist/main.js",
   "author": "Tandem Browser contributors",

--- a/src/integrations/google-photos.ts
+++ b/src/integrations/google-photos.ts
@@ -5,6 +5,8 @@ import { API_PORT } from '../utils/constants';
 import { tandemDir } from '../utils/paths';
 import type { ConfigManager } from '../config/manager';
 import { createLogger } from '../utils/logger';
+import type { SecretStore } from '../security/secret-store';
+import { getDefaultSecretStore } from '../security/secret-store';
 
 const log = createLogger('GooglePhotos');
 const GOOGLE_AUTH_URL = 'https://accounts.google.com/o/oauth2/v2/auth';
@@ -12,6 +14,7 @@ const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
 const GOOGLE_PHOTOS_UPLOAD_URL = 'https://photoslibrary.googleapis.com/v1/uploads';
 const GOOGLE_PHOTOS_BATCH_CREATE_URL = 'https://photoslibrary.googleapis.com/v1/mediaItems:batchCreate';
 const GOOGLE_PHOTOS_SCOPE = 'https://www.googleapis.com/auth/photoslibrary.appendonly';
+const GOOGLE_PHOTOS_AUTH_SECRET = 'google-photos-auth';
 
 // ─── Types ───
 
@@ -80,11 +83,13 @@ export class GooglePhotosManager {
   private configManager: ConfigManager;
   private configPath: string;
   private authPath: string;
+  private secretStore: SecretStore;
   private pendingAuth: PendingAuth | null = null;
 
   // === 2. Constructor ===
-  constructor(configManager: ConfigManager) {
+  constructor(configManager: ConfigManager, secretStore: SecretStore = getDefaultSecretStore()) {
     this.configManager = configManager;
+    this.secretStore = secretStore;
     const baseDir = tandemDir();
     if (!fs.existsSync(baseDir)) {
       fs.mkdirSync(baseDir, { recursive: true });
@@ -204,6 +209,7 @@ export class GooglePhotosManager {
   /** Disconnect from Google Photos by deleting stored auth tokens. */
   disconnect(): GooglePhotosStatus {
     this.pendingAuth = null;
+    this.secretStore.delete(GOOGLE_PHOTOS_AUTH_SECRET);
     if (fs.existsSync(this.authPath)) {
       fs.unlinkSync(this.authPath);
     }
@@ -291,11 +297,28 @@ export class GooglePhotosManager {
   }
 
   private loadAuth(): GooglePhotosAuth | null {
-    return parseJsonFile<GooglePhotosAuth>(this.authPath);
+    const stored = this.secretStore.get(GOOGLE_PHOTOS_AUTH_SECRET);
+    if (stored) {
+      return JSON.parse(stored) as GooglePhotosAuth;
+    }
+
+    const legacy = parseJsonFile<GooglePhotosAuth>(this.authPath);
+    if (!legacy) {
+      return null;
+    }
+
+    const result = this.secretStore.set(GOOGLE_PHOTOS_AUTH_SECRET, JSON.stringify(legacy, null, 2));
+    if (result.encoding === 'safe-storage') {
+      try { fs.unlinkSync(this.authPath); } catch { /* best effort legacy cleanup */ }
+    }
+    return legacy;
   }
 
   private saveAuth(auth: GooglePhotosAuth): void {
-    fs.writeFileSync(this.authPath, JSON.stringify(auth, null, 2), { mode: 0o600 });
+    const result = this.secretStore.set(GOOGLE_PHOTOS_AUTH_SECRET, JSON.stringify(auth, null, 2));
+    if (result.encoding === 'safe-storage' && fs.existsSync(this.authPath)) {
+      try { fs.unlinkSync(this.authPath); } catch { /* best effort legacy cleanup */ }
+    }
   }
 
   private async getValidAccessToken(): Promise<string | null> {

--- a/src/integrations/tests/google-photos.test.ts
+++ b/src/integrations/tests/google-photos.test.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SecretStore } from '../../security/secret-store';
 
 vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof fs>('fs');
@@ -26,6 +27,22 @@ import { tandemDir } from '../../utils/paths';
 
 const configPath = tandemDir('google-photos.json');
 const authPath = tandemDir('google-photos-auth.json');
+const secretRecordPath = tandemDir('secret-store', 'google-photos-auth.json');
+
+function createMemorySecretStore(initialValue: string | null = null): SecretStore {
+  let stored = initialValue;
+  return {
+    get: vi.fn(() => stored),
+    set: vi.fn((_key: string, value: string) => {
+      stored = value;
+      return { encoding: 'safe-storage' as const, path: secretRecordPath };
+    }),
+    delete: vi.fn(() => {
+      stored = null;
+    }),
+    getRecordPath: vi.fn(() => secretRecordPath),
+  } as unknown as SecretStore;
+}
 
 describe('GooglePhotosManager', () => {
   const configManager = {
@@ -43,7 +60,8 @@ describe('GooglePhotosManager', () => {
   });
 
   it('stores a client id and reports status', () => {
-    const manager = new GooglePhotosManager(configManager);
+    const secretStore = createMemorySecretStore();
+    const manager = new GooglePhotosManager(configManager, secretStore);
     const status = manager.setClientId('desktop-client-id.apps.googleusercontent.com');
 
     expect(fs.writeFileSync).toHaveBeenCalledWith(
@@ -64,7 +82,7 @@ describe('GooglePhotosManager', () => {
       return '' as any;
     });
 
-    const manager = new GooglePhotosManager(configManager);
+    const manager = new GooglePhotosManager(configManager, createMemorySecretStore());
     const authUrl = manager.beginAuth();
     const url = new URL(authUrl);
 
@@ -110,7 +128,8 @@ describe('GooglePhotosManager', () => {
         ],
       }), { status: 200 }));
 
-    const manager = new GooglePhotosManager(configManager);
+    const secretStore = createMemorySecretStore();
+    const manager = new GooglePhotosManager(configManager, secretStore);
     const result = await manager.uploadScreenshot('/tmp/test.png');
 
     expect(globalThis.fetch).toHaveBeenNthCalledWith(1, 'https://photoslibrary.googleapis.com/v1/uploads', expect.objectContaining({
@@ -125,10 +144,37 @@ describe('GooglePhotosManager', () => {
       mediaItemId: 'media-1',
       productUrl: 'https://photos.google.com/lr/photo/abc',
     });
-    expect(fs.writeFileSync).toHaveBeenCalledWith(
-      authPath,
+    expect(secretStore.set).toHaveBeenLastCalledWith(
+      'google-photos-auth',
       expect.stringContaining('"lastUploadAt"'),
-      { mode: 0o600 },
     );
+  });
+
+  it('migrates legacy Google Photos auth into the encrypted secret store', () => {
+    vi.mocked(fs.existsSync).mockImplementation((filePath) => filePath === authPath);
+    vi.mocked(fs.readFileSync).mockImplementation((filePath) => {
+      if (filePath === authPath) {
+        return JSON.stringify({
+          accessToken: 'access-token',
+          refreshToken: 'refresh-token',
+          expiresAt: Date.now() + 120_000,
+          scope: 'https://www.googleapis.com/auth/photoslibrary.appendonly',
+          tokenType: 'Bearer',
+          updatedAt: '2026-03-08T00:00:00.000Z',
+        }) as any;
+      }
+      return '' as any;
+    });
+
+    const secretStore = createMemorySecretStore();
+    const manager = new GooglePhotosManager(configManager, secretStore);
+    const status = manager.getStatus();
+
+    expect(status.connected).toBe(true);
+    expect(secretStore.set).toHaveBeenCalledWith(
+      'google-photos-auth',
+      expect.stringContaining('"refreshToken"'),
+    );
+    expect(fs.unlinkSync).toHaveBeenCalledWith(authPath);
   });
 });

--- a/src/security/secret-store/index.ts
+++ b/src/security/secret-store/index.ts
@@ -1,0 +1,162 @@
+import fs from 'fs';
+import path from 'path';
+import { tandemDir } from '../../utils/paths';
+
+type SecretEncoding = 'safe-storage' | 'plaintext-fallback-on-init';
+
+export interface SafeStorageProvider {
+  isEncryptionAvailable(): boolean;
+  encryptString(plainText: string): Buffer;
+  decryptString(encrypted: Buffer): string;
+  getSelectedStorageBackend?(): string;
+}
+
+export interface SecretStoreRecord {
+  version: 1;
+  key: string;
+  encoding: SecretEncoding;
+  createdAt: string;
+  updatedAt: string;
+  ciphertext?: string;
+  plaintext?: string;
+  fallbackReason?: string;
+}
+
+export interface SecretStoreSetResult {
+  encoding: SecretEncoding;
+  path: string;
+}
+
+export interface SecretStoreOptions {
+  rootDir?: string;
+  safeStorage?: SafeStorageProvider;
+  allowPlaintextFallbackOnInit?: boolean;
+  now?: () => Date;
+}
+
+const KEY_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$/;
+
+/**
+ * Stores Electron-owned secrets using Electron safeStorage when available.
+ * During very early app startup, safeStorage can be unavailable; callers may
+ * allow an explicit plaintext fallback record for initialization-only paths.
+ */
+export class SecretStore {
+  private readonly rootDir: string;
+  private readonly safeStorage?: SafeStorageProvider;
+  private readonly allowPlaintextFallbackOnInit: boolean;
+  private readonly now: () => Date;
+
+  constructor(options: SecretStoreOptions = {}) {
+    this.rootDir = options.rootDir ?? tandemDir('secret-store');
+    this.safeStorage = options.safeStorage;
+    this.allowPlaintextFallbackOnInit = options.allowPlaintextFallbackOnInit ?? true;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  get(key: string): string | null {
+    const recordPath = this.getRecordPath(key);
+    if (!fs.existsSync(recordPath)) {
+      return null;
+    }
+
+    const record = this.readRecord(recordPath);
+    if (record.encoding === 'plaintext-fallback-on-init') {
+      return record.plaintext ?? null;
+    }
+
+    if (!record.ciphertext) {
+      throw new Error(`Secret store record ${key} is missing ciphertext`);
+    }
+
+    const safeStorage = this.getSafeStorage();
+    return safeStorage.decryptString(Buffer.from(record.ciphertext, 'base64'));
+  }
+
+  set(key: string, value: string): SecretStoreSetResult {
+    const recordPath = this.getRecordPath(key);
+    const existing = fs.existsSync(recordPath) ? this.readRecord(recordPath) : null;
+    const timestamp = this.now().toISOString();
+    const base = {
+      version: 1 as const,
+      key,
+      createdAt: existing?.createdAt ?? timestamp,
+      updatedAt: timestamp,
+    };
+
+    const safeStorage = this.getSafeStorage();
+    let record: SecretStoreRecord;
+    if (safeStorage.isEncryptionAvailable()) {
+      record = {
+        ...base,
+        encoding: 'safe-storage',
+        ciphertext: safeStorage.encryptString(value).toString('base64'),
+      };
+    } else {
+      if (!this.allowPlaintextFallbackOnInit) {
+        throw new Error('Electron safeStorage encryption is not available');
+      }
+
+      record = {
+        ...base,
+        encoding: 'plaintext-fallback-on-init',
+        plaintext: value,
+        fallbackReason: 'Electron safeStorage encryption was unavailable during initialization',
+      };
+    }
+
+    fs.mkdirSync(path.dirname(recordPath), { recursive: true });
+    fs.writeFileSync(recordPath, JSON.stringify(record, null, 2), { mode: 0o600 });
+    try { fs.chmodSync(recordPath, 0o600); } catch { /* best effort on platforms without chmod semantics */ }
+    return { encoding: record.encoding, path: recordPath };
+  }
+
+  delete(key: string): void {
+    const recordPath = this.getRecordPath(key);
+    if (fs.existsSync(recordPath)) {
+      fs.unlinkSync(recordPath);
+    }
+  }
+
+  getRecordPath(key: string): string {
+    this.validateKey(key);
+    return path.join(this.rootDir, `${key}.json`);
+  }
+
+  private readRecord(recordPath: string): SecretStoreRecord {
+    const parsed = JSON.parse(fs.readFileSync(recordPath, 'utf-8')) as Partial<SecretStoreRecord>;
+    if (
+      parsed.version !== 1 ||
+      typeof parsed.key !== 'string' ||
+      (parsed.encoding !== 'safe-storage' && parsed.encoding !== 'plaintext-fallback-on-init')
+    ) {
+      throw new Error(`Invalid secret store record: ${recordPath}`);
+    }
+    return parsed as SecretStoreRecord;
+  }
+
+  private validateKey(key: string): void {
+    if (!KEY_PATTERN.test(key)) {
+      throw new Error(`Invalid secret key name: ${key}`);
+    }
+  }
+
+  private getSafeStorage(): SafeStorageProvider {
+    if (this.safeStorage) {
+      return this.safeStorage;
+    }
+
+    const electron = require('electron') as { safeStorage?: SafeStorageProvider };
+    if (!electron.safeStorage) {
+      throw new Error('Electron safeStorage is not available outside the Electron main process');
+    }
+    return electron.safeStorage;
+  }
+}
+
+let defaultSecretStore: SecretStore | null = null;
+
+export function getDefaultSecretStore(): SecretStore {
+  defaultSecretStore ??= new SecretStore();
+  return defaultSecretStore;
+}

--- a/src/security/tests/secret-store.test.ts
+++ b/src/security/tests/secret-store.test.ts
@@ -1,0 +1,94 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SecretStore, type SafeStorageProvider } from '../secret-store';
+
+function createTempRoot(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'tandem-secret-store-'));
+}
+
+function createSafeStorageMock(encryptionAvailable = true): SafeStorageProvider {
+  return {
+    isEncryptionAvailable: vi.fn(() => encryptionAvailable),
+    encryptString: vi.fn((plainText: string) => Buffer.from(`encrypted:${plainText}`, 'utf-8')),
+    decryptString: vi.fn((encrypted: Buffer) => {
+      const value = encrypted.toString('utf-8');
+      if (!value.startsWith('encrypted:')) {
+        throw new Error('Invalid ciphertext');
+      }
+      return value.slice('encrypted:'.length);
+    }),
+  };
+}
+
+describe('SecretStore', () => {
+  const tempRoots: string[] = [];
+
+  afterEach(() => {
+    for (const root of tempRoots.splice(0)) {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('stores and reads encrypted records through Electron safeStorage', () => {
+    const rootDir = createTempRoot();
+    tempRoots.push(rootDir);
+    const safeStorage = createSafeStorageMock(true);
+    const store = new SecretStore({ rootDir, safeStorage });
+
+    const result = store.set('oauth-refresh', 'refresh-token');
+    const recordText = fs.readFileSync(result.path, 'utf-8');
+    const record = JSON.parse(recordText) as { encoding: string; ciphertext?: string; plaintext?: string };
+
+    expect(result.encoding).toBe('safe-storage');
+    expect(record.encoding).toBe('safe-storage');
+    expect(record.ciphertext).toBe(Buffer.from('encrypted:refresh-token').toString('base64'));
+    expect(record.plaintext).toBeUndefined();
+    expect(store.get('oauth-refresh')).toBe('refresh-token');
+    expect(safeStorage.decryptString).toHaveBeenCalledOnce();
+  });
+
+  it('writes a plaintext fallback record when safeStorage is unavailable during init', () => {
+    const rootDir = createTempRoot();
+    tempRoots.push(rootDir);
+    const safeStorage = createSafeStorageMock(false);
+    const store = new SecretStore({ rootDir, safeStorage });
+
+    const result = store.set('early-init-secret', 'bootstrap-secret');
+    const record = JSON.parse(fs.readFileSync(result.path, 'utf-8')) as {
+      encoding: string;
+      plaintext?: string;
+      fallbackReason?: string;
+    };
+
+    expect(result.encoding).toBe('plaintext-fallback-on-init');
+    expect(record.encoding).toBe('plaintext-fallback-on-init');
+    expect(record.plaintext).toBe('bootstrap-secret');
+    expect(record.fallbackReason).toContain('safeStorage encryption was unavailable');
+    expect(store.get('early-init-secret')).toBe('bootstrap-secret');
+    expect(safeStorage.encryptString).not.toHaveBeenCalled();
+  });
+
+  it('deletes records by key', () => {
+    const rootDir = createTempRoot();
+    tempRoots.push(rootDir);
+    const store = new SecretStore({ rootDir, safeStorage: createSafeStorageMock(true) });
+
+    const result = store.set('to-delete', 'secret');
+    expect(fs.existsSync(result.path)).toBe(true);
+
+    store.delete('to-delete');
+    expect(fs.existsSync(result.path)).toBe(false);
+    expect(store.get('to-delete')).toBeNull();
+  });
+
+  it('rejects unsafe key names', () => {
+    const rootDir = createTempRoot();
+    tempRoots.push(rootDir);
+    const store = new SecretStore({ rootDir, safeStorage: createSafeStorageMock(true) });
+
+    expect(() => store.set('../escape', 'secret')).toThrow('Invalid secret key name');
+    expect(() => store.get('nested/path')).toThrow('Invalid secret key name');
+  });
+});


### PR DESCRIPTION
## Built
- Windows support Phase 5 only: added `src/security/secret-store/` with `get`, `set`, and `delete` operations backed by Electron `safeStorage`.
- Added explicit `plaintext-fallback-on-init` records for initialization paths where `safeStorage.isEncryptionAvailable()` is false.
- Migrated only Google Photos OAuth auth state as the Electron-owned proof consumer, with legacy plaintext readback and encrypted cleanup.

## Scope Guardrails
- No Phase 6+ work included.
- No dependency added; this uses Electron `safeStorage`, not `keytar`.
- `~/.tandem/api-token` remains plaintext and readable for MCP/HTTP bootstrap compatibility.
- No public Windows support announcement was added.
- Private Windows support docs remain ignored/local-only.

## macOS Safety
- macOS continues to use Electron `safeStorage`, which maps to Keychain-backed storage per Electron semantics.
- Existing Google Photos plaintext auth is still readable; it is migrated only after a successful encrypted write.
- Existing local API token behavior and path remain unchanged for macOS local agents.

## Tested
- `npm run verify` - compile, lint, full Vitest suite, and consistency check passed.