### PR TITLE
[codex] feat: windows window chrome (phase 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to Tandem Browser will be documented in this file.
 
 ## Unreleased
 
+## [v1.4.0] - 2026-05-04
+
+Windows support Phase 6. Tandem now uses adapter-driven window chrome options
+and gives Windows source runs a frameless browser window with shell-owned
+minimize, maximize/restore, and close controls.
+
+### Added
+
+- **Windows window chrome adapter** (`src/platform/window-chrome/`) - added a
+  Windows BrowserWindow option path returning `frame: false` for custom
+  shell-owned titlebar controls.
+- **Windows platform body class** (`shell/js/window-chrome.js`) - adds
+  `platform-win` on Windows while preserving the existing platform class.
+
+### Changed
+
+- **BrowserWindow option selection** (`src/main.ts`) - moved platform-specific
+  window chrome branching into the platform adapter.
+- **Shell chrome CSS** (`shell/css/browser-shell.css`) - targets Windows
+  titlebar padding and controls through `platform-win`, while keeping existing
+  macOS hidden inset titlebar selectors intact.
+
+### Technical Details
+
+- macOS BrowserWindow options remain hidden inset titlebar, traffic-light
+  position, under-window vibrancy, active visual effect state, and transparent
+  background.
+- Linux remains frameless through the same adapter pattern used by Windows.
+
 ## [v1.3.0] - 2026-05-04
 
 Windows support Phase 5. Tandem now has a safeStorage-backed secret-store

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -31,7 +31,7 @@ The security layer exists because when an AI has access to your browser, your th
 Data stays local. Sessions are isolated. Nothing leaves the machine through Tandem Browser without going through a filter first.
 
 **GitHub:** `hydro13/tandem-browser`  
-**Current version:** `1.3.0`
+**Current version:** `1.4.0`
 **Repository status:** Public developer preview  
 **Started:** February 11, 2026
 

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ contributors, not yet a polished mass-user release.
 - Secondary platform: Linux
 - Windows: validated as a remote agent host (VS Code + Claude Code over Tailscale)
 - Binaries: signed & notarized macOS Apple Silicon builds published on [GitHub Releases](https://github.com/hydro13/tandem-browser/releases), starting at v1.0.0
-- Current version: `1.3.0`
+- Current version: `1.4.0`
 - Package metadata: [package.json](package.json)
 
 ## Community

--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@ Last updated: May 4, 2026
 
 ## Current Snapshot
 
-- Current app version: `1.2.0`
+- Current app version: `1.4.0`
 - MCP server: 253 tools (full API parity + awareness)
 - The codebase scope is larger than this backlog summary and includes major subsystems such as `sidebar`, `workspaces`, `pinboards`, `sync`, `headless`, and `sessions`.
 - Scheduled browsing already exists in baseline form via `WatchManager` and the `/watch/*` API routes.
@@ -93,6 +93,9 @@ Last updated: May 4, 2026
 
 ## Recently Completed
 
+- [x] Windows support Phase 6: moved BrowserWindow chrome options into the
+  platform adapter, enabled frameless Windows source runs, and reused the
+  shell-owned min/max/close titlebar controls behind a Windows body class
 - [x] Windows support Phase 5: added the safeStorage-backed secret store with
   encrypted and plaintext-initialization fallback records, plus Google Photos
   OAuth auth migration while preserving the local `api-token` bootstrap file

--- a/docs/index.html
+++ b/docs/index.html
@@ -325,7 +325,7 @@ footer a:hover{color:var(--text2)}
 </header>
 
 <div class="hero">
-<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v1.3.0</div>
+<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v1.4.0</div>
 <p class="hero-lead">Tandem Browser is the <strong>open-source, local-first browser for AI agents</strong> — where the AI lives inside your real browser session, sharing your tabs, cookies, and DOM, ready to ask for your help the moment it gets stuck.</p>
 <h1>The browser becomes a <em>programmable workspace</em> where human intent and AI capability meet.</h1>
 <p>Tandem Browser is built around a simple shift: the AI is not a sidebar talking <em>about</em> your browser, it is <em>inside</em> it. Same tabs, same cookies, same logged-in sessions, same page you are looking at right now. Reading the accessibility tree, watching the network, writing live styles, handing back to you when something needs a human. It turns the web that already exists into something agents can actually operate on — no per-site API, no RPA rig, no screenshot loop. The real browser, as a shared human-AI symbiotic runtime.</p>

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -40,7 +40,7 @@
 | App startup (`npm start` from source) | supported | unsupported | partial | Windows blocked by Unix-only start script; fixed in windows-support phase 2. |
 | Signed installer | supported | unsupported | unsupported | Windows installer planned in windows-support phase 13–14. |
 | Auto-update | supported | unsupported | unsupported | Windows feed planned in windows-support phase 15. |
-| Custom titlebar / window chrome | supported | unsupported | supported | Windows custom titlebar planned in windows-support phase 6. |
+| Custom titlebar / window chrome | supported | supported | supported | Windows source runs use frameless shell-owned controls; public Windows release remains unannounced. |
 | Stealth UA matches host OS | supported | unsupported | partial | Windows UA persona planned in windows-support phase 7. |
 | Chrome bookmark + history import | supported | unsupported | partial | Windows path detection planned in windows-support phase 8. |
 | Chrome cookie import | partial | unsupported | partial | Windows DPAPI decrypt evaluated in windows-support phase 8. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tandem-browser",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tandem-browser",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-browser",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Local-first Electron browser with a 253-tool MCP server, MCP/HTTP control surfaces, and built-in security controls",
   "main": "dist/main.js",
   "author": "Tandem Browser contributors",

--- a/shell/css/browser-shell.css
+++ b/shell/css/browser-shell.css
@@ -198,12 +198,14 @@
     }
 
     /* Platform-specific padding for native controls */
-    body.platform-darwin .tab-bar {
+    body.platform-darwin .tab-bar,
+    body.platform-mac .tab-bar {
       padding-left: 80px;
       /* macOS traffic lights */
     }
 
     body.platform-linux .tab-bar,
+    body.platform-win .tab-bar,
     body.platform-win32 .tab-bar {
       padding-right: 140px;
       /* Space for custom window controls */
@@ -431,6 +433,7 @@
     }
 
     body.platform-linux .window-controls,
+    body.platform-win .window-controls,
     body.platform-win32 .window-controls {
       display: flex;
     }

--- a/shell/js/window-chrome.js
+++ b/shell/js/window-chrome.js
@@ -7,6 +7,8 @@
     (async () => {
       const platform = await window.tandem?.getPlatform?.() || 'unknown';
       document.body.classList.add(`platform-${platform}`);
+      if (platform === 'darwin') document.body.classList.add('platform-mac');
+      if (platform === 'win32') document.body.classList.add('platform-win');
     })();
 
     const btnAppMenu = document.getElementById('btn-app-menu');

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,6 +45,7 @@ import type { PendingTabRegister, RuntimeManagers } from './bootstrap/types';
 import { isGoogleAuthUrl, shouldSkipStealth, pathnameMatchesPrefix, tryParseUrl, urlHasProtocol, hostnameMatches } from './utils/security';
 import { readConfigFileSync } from './config/io';
 import { resolveInitialTheme, buildThemeAdditionalArg, toNativeThemeSource, type ResolvedTheme } from './theme/resolver';
+import { selectPlatform } from './platform';
 import { CloudflarePolicyManager } from './cloudflare/policy-manager';
 import {
   CLOUDFLARE_CHALLENGE_SELECTORS,
@@ -803,25 +804,7 @@ async function createWindow(): Promise<BrowserWindow> {
     }
   });
 
-  // macOS: hiddenInset titlebar (tabs inline with traffic lights, Chrome-style)
-  //        + under-window vibrancy (deepest native glass effect)
-  //        + transparent background so macOS glass shows through chrome areas
-  //        + trafficLightPosition centered in the 36px tab bar
-  // Linux: frameless window (Chrome-style tabs + custom window controls)
-  // Windows: native frame for now (TODO: implement custom titlebar)
-  const platformWindowOptions: Partial<Electron.BrowserWindowConstructorOptions> = process.platform === 'darwin'
-    ? {
-        titleBarStyle: 'hiddenInset',
-        trafficLightPosition: { x: 16, y: 10 },
-        vibrancy: 'under-window',
-        visualEffectState: 'active',
-        backgroundColor: '#00000000',  // transparent so macOS vibrancy shows through chrome
-      }
-    : process.platform === 'linux'
-    ? {
-        frame: false,  // frameless → custom titlebar with Chrome-style tabs
-      }
-    : {};
+  const platformWindowOptions = selectPlatform().windowChrome.getBrowserWindowOptions();
 
   // Pre-paint theme resolution — eliminates dark→light flash.
   // We read the file directly because ConfigManager is not yet initialized.

--- a/src/platform/capabilities.ts
+++ b/src/platform/capabilities.ts
@@ -67,7 +67,7 @@ const CAPABILITY_PROFILES: Record<PlatformId, PlatformSupportProfile> = {
       appStartup: unsupportedCapability('Blocked by Unix-only start script until windows-support phase 2.'),
       signedInstaller: unsupportedCapability('Windows installer planned in windows-support phases 13-14.'),
       autoUpdate: unsupportedCapability('Windows update feed planned in windows-support phase 15.'),
-      windowChrome: unsupportedCapability('Windows custom titlebar planned in windows-support phase 6.'),
+      windowChrome: { status: 'supported', notes: 'Frameless custom titlebar with shell controls is implemented for source runs.' },
       stealthUa: unsupportedCapability('Windows UA persona planned in windows-support phase 7.'),
       chromeBookmarkHistoryImport: unsupportedCapability('Windows Chrome paths planned in windows-support phase 8.'),
       chromeCookieImport: unsupportedCapability('Windows DPAPI decrypt evaluation planned in windows-support phase 8.'),

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -9,7 +9,12 @@ import { createDarwinStealthUaAdapter, createUnsupportedStealthUaAdapter } from 
 import type { PlatformAdapter } from './types';
 import { createDarwinVideoAudioAdapter, createUnsupportedVideoAudioAdapter } from './video-audio';
 import { createDarwinVoiceAdapter, createUnsupportedVoiceAdapter } from './voice';
-import { createDarwinWindowChromeAdapter, createUnsupportedWindowChromeAdapter } from './window-chrome';
+import {
+  createDarwinWindowChromeAdapter,
+  createLinuxWindowChromeAdapter,
+  createUnsupportedWindowChromeAdapter,
+  createWindowsWindowChromeAdapter,
+} from './window-chrome';
 
 export type { PlatformId } from './errors';
 export { NotImplementedError } from './errors';
@@ -53,7 +58,11 @@ function createStubPlatform(id: PlatformId): PlatformAdapter {
     nativeMessaging: createUnsupportedNativeMessagingAdapter(id),
     voice: createUnsupportedVoiceAdapter(id),
     videoAudio: createUnsupportedVideoAudioAdapter(id),
-    windowChrome: createUnsupportedWindowChromeAdapter(id),
+    windowChrome: id === 'win32'
+      ? createWindowsWindowChromeAdapter()
+      : id === 'linux'
+        ? createLinuxWindowChromeAdapter()
+        : createUnsupportedWindowChromeAdapter(id),
     stealthUa: createUnsupportedStealthUaAdapter(id),
     secrets: createUnsupportedSecretsAdapter(id),
   };

--- a/src/platform/tests/platform.test.ts
+++ b/src/platform/tests/platform.test.ts
@@ -16,15 +16,18 @@ describe('selectPlatform', () => {
     });
   });
 
-  it('returns the Windows stub adapter without throwing on capability reads', () => {
+  it('returns the Windows adapter without throwing on capability reads', () => {
     const platform = selectPlatform('win32');
 
     expect(platform.id).toBe('win32');
     expect(platform.process.isWindows()).toBe(true);
     expect(platform.capabilities.capabilities.appStartup.status).toBe('unsupported');
+    expect(platform.capabilities.capabilities.windowChrome.status).toBe('supported');
     expect(platform.capabilities.capabilities.userDataDirectory.status).toBe('supported');
     expect(() => platform.chromeImport.getUnavailableStatus()).not.toThrow();
-    expect(() => platform.windowChrome.getBrowserWindowOptions()).toThrow(NotImplementedError);
+    expect(platform.windowChrome.getBrowserWindowOptions()).toMatchObject({
+      frame: false,
+    });
   });
 
   it('returns the Linux stub adapter without throwing on capability reads', () => {
@@ -35,6 +38,9 @@ describe('selectPlatform', () => {
     expect(platform.capabilities.capabilities.windowChrome.status).toBe('supported');
     expect(platform.paths.tandemDir('foo')).toBe(path.join(os.homedir(), '.tandem', 'foo'));
     expect(() => platform.chromeImport.getUnavailableStatus()).not.toThrow();
+    expect(platform.windowChrome.getBrowserWindowOptions()).toMatchObject({
+      frame: false,
+    });
     expect(() => platform.secrets.loadOrCreateInstallSecret()).toThrow(NotImplementedError);
   });
 

--- a/src/platform/window-chrome/index.ts
+++ b/src/platform/window-chrome/index.ts
@@ -13,10 +13,26 @@ export function createDarwinWindowChromeAdapter(): WindowChromeAdapter {
   };
 }
 
+export function createLinuxWindowChromeAdapter(): WindowChromeAdapter {
+  return {
+    getBrowserWindowOptions: () => ({
+      frame: false,
+    }),
+  };
+}
+
+export function createWindowsWindowChromeAdapter(): WindowChromeAdapter {
+  return {
+    getBrowserWindowOptions: () => ({
+      frame: false,
+    }),
+  };
+}
+
 export function createUnsupportedWindowChromeAdapter(platform: PlatformId): WindowChromeAdapter {
   return {
     getBrowserWindowOptions: () => {
-      throw new NotImplementedError('Window chrome', platform, platform === 'win32' ? 'phase-6' : 'phase-1');
+      throw new NotImplementedError('Window chrome', platform, 'phase-1');
     },
   };
 }


### PR DESCRIPTION
## Summary

Implements Windows support Phase 6 only:
- moves BrowserWindow chrome options out of `createWindow()` and into the platform window-chrome adapter
- adds Windows frameless BrowserWindow options with shell-owned minimize, maximize/restore, and close controls
- adds the `platform-win` body class for Windows titlebar spacing while preserving existing platform classes
- bumps the feature release to `1.4.0` and updates changelog/version references

## macOS Safety

macOS BrowserWindow behavior is preserved through the Darwin window-chrome adapter: hidden inset titlebar, traffic-light position, under-window vibrancy, active visual effect state, transparent background, and existing tab bar spacing selectors remain in place.

No macOS host was available in this session, so Robin must confirm the macOS visual diff before merge.

## Windows Manual Check

Performed on Windows in-session:
- launched with `npm start`
- captured the frameless Tandem window showing custom controls in the shell titlebar
- verified custom maximize, restore, minimize, and close controls by clicking them and checking native window state

## Validation

- `npm run verify` passed
- `node scripts/check-consistency.js` passed

## Notes

No Phase 7+ work is included. No public Windows support announcement is included; the platform matrix only records the Phase 6 window-chrome capability for source runs.