### PR TITLE
[codex] feat: Windows stealth UA profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to Tandem Browser will be documented in this file.
 
 ## Unreleased
 
+## [v1.5.0] - 2026-05-04
+
+Windows support Phase 7. Tandem now builds stealth UA and UA-CH values through
+the platform adapter so Windows source runs present Chrome on Windows while the
+macOS Chrome-on-macOS fingerprint remains pinned.
+
+### Added
+
+- **Windows stealth UA adapter** (`src/platform/stealth-ua/`) - added a
+  Chrome-on-Windows UA profile with Windows UA-CH platform, platform-version,
+  architecture, bitness, and full-version brand values.
+- **Stealth UA snapshots** (`src/stealth/tests/manager.test.ts`) - pinned the
+  macOS UA and UA-CH profile and added Windows profile coverage.
+
+### Changed
+
+- **Stealth manager UA construction** (`src/stealth/manager.ts`) - moved
+  session user-agent, request UA-CH headers, and injected
+  `navigator.userAgentData` values onto the platform stealth-ua adapter.
+- **Windows platform selection** (`src/platform/index.ts`) - wires the Windows
+  stealth UA adapter for `win32` platform runs.
+
+### Technical Details
+
+- macOS keeps the existing UA string, low/high-entropy UA-CH values, and
+  request header behavior, including no `sec-ch-ua-platform-version` header.
+- Windows emits `Sec-CH-UA-Platform: "Windows"` and
+  `Sec-CH-UA-Platform-Version: "15.0.0"` for a Windows 11-compatible Chrome
+  profile.
+- No canvas, WebGL, audio, font-noise, or humanized input timing logic changed.
+
 ## [v1.4.0] - 2026-05-04
 
 Windows support Phase 6. Tandem now uses adapter-driven window chrome options

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -31,7 +31,7 @@ The security layer exists because when an AI has access to your browser, your th
 Data stays local. Sessions are isolated. Nothing leaves the machine through Tandem Browser without going through a filter first.
 
 **GitHub:** `hydro13/tandem-browser`  
-**Current version:** `1.4.0`
+**Current version:** `1.5.0`
 **Repository status:** Public developer preview  
 **Started:** February 11, 2026
 

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ contributors, not yet a polished mass-user release.
 - Secondary platform: Linux
 - Windows: validated as a remote agent host (VS Code + Claude Code over Tailscale)
 - Binaries: signed & notarized macOS Apple Silicon builds published on [GitHub Releases](https://github.com/hydro13/tandem-browser/releases), starting at v1.0.0
-- Current version: `1.4.0`
+- Current version: `1.5.0`
 - Package metadata: [package.json](package.json)
 
 ## Community

--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@ Last updated: May 4, 2026
 
 ## Current Snapshot
 
-- Current app version: `1.4.0`
+- Current app version: `1.5.0`
 - MCP server: 253 tools (full API parity + awareness)
 - The codebase scope is larger than this backlog summary and includes major subsystems such as `sidebar`, `workspaces`, `pinboards`, `sync`, `headless`, and `sessions`.
 - Scheduled browsing already exists in baseline form via `WatchManager` and the `/watch/*` API routes.
@@ -93,6 +93,9 @@ Last updated: May 4, 2026
 
 ## Recently Completed
 
+- [x] Windows support Phase 7: moved stealth UA and UA-CH construction into
+  the platform adapter, pinned macOS output with snapshots, and added Windows
+  Chrome-on-Windows values for source runs
 - [x] Windows support Phase 6: moved BrowserWindow chrome options into the
   platform adapter, enabled frameless Windows source runs, and reused the
   shell-owned min/max/close titlebar controls behind a Windows body class

--- a/docs/index.html
+++ b/docs/index.html
@@ -325,7 +325,7 @@ footer a:hover{color:var(--text2)}
 </header>
 
 <div class="hero">
-<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v1.4.0</div>
+<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v1.5.0</div>
 <p class="hero-lead">Tandem Browser is the <strong>open-source, local-first browser for AI agents</strong> — where the AI lives inside your real browser session, sharing your tabs, cookies, and DOM, ready to ask for your help the moment it gets stuck.</p>
 <h1>The browser becomes a <em>programmable workspace</em> where human intent and AI capability meet.</h1>
 <p>Tandem Browser is built around a simple shift: the AI is not a sidebar talking <em>about</em> your browser, it is <em>inside</em> it. Same tabs, same cookies, same logged-in sessions, same page you are looking at right now. Reading the accessibility tree, watching the network, writing live styles, handing back to you when something needs a human. It turns the web that already exists into something agents can actually operate on — no per-site API, no RPA rig, no screenshot loop. The real browser, as a shared human-AI symbiotic runtime.</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tandem-browser",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tandem-browser",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-browser",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Local-first Electron browser with a 253-tool MCP server, MCP/HTTP control surfaces, and built-in security controls",
   "main": "dist/main.js",
   "author": "Tandem Browser contributors",

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -5,7 +5,7 @@ import { createDarwinNativeMessagingAdapter, createUnsupportedNativeMessagingAda
 import { createDarwinPathsAdapter, createLinuxPathsAdapter, createUnsupportedPathsAdapter, createWindowsPathsAdapter } from './paths';
 import { createProcessAdapter } from './process';
 import { createDarwinSecretsAdapter, createUnsupportedSecretsAdapter } from './secrets';
-import { createDarwinStealthUaAdapter, createUnsupportedStealthUaAdapter } from './stealth-ua';
+import { createDarwinStealthUaAdapter, createUnsupportedStealthUaAdapter, createWindowsStealthUaAdapter } from './stealth-ua';
 import type { PlatformAdapter } from './types';
 import { createDarwinVideoAudioAdapter, createUnsupportedVideoAudioAdapter } from './video-audio';
 import { createDarwinVoiceAdapter, createUnsupportedVoiceAdapter } from './voice';
@@ -63,7 +63,11 @@ function createStubPlatform(id: PlatformId): PlatformAdapter {
       : id === 'linux'
         ? createLinuxWindowChromeAdapter()
         : createUnsupportedWindowChromeAdapter(id),
-    stealthUa: createUnsupportedStealthUaAdapter(id),
+    stealthUa: id === 'win32'
+      ? createWindowsStealthUaAdapter()
+      : id === 'linux'
+        ? createDarwinStealthUaAdapter()
+        : createUnsupportedStealthUaAdapter(id),
     secrets: createUnsupportedSecretsAdapter(id),
   };
 }

--- a/src/platform/stealth-ua/index.ts
+++ b/src/platform/stealth-ua/index.ts
@@ -1,11 +1,101 @@
 import { NotImplementedError, type PlatformId } from '../errors';
-import type { StealthUaAdapter } from '../types';
+import type { StealthUaAdapter, StealthUaBrandVersion, StealthUaProfile } from '../types';
+
+function getChromeMajor(chromeVersion: string): string {
+  return chromeVersion.split('.')[0];
+}
+
+function createBrandList(chromeMajor: string): StealthUaBrandVersion[] {
+  return [
+    { brand: 'Google Chrome', version: chromeMajor },
+    { brand: 'Chromium', version: chromeMajor },
+    { brand: 'Not(A:Brand', version: '8' },
+  ];
+}
+
+function createFullVersionList(chromeVersion: string): StealthUaBrandVersion[] {
+  return [
+    { brand: 'Google Chrome', version: chromeVersion },
+    { brand: 'Chromium', version: chromeVersion },
+    { brand: 'Not(A:Brand', version: '8.0.0.0' },
+  ];
+}
+
+function createProfile(
+  chromeVersion: string,
+  userAgentPlatform: string,
+  clientHints: {
+    platform: string;
+    platformVersion: string;
+    architecture: string;
+    bitness: string;
+  },
+  requestHeaders: { platform: string; platformVersion?: string },
+): StealthUaProfile {
+  const chromeMajor = getChromeMajor(chromeVersion);
+  return {
+    userAgent:
+      `Mozilla/5.0 (${userAgentPlatform}) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${chromeVersion} Safari/537.36`,
+    chromeVersion,
+    chromeMajor,
+    clientHints: {
+      brands: createBrandList(chromeMajor),
+      mobile: false,
+      platform: clientHints.platform,
+      platformVersion: clientHints.platformVersion,
+      architecture: clientHints.architecture,
+      bitness: clientHints.bitness,
+      model: '',
+      uaFullVersion: chromeVersion,
+      fullVersionList: createFullVersionList(chromeVersion),
+    },
+    requestHeaders,
+  };
+}
+
+function createDarwinProfile(chromeVersion: string): StealthUaProfile {
+  return createProfile(
+    chromeVersion,
+    'Macintosh; Intel Mac OS X 10_15_7',
+    {
+      platform: 'macOS',
+      platformVersion: '15.3.0',
+      architecture: 'arm',
+      bitness: '64',
+    },
+    { platform: '"macOS"' },
+  );
+}
+
+function createWindowsProfile(chromeVersion: string): StealthUaProfile {
+  return createProfile(
+    chromeVersion,
+    'Windows NT 10.0; Win64; x64',
+    {
+      platform: 'Windows',
+      platformVersion: '15.0.0',
+      architecture: 'x86',
+      bitness: '64',
+    },
+    { platform: '"Windows"', platformVersion: '"15.0.0"' },
+  );
+}
 
 export function createDarwinStealthUaAdapter(): StealthUaAdapter {
   return {
     getUserAgent: (chromeVersion = process.versions.chrome) =>
-      `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${chromeVersion} Safari/537.36`,
+      createDarwinProfile(chromeVersion).userAgent,
     getClientHintsPlatform: () => 'macOS',
+    getProfile: (chromeVersion = process.versions.chrome) => createDarwinProfile(chromeVersion),
+  };
+}
+
+export function createWindowsStealthUaAdapter(): StealthUaAdapter {
+  return {
+    getUserAgent: (chromeVersion = process.versions.chrome) =>
+      createWindowsProfile(chromeVersion).userAgent,
+    getClientHintsPlatform: () => 'Windows',
+    getProfile: (chromeVersion = process.versions.chrome) => createWindowsProfile(chromeVersion),
   };
 }
 
@@ -15,6 +105,9 @@ export function createUnsupportedStealthUaAdapter(platform: PlatformId): Stealth
       throw new NotImplementedError('Stealth UA', platform, 'phase-7');
     },
     getClientHintsPlatform: () => {
+      throw new NotImplementedError('Stealth UA', platform, 'phase-7');
+    },
+    getProfile: () => {
       throw new NotImplementedError('Stealth UA', platform, 'phase-7');
     },
   };

--- a/src/platform/tests/platform.test.ts
+++ b/src/platform/tests/platform.test.ts
@@ -41,6 +41,7 @@ describe('selectPlatform', () => {
     expect(platform.windowChrome.getBrowserWindowOptions()).toMatchObject({
       frame: false,
     });
+    expect(platform.stealthUa.getProfile('132.0.6834.160').clientHints.platform).toBe('macOS');
     expect(() => platform.secrets.loadOrCreateInstallSecret()).toThrow(NotImplementedError);
   });
 

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -62,6 +62,7 @@ export interface WindowChromeAdapter {
 export interface StealthUaAdapter {
   getUserAgent(chromeVersion?: string): string;
   getClientHintsPlatform(): string;
+  getProfile(chromeVersion?: string): StealthUaProfile;
 }
 
 export interface SecretsAdapter {
@@ -80,4 +81,34 @@ export interface PlatformAdapter {
   windowChrome: WindowChromeAdapter;
   stealthUa: StealthUaAdapter;
   secrets: SecretsAdapter;
+}
+
+export interface StealthUaBrandVersion {
+  brand: string;
+  version: string;
+}
+
+export interface StealthUaClientHints {
+  brands: StealthUaBrandVersion[];
+  mobile: false;
+  platform: string;
+  platformVersion: string;
+  architecture: string;
+  bitness: string;
+  model: string;
+  uaFullVersion: string;
+  fullVersionList: StealthUaBrandVersion[];
+}
+
+export interface StealthUaRequestHeaders {
+  platform: string;
+  platformVersion?: string;
+}
+
+export interface StealthUaProfile {
+  userAgent: string;
+  chromeVersion: string;
+  chromeMajor: string;
+  clientHints: StealthUaClientHints;
+  requestHeaders: StealthUaRequestHeaders;
 }

--- a/src/stealth/manager.ts
+++ b/src/stealth/manager.ts
@@ -3,6 +3,9 @@ import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import type { RequestDispatcher } from '../network/dispatcher';
+import { selectPlatform } from '../platform';
+import { createDarwinStealthUaAdapter } from '../platform/stealth-ua';
+import type { StealthUaAdapter, StealthUaProfile } from '../platform/types';
 import { createLogger } from '../utils/logger';
 import { tandemDir } from '../utils/paths';
 import { isGoogleAuthUrl } from '../utils/security';
@@ -70,12 +73,17 @@ export class StealthManager {
   private session: Session;
   private partitionSeed: string;
   private readonly originalUserAgent: string;
-  private readonly USER_AGENT: string;
-  private readonly chromeMajor: string;
+  private readonly stealthUa: StealthUaAdapter;
+  private readonly uaProfile: StealthUaProfile;
 
   // === 2. Constructor ===
-  constructor(session: Session, partition: string = 'persist:tandem') {
+  constructor(
+    session: Session,
+    partition: string = 'persist:tandem',
+    stealthUa: StealthUaAdapter = selectPlatform().stealthUa,
+  ) {
     this.session = session;
+    this.stealthUa = stealthUa;
     // Store the real Electron UA before overwriting — needed for Google auth
     this.originalUserAgent = session.getUserAgent();
     // Derive seed from per-install secret + partition — unique per install,
@@ -84,10 +92,7 @@ export class StealthManager {
     this.partitionSeed = deriveStealthSeed(installSecret, partition);
 
     // Build UA from Electron's actual Chromium version to avoid detection mismatches
-    const chromeVersion = process.versions.chrome;
-    this.chromeMajor = chromeVersion.split('.')[0];
-    this.USER_AGENT =
-      `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/${chromeVersion} Safari/537.36`;
+    this.uaProfile = this.stealthUa.getProfile(process.versions.chrome);
   }
 
   // === 4. Public methods ===
@@ -96,7 +101,7 @@ export class StealthManager {
   async apply(options?: { cloudflarePolicySyncChannel?: string }): Promise<void> {
     // Set realistic User-Agent globally (LinkedIn etc. block "Electron" UA)
     // Google auth is excluded via the onBeforeSendHeaders handler in registerWith()
-    this.session.setUserAgent(this.USER_AGENT);
+    this.session.setUserAgent(this.uaProfile.userAgent);
 
     // Write a session-level preload that injects stealth patches into EVERY
     // renderer frame — including cross-origin out-of-process iframes (OOPIF)
@@ -127,8 +132,12 @@ export class StealthManager {
    * propagate to cross-process iframes depending on the Electron / Chromium version.
    */
   private async writeAndRegisterPreload(cloudflarePolicySyncChannel?: string): Promise<void> {
-    const stealthScript = StealthManager.getStealthScript(this.partitionSeed);
-    const earlyScript = StealthManager.getEarlyScript();
+    const stealthScript = StealthManager.getStealthScript(
+      this.partitionSeed,
+      this.uaProfile.chromeVersion,
+      this.stealthUa,
+    );
+    const earlyScript = StealthManager.getEarlyScript(this.uaProfile.chromeVersion, this.stealthUa);
 
     // The preload runs in Electron's isolated renderer world.
     // executeJavaScriptInIsolatedWorld(0, ...) injects into world 0 = main page world,
@@ -254,14 +263,17 @@ export class StealthManager {
           return `${brands}, "Google Chrome";v="${version}"`;
         };
 
-        headers['sec-ch-ua']          = withGoogleChrome(chromiumBrands, this.chromeMajor);
+        headers['sec-ch-ua']          = withGoogleChrome(chromiumBrands, this.uaProfile.chromeMajor);
         headers['sec-ch-ua-mobile']   = '?0';
-        headers['sec-ch-ua-platform'] = '"macOS"';
+        headers['sec-ch-ua-platform'] = this.uaProfile.requestHeaders.platform;
+        if (this.uaProfile.requestHeaders.platformVersion) {
+          headers['sec-ch-ua-platform-version'] = this.uaProfile.requestHeaders.platformVersion;
+        }
         // Only send full-version-list if Chromium already included it;
         // it's a high-entropy hint that browsers normally send only on request.
         if (chromiumFullList) {
           headers['sec-ch-ua-full-version-list'] =
-            withGoogleChrome(chromiumFullList, process.versions.chrome);
+            withGoogleChrome(chromiumFullList, this.uaProfile.chromeVersion);
         }
 
         return headers;
@@ -285,8 +297,13 @@ export class StealthManager {
    * Uses its own idempotency guard (Symbol '__tandem_early_v1') so it doesn't
    * collide with the full stealth script that runs at dom-ready on main frames.
    */
-  static getEarlyScript(chromeVersion: string = process.versions.chrome): string {
-    const chromeMajor = chromeVersion.split('.')[0];
+  static getEarlyScript(
+    chromeVersion: string = process.versions.chrome,
+    stealthUa: StealthUaAdapter = createDarwinStealthUaAdapter(),
+  ): string {
+    const profile = stealthUa.getProfile(chromeVersion);
+    const brands = JSON.stringify(profile.clientHints.brands);
+    const fullVersionList = JSON.stringify(profile.clientHints.fullVersionList);
     return `
 (function() {
   var _sym = Symbol.for('__tandem_early_v1');
@@ -298,37 +315,23 @@ export class StealthManager {
 
   // 2. navigator.userAgentData — inject "Google Chrome" brand (the critical Cloudflare check)
   try {
-    var _chromeMajor = '${chromeMajor}';
-    var _chromeVersion = '${chromeVersion}';
     Object.defineProperty(navigator, 'userAgentData', {
       get: function() {
         return {
-          brands: [
-            { brand: 'Google Chrome',  version: _chromeMajor },
-            { brand: 'Chromium',       version: _chromeMajor },
-            { brand: 'Not(A:Brand',    version: '8' },
-          ],
+          brands: ${brands},
           mobile: false,
-          platform: 'macOS',
+          platform: ${JSON.stringify(profile.clientHints.platform)},
           getHighEntropyValues: function(hints) {
             return Promise.resolve({
-              brands: [
-                { brand: 'Google Chrome',  version: _chromeMajor },
-                { brand: 'Chromium',       version: _chromeMajor },
-                { brand: 'Not(A:Brand',    version: '8' },
-              ],
+              brands: ${brands},
               mobile: false,
-              platform: 'macOS',
-              platformVersion: '15.3.0',
-              architecture: 'arm',
-              bitness: '64',
-              model: '',
-              uaFullVersion: _chromeVersion,
-              fullVersionList: [
-                { brand: 'Google Chrome',  version: _chromeVersion },
-                { brand: 'Chromium',       version: _chromeVersion },
-                { brand: 'Not(A:Brand',    version: '8.0.0.0' },
-              ],
+              platform: ${JSON.stringify(profile.clientHints.platform)},
+              platformVersion: ${JSON.stringify(profile.clientHints.platformVersion)},
+              architecture: ${JSON.stringify(profile.clientHints.architecture)},
+              bitness: ${JSON.stringify(profile.clientHints.bitness)},
+              model: ${JSON.stringify(profile.clientHints.model)},
+              uaFullVersion: ${JSON.stringify(profile.clientHints.uaFullVersion)},
+              fullVersionList: ${fullVersionList},
             });
           },
           toJSON: function() {
@@ -387,8 +390,14 @@ export class StealthManager {
    * Phase 5: includes canvas, WebGL, audio, font, and timing fingerprint protection.
    * @param seed - Deterministic seed for consistent noise per session
    */
-  static getStealthScript(seed: string = 'tandem-default-seed', chromeVersion: string = process.versions.chrome): string {
-    const chromeMajor = chromeVersion.split('.')[0];
+  static getStealthScript(
+    seed: string = 'tandem-default-seed',
+    chromeVersion: string = process.versions.chrome,
+    stealthUa: StealthUaAdapter = createDarwinStealthUaAdapter(),
+  ): string {
+    const profile = stealthUa.getProfile(chromeVersion);
+    const brands = JSON.stringify(profile.clientHints.brands);
+    const fullVersionList = JSON.stringify(profile.clientHints.fullVersionList);
     return `
       // ═══ All stealth patches in one IIFE — no globals leaked to window ═══
       // Idempotency guard: both the session preload and the dom-ready injection
@@ -652,38 +661,24 @@ export class StealthManager {
       // header — Cloudflare cross-checks them.  Chromium 120+ uses "Not(A:Brand"
       // version "8".  The header handler (registerWith) preserves this naturally.
       {
-        var __chromeMajor = '${chromeMajor}';
-        var __chromeVersion = '${chromeVersion}';
         // Chrome 120+ GREASE brand — must stay in sync with the sec-ch-ua header
         var __greaseBrand   = 'Not(A:Brand';
         var __greaseVersion = '8';
         Object.defineProperty(navigator, 'userAgentData', {
           get: () => ({
-            brands: [
-              { brand: 'Google Chrome',  version: __chromeMajor },
-              { brand: 'Chromium',       version: __chromeMajor },
-              { brand: __greaseBrand,    version: __greaseVersion },
-            ],
+            brands: ${brands},
             mobile: false,
-            platform: 'macOS',
+            platform: ${JSON.stringify(profile.clientHints.platform)},
             getHighEntropyValues: (hints) => Promise.resolve({
-              brands: [
-                { brand: 'Google Chrome',  version: __chromeMajor },
-                { brand: 'Chromium',       version: __chromeMajor },
-                { brand: __greaseBrand,    version: __greaseVersion },
-              ],
+              brands: ${brands},
               mobile: false,
-              platform: 'macOS',
-              platformVersion: '15.3.0',
-              architecture: 'arm',
-              bitness: '64',
-              model: '',
-              uaFullVersion: __chromeVersion,
-              fullVersionList: [
-                { brand: 'Google Chrome',  version: __chromeVersion },
-                { brand: 'Chromium',       version: __chromeVersion },
-                { brand: __greaseBrand,    version: __greaseVersion + '.0.0.0' },
-              ],
+              platform: ${JSON.stringify(profile.clientHints.platform)},
+              platformVersion: ${JSON.stringify(profile.clientHints.platformVersion)},
+              architecture: ${JSON.stringify(profile.clientHints.architecture)},
+              bitness: ${JSON.stringify(profile.clientHints.bitness)},
+              model: ${JSON.stringify(profile.clientHints.model)},
+              uaFullVersion: ${JSON.stringify(profile.clientHints.uaFullVersion)},
+              fullVersionList: ${fullVersionList},
             }),
             toJSON: function() {
               return { brands: this.brands, mobile: this.mobile, platform: this.platform };

--- a/src/stealth/tests/manager.test.ts
+++ b/src/stealth/tests/manager.test.ts
@@ -53,6 +53,8 @@ vi.mock('../../utils/logger', () => ({
 
 import fs from 'fs';
 import { StealthManager, deriveStealthSeed, loadOrCreateInstallSecret } from '../manager';
+import { createDarwinStealthUaAdapter, createWindowsStealthUaAdapter } from '../../platform/stealth-ua';
+import type { StealthUaAdapter } from '../../platform/types';
 
 const normalizePath = (value: unknown) => String(value).replace(/\\/g, '/');
 
@@ -190,8 +192,8 @@ describe('StealthManager — per-install seed', () => {
       JSON.stringify({ stealthInstallSecret: existing })
     );
 
-    const m1 = new StealthManager(makeMockSession(), 'persist:tandem');
-    const m2 = new StealthManager(makeMockSession(), 'persist:tandem');
+    const m1 = new StealthManager(makeMockSession(), 'persist:tandem', createDarwinStealthUaAdapter());
+    const m2 = new StealthManager(makeMockSession(), 'persist:tandem', createDarwinStealthUaAdapter());
 
     expect(m1.getPartitionSeed()).toBe(m2.getPartitionSeed());
   });
@@ -201,7 +203,7 @@ describe('StealthManager — per-install seed', () => {
     vi.mocked(fs.existsSync).mockImplementation((p: fs.PathLike) => {
       return !normalizePath(p).endsWith('/config.json');
     });
-    const m1 = new StealthManager(makeMockSession(), 'persist:tandem');
+    const m1 = new StealthManager(makeMockSession(), 'persist:tandem', createDarwinStealthUaAdapter());
     const seed1 = m1.getPartitionSeed();
 
     // Reset mocks — simulate a second, separate install with a different secret
@@ -210,7 +212,7 @@ describe('StealthManager — per-install seed', () => {
     vi.mocked(fs.readFileSync).mockReturnValue(
       JSON.stringify({ stealthInstallSecret: 'b'.repeat(64) })
     );
-    const m2 = new StealthManager(makeMockSession(), 'persist:tandem');
+    const m2 = new StealthManager(makeMockSession(), 'persist:tandem', createDarwinStealthUaAdapter());
     const seed2 = m2.getPartitionSeed();
 
     expect(seed1).not.toBe(seed2);
@@ -222,8 +224,8 @@ describe('StealthManager — per-install seed', () => {
       JSON.stringify({ stealthInstallSecret: 'c'.repeat(64) })
     );
 
-    const m1 = new StealthManager(makeMockSession(), 'persist:tandem');
-    const m2 = new StealthManager(makeMockSession(), 'persist:workspace-a');
+    const m1 = new StealthManager(makeMockSession(), 'persist:tandem', createDarwinStealthUaAdapter());
+    const m2 = new StealthManager(makeMockSession(), 'persist:workspace-a', createDarwinStealthUaAdapter());
 
     expect(m1.getPartitionSeed()).not.toBe(m2.getPartitionSeed());
   });
@@ -252,13 +254,122 @@ function makeDispatcherMock() {
 }
 
 /** Sets up a StealthManager backed by a deterministic fake install secret. */
-function makeManagerWithFixedSecret(): StealthManager {
+function makeManagerWithFixedSecret(stealthUa: StealthUaAdapter = createDarwinStealthUaAdapter()): StealthManager {
   vi.mocked(fs.existsSync).mockReturnValue(true);
   vi.mocked(fs.readFileSync).mockReturnValue(
     JSON.stringify({ stealthInstallSecret: 'a'.repeat(64) })
   );
-  return new StealthManager(makeMockSession(), 'persist:tandem');
+  return new StealthManager(makeMockSession(), 'persist:tandem', stealthUa);
 }
+
+describe('stealth-ua platform adapters', () => {
+  const chromeVersion = '132.0.6834.160';
+
+  it('pins the macOS UA and UA-CH profile byte-for-byte', () => {
+    const profile = createDarwinStealthUaAdapter().getProfile(chromeVersion);
+
+    expect(profile).toMatchInlineSnapshot(`
+      {
+        "chromeMajor": "132",
+        "chromeVersion": "132.0.6834.160",
+        "clientHints": {
+          "architecture": "arm",
+          "bitness": "64",
+          "brands": [
+            {
+              "brand": "Google Chrome",
+              "version": "132",
+            },
+            {
+              "brand": "Chromium",
+              "version": "132",
+            },
+            {
+              "brand": "Not(A:Brand",
+              "version": "8",
+            },
+          ],
+          "fullVersionList": [
+            {
+              "brand": "Google Chrome",
+              "version": "132.0.6834.160",
+            },
+            {
+              "brand": "Chromium",
+              "version": "132.0.6834.160",
+            },
+            {
+              "brand": "Not(A:Brand",
+              "version": "8.0.0.0",
+            },
+          ],
+          "mobile": false,
+          "model": "",
+          "platform": "macOS",
+          "platformVersion": "15.3.0",
+          "uaFullVersion": "132.0.6834.160",
+        },
+        "requestHeaders": {
+          "platform": ""macOS"",
+        },
+        "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.6834.160 Safari/537.36",
+      }
+    `);
+  });
+
+  it('builds a Chrome-on-Windows UA and UA-CH profile', () => {
+    const profile = createWindowsStealthUaAdapter().getProfile(chromeVersion);
+
+    expect(profile).toMatchInlineSnapshot(`
+      {
+        "chromeMajor": "132",
+        "chromeVersion": "132.0.6834.160",
+        "clientHints": {
+          "architecture": "x86",
+          "bitness": "64",
+          "brands": [
+            {
+              "brand": "Google Chrome",
+              "version": "132",
+            },
+            {
+              "brand": "Chromium",
+              "version": "132",
+            },
+            {
+              "brand": "Not(A:Brand",
+              "version": "8",
+            },
+          ],
+          "fullVersionList": [
+            {
+              "brand": "Google Chrome",
+              "version": "132.0.6834.160",
+            },
+            {
+              "brand": "Chromium",
+              "version": "132.0.6834.160",
+            },
+            {
+              "brand": "Not(A:Brand",
+              "version": "8.0.0.0",
+            },
+          ],
+          "mobile": false,
+          "model": "",
+          "platform": "Windows",
+          "platformVersion": "15.0.0",
+          "uaFullVersion": "132.0.6834.160",
+        },
+        "requestHeaders": {
+          "platform": ""Windows"",
+          "platformVersion": ""15.0.0"",
+        },
+        "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.6834.160 Safari/537.36",
+      }
+    `);
+  });
+});
 
 // ─── registerWith() — Sec-CH-UA header patching ───────────────────────────────
 
@@ -416,6 +527,31 @@ describe('registerWith() — Sec-CH-UA client-hints injection', () => {
     expect(result['Sec-CH-UA-Mobile']).toBeUndefined();
     expect(result['Sec-CH-UA-Platform']).toBeUndefined();
   });
+
+  it('keeps macOS request UA-CH headers byte-compatible by not adding platform-version', () => {
+    const mgr = makeManagerWithFixedSecret(createDarwinStealthUaAdapter());
+    const disp = makeDispatcherMock();
+    mgr.registerWith(disp as never);
+    const handle = disp.getHandler();
+
+    const result = handle({ url: 'https://example.com' }, {});
+
+    expect(result['sec-ch-ua-platform']).toBe('"macOS"');
+    expect(result['sec-ch-ua-platform-version']).toBeUndefined();
+  });
+
+  it('emits Windows request UA-CH headers from the Windows stealth adapter', () => {
+    const mgr = makeManagerWithFixedSecret(createWindowsStealthUaAdapter());
+    const disp = makeDispatcherMock();
+    mgr.registerWith(disp as never);
+    const handle = disp.getHandler();
+
+    const result = handle({ url: 'https://example.com' }, {});
+
+    expect(result['sec-ch-ua']).toContain('"Google Chrome";v="132"');
+    expect(result['sec-ch-ua-platform']).toBe('"Windows"');
+    expect(result['sec-ch-ua-platform-version']).toBe('"15.0.0"');
+  });
 });
 
 describe('getStealthScript() — timing protection', () => {
@@ -455,13 +591,12 @@ describe('getStealthScript() — userAgentData GREASE brand consistency', () => 
     expect(script).not.toMatch(/__greaseVersion\s*=\s*'24'/);
   });
 
-  it('fullVersionList GREASE version is built from __greaseVersion (e.g. "8.0.0.0")', () => {
+  it('fullVersionList GREASE version is pinned to Chrome 120+ "8.0.0.0"', () => {
     const script = StealthManager.getStealthScript('seed');
     // Should not hardcode the old wrong "24.0.0.0"
     expect(script).not.toContain('"24.0.0.0"');
     expect(script).not.toContain("'24.0.0.0'");
-    // Should compose it from the variable
-    expect(script).toContain("__greaseVersion + '.0.0.0'");
+    expect(script).toContain('"8.0.0.0"');
   });
 
   it('includes "Google Chrome" in all brand lists', () => {
@@ -470,6 +605,19 @@ describe('getStealthScript() — userAgentData GREASE brand consistency', () => 
     const chromeCount = (script.match(/Google Chrome/g) || []).length;
     // brands (1) + getHighEntropyValues brands (1) + fullVersionList (1) = min 3
     expect(chromeCount).toBeGreaterThanOrEqual(3);
+  });
+
+  it('uses Windows userAgentData values when given the Windows stealth adapter', () => {
+    const script = StealthManager.getStealthScript(
+      'seed',
+      '132.0.6834.160',
+      createWindowsStealthUaAdapter(),
+    );
+
+    expect(script).toContain('platform: "Windows"');
+    expect(script).toContain('platformVersion: "15.0.0"');
+    expect(script).toContain('architecture: "x86"');
+    expect(script).not.toContain("platform: 'macOS'");
   });
 });
 
@@ -544,6 +692,13 @@ describe('getEarlyScript() — minimal OOPIF-safe stealth', () => {
     expect(script).toContain('130'); // chromeMajor
   });
 
+  it('uses Windows userAgentData values when given the Windows stealth adapter', () => {
+    const script = StealthManager.getEarlyScript('132.0.6834.160', createWindowsStealthUaAdapter());
+    expect(script).toContain('platform: "Windows"');
+    expect(script).toContain('platformVersion: "15.0.0"');
+    expect(script).toContain('architecture: "x86"');
+  });
+
   it('uses process.versions.chrome by default', () => {
     const script = StealthManager.getEarlyScript();
     // The test environment sets chrome to 132.0.6834.160 in beforeAll
@@ -568,7 +723,7 @@ describe('apply() — preload policy sync', () => {
       registerPreloadScript: ReturnType<typeof vi.fn>;
     };
 
-    const manager = new StealthManager(session as never, 'persist:tandem');
+    const manager = new StealthManager(session as never, 'persist:tandem', createDarwinStealthUaAdapter());
     await manager.apply({ cloudflarePolicySyncChannel: 'tandem:cloudflare-policy-sync' });
 
     expect(session.setUserAgent).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Moves stealth UA and UA-CH construction behind the platform `stealth-ua` adapter.
- Adds a Windows Chrome-on-Windows profile for source runs: UA, low/high-entropy UA-CH values, and request client-hint headers.
- Pins the existing macOS Chrome-on-macOS profile with inline snapshots so macOS output cannot drift unnoticed.
- Keeps Linux on the legacy macOS-style stealth profile for now so this production migration does not break secondary Linux source runs.
- Bumps the project version to `1.5.0` for the Phase 7 feature release.

## Why
Phase 7 is fingerprint-critical. Windows must not present as Chrome on macOS, but macOS must remain byte-compatible with the existing stealth profile. Moving construction into the adapter makes the platform split explicit and testable without touching canvas, WebGL, audio, font-noise, or humanized input timing.

## Validation
- `npm run verify` passed locally on Windows.
- 144 Vitest files passed.
- 2913 tests passed, 39 skipped.
- `npx vitest run src/platform/tests/platform.test.ts src/stealth/tests/manager.test.ts` passed: 50 tests.
- Manual Windows visible fingerprint check: whatismybrowser.com reports `Chrome 144 on Windows 11`.

## Platform impact
- macOS: UA and UA-CH output is pinned with snapshots; request headers still avoid `sec-ch-ua-platform-version` exactly as before.
- Windows: reports Chrome on Windows through UA, UA-CH platform, platformVersion, architecture, bitness, and brand values.
- Linux: remains on the previous macOS-style stealth fallback until a dedicated Linux stealth pass exists.

## Scope control
- No canvas/WebGL/audio/font-noise changes.
- No humanized input timing changes.
- No Phase 8 Chrome import work.
- No public Windows support announcement.