### PR TITLE
[codex] Windows support phase 9 native messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to Tandem Browser will be documented in this file.
 
 ## Unreleased
 
+## [v1.7.0] - 2026-05-04
+
+Windows support Phase 9. Tandem now detects Chrome native messaging hosts on
+Windows through read-only registry lookup while keeping the existing filesystem
+fallback and preserving macOS/Linux directory scanning behavior.
+
+### Added
+
+- **Windows native messaging registry detection** (`src/platform/native-messaging/`) -
+  reads Chrome native messaging host manifest paths from
+  `HKCU\Software\Google\Chrome\NativeMessagingHosts` and
+  `HKLM\Software\Google\Chrome\NativeMessagingHosts`.
+- **Native messaging adapter coverage** (`src/extensions/tests/extensions.test.ts`) -
+  added mocked Windows registry coverage and pinned the macOS native messaging
+  directory list.
+
+### Changed
+
+- **Native messaging setup** (`src/extensions/native-messaging.ts`) - moved
+  manifest discovery onto the platform adapter while retaining shared host
+  validation, status reporting, and extension access checks.
+- **Extension manager** (`src/extensions/manager.ts`) - creates native messaging
+  setup through the selected platform adapter.
+- **Platform support matrix** (`docs/platform-support.md`) - marks Windows native
+  messaging host detection as supported for source runs.
+
+### Technical Details
+
+- Windows registry access is read-only and uses a zero-dependency PowerShell
+  query from Node.
+- Windows detection combines HKCU/HKLM registry manifests with the existing
+  `%LOCALAPPDATA%\Google\Chrome\User Data\NativeMessagingHosts` filesystem
+  fallback.
+- macOS native messaging directories remain unchanged.
+- No new dependency was added.
+
 ## [v1.6.0] - 2026-05-04
 
 Windows support Phase 8. Tandem now resolves Chrome profile paths through the

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -31,7 +31,7 @@ The security layer exists because when an AI has access to your browser, your th
 Data stays local. Sessions are isolated. Nothing leaves the machine through Tandem Browser without going through a filter first.
 
 **GitHub:** `hydro13/tandem-browser`  
-**Current version:** `1.6.0`
+**Current version:** `1.7.0`
 **Repository status:** Public developer preview  
 **Started:** February 11, 2026
 

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ contributors, not yet a polished mass-user release.
 - Secondary platform: Linux
 - Windows: validated as a remote agent host (VS Code + Claude Code over Tailscale)
 - Binaries: signed & notarized macOS Apple Silicon builds published on [GitHub Releases](https://github.com/hydro13/tandem-browser/releases), starting at v1.0.0
-- Current version: `1.6.0`
+- Current version: `1.7.0`
 - Package metadata: [package.json](package.json)
 
 ## Community

--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@ Last updated: May 4, 2026
 
 ## Current Snapshot
 
-- Current app version: `1.6.0`
+- Current app version: `1.7.0`
 - MCP server: 253 tools (full API parity + awareness)
 - The codebase scope is larger than this backlog summary and includes major subsystems such as `sidebar`, `workspaces`, `pinboards`, `sync`, `headless`, and `sessions`.
 - Scheduled browsing already exists in baseline form via `WatchManager` and the `/watch/*` API routes.
@@ -93,6 +93,10 @@ Last updated: May 4, 2026
 
 ## Recently Completed
 
+- [x] Windows support Phase 9: moved native messaging host detection into the
+  native-messaging platform adapter, added read-only Windows Chrome registry
+  detection for HKCU/HKLM native messaging hosts, kept the filesystem fallback,
+  and pinned macOS directory scanning behavior with tests
 - [x] Windows support Phase 8: moved Chrome profile path detection into the
   chrome-import platform adapter, added Windows Chrome profile scanning under
   `%LOCALAPPDATA%\Google\Chrome\User Data`, enabled Windows bookmark and

--- a/docs/index.html
+++ b/docs/index.html
@@ -325,7 +325,7 @@ footer a:hover{color:var(--text2)}
 </header>
 
 <div class="hero">
-<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v1.6.0</div>
+<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v1.7.0</div>
 <p class="hero-lead">Tandem Browser is the <strong>open-source, local-first browser for AI agents</strong> — where the AI lives inside your real browser session, sharing your tabs, cookies, and DOM, ready to ask for your help the moment it gets stuck.</p>
 <h1>The browser becomes a <em>programmable workspace</em> where human intent and AI capability meet.</h1>
 <p>Tandem Browser is built around a simple shift: the AI is not a sidebar talking <em>about</em> your browser, it is <em>inside</em> it. Same tabs, same cookies, same logged-in sessions, same page you are looking at right now. Reading the accessibility tree, watching the network, writing live styles, handing back to you when something needs a human. It turns the web that already exists into something agents can actually operate on — no per-site API, no RPA rig, no screenshot loop. The real browser, as a shared human-AI symbiotic runtime.</p>

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -44,7 +44,7 @@
 | Stealth UA matches host OS | supported | supported | partial | Windows source runs present Chrome on Windows; public Windows release remains unannounced. |
 | Chrome bookmark + history import | supported | supported | partial | Windows source runs scan `%LOCALAPPDATA%\Google\Chrome\User Data\<Profile>\` for bookmark and history import. |
 | Chrome cookie import | partial | unsupported | partial | Windows encrypted cookie import requires DPAPI support and is intentionally not implemented in phase 8; no risky dependency was added. |
-| Native messaging host detection | supported | partial | supported | Windows uses filesystem fallback today; registry reader planned in windows-support phase 9. |
+| Native messaging host detection | supported | supported | supported | Windows reads Chrome native messaging host registry keys under HKCU/HKLM and keeps the filesystem fallback. |
 | Voice transcription | supported | unsupported | partial | Windows Whisper fallback planned in windows-support phase 10. |
 | Video recorder with system audio | supported | unsupported | partial | Windows WASAPI loopback planned in windows-support phase 11. |
 | Keyboard shortcuts and labels | supported | partial | supported | Cross-platform labels finalized in windows-support phase 12. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tandem-browser",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tandem-browser",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-browser",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Local-first Electron browser with a 253-tool MCP server, MCP/HTTP control surfaces, and built-in security controls",
   "main": "dist/main.js",
   "author": "Tandem Browser contributors",

--- a/src/extensions/manager.ts
+++ b/src/extensions/manager.ts
@@ -4,8 +4,7 @@ import fs from 'fs';
 import { ExtensionLoader } from './loader';
 import type { InstallResult } from './crx-downloader';
 import { CrxDownloader } from './crx-downloader';
-import type { NativeMessagingStatus } from './native-messaging';
-import { NativeMessagingSetup } from './native-messaging';
+import type { NativeMessagingHostAccessDecision, NativeMessagingHost, NativeMessagingStatus } from './native-messaging';
 import { IdentityPolyfill } from './identity-polyfill';
 import { ActionPolyfill } from './action-polyfill';
 import type { UpdateCheckResult, UpdateResult, UpdateState, InstalledExtension } from './update-checker';
@@ -15,6 +14,7 @@ import { ConflictDetector } from './conflict-detector';
 import { tandemDir } from '../utils/paths';
 import { API_PORT } from '../utils/constants';
 import { createLogger } from '../utils/logger';
+import { selectPlatform } from '../platform';
 
 const log = createLogger('ExtensionManager');
 
@@ -46,6 +46,14 @@ export interface ExtensionRouteAccessDecision {
   extensionName: string | null;
   permissions: string[];
   auditLabel: string;
+}
+
+interface NativeMessagingRuntime {
+  detectHosts(): NativeMessagingHost[];
+  configure(session: Session): { configured: string[]; missing: string[] };
+  getStatus(): NativeMessagingStatus;
+  evaluateHostAccess(hostName: string, candidateExtensionIds: Array<string | null | undefined>): NativeMessagingHostAccessDecision;
+  isHostAvailable(extensionId: string): boolean;
 }
 
 interface ExtensionRoutePolicy {
@@ -115,7 +123,7 @@ export class ExtensionManager {
 
   private loader: ExtensionLoader;
   private downloader: CrxDownloader;
-  private nativeMessaging: NativeMessagingSetup;
+  private nativeMessaging: NativeMessagingRuntime;
   private identityPolyfill: IdentityPolyfill;
   private actionPolyfill: ActionPolyfill;
   private updateChecker: UpdateChecker;
@@ -126,7 +134,7 @@ export class ExtensionManager {
   constructor(apiPort: number = API_PORT) {
     this.loader = new ExtensionLoader();
     this.downloader = new CrxDownloader();
-    this.nativeMessaging = new NativeMessagingSetup();
+    this.nativeMessaging = selectPlatform().nativeMessaging.createSetup();
     this.identityPolyfill = new IdentityPolyfill(apiPort);
     this.actionPolyfill = new ActionPolyfill(apiPort);
     this.updateChecker = new UpdateChecker(this.downloader, this.loader);

--- a/src/extensions/native-messaging.ts
+++ b/src/extensions/native-messaging.ts
@@ -32,6 +32,18 @@ export interface NativeMessagingHostAccessDecision {
   reason: string;
 }
 
+export interface NativeMessagingManifestLocation {
+  manifestPath: string;
+  source: 'filesystem' | 'registry';
+  registryKey?: string;
+}
+
+export interface NativeMessagingDetectionAdapter {
+  getNativeMessagingDirs(): { path: string; exists: boolean }[];
+  getManifestLocations(): NativeMessagingManifestLocation[];
+  mirrorManifestsToTandemDir(): void;
+}
+
 // Host aliases used by extension variants that expect the same native helper.
 const HOST_ALIASES: Record<string, string> = {
   'com.1password.1password7': 'com.1password.1password',
@@ -71,47 +83,14 @@ export class NativeMessagingSetup {
   private missingHosts: string[] = [];
   private apiSupported = false;
 
+  constructor(private readonly detectionAdapter: NativeMessagingDetectionAdapter) {}
+
   /**
    * Get the platform-specific directories where native messaging host
    * manifests are installed.
    */
   getNativeMessagingDirs(): { path: string; exists: boolean }[] {
-    const dirs: string[] = [];
-
-    switch (process.platform) {
-      case 'darwin':
-        // macOS: system-wide and per-user directories
-        dirs.push('/Library/Google/Chrome/NativeMessagingHosts');
-        dirs.push(path.join(os.homedir(), 'Library', 'Application Support', 'Google', 'Chrome', 'NativeMessagingHosts'));
-        // Chromium (non-Google-branded) directories
-        dirs.push(path.join(os.homedir(), 'Library', 'Application Support', 'Chromium', 'NativeMessagingHosts'));
-        // Tandem Browser / Electron app-specific directories
-        // Electron 40 does not expose setNativeMessagingHostDirectory(); it reads from
-        // the app's own userData directory. We mirror manifests there at startup.
-        dirs.push(path.join(os.homedir(), 'Library', 'Application Support', 'Tandem Browser', 'NativeMessagingHosts'));
-        dirs.push(path.join(os.homedir(), 'Library', 'Application Support', 'tandem-browser', 'NativeMessagingHosts'));
-        dirs.push(path.join(os.homedir(), 'Library', 'Application Support', 'Electron', 'NativeMessagingHosts'));
-        break;
-
-      case 'linux':
-        // Linux: system-wide and per-user directories
-        dirs.push('/etc/opt/chrome/native-messaging-hosts');
-        dirs.push(path.join(os.homedir(), '.config', 'google-chrome', 'NativeMessagingHosts'));
-        // Chromium
-        dirs.push(path.join(os.homedir(), '.config', 'chromium', 'NativeMessagingHosts'));
-        break;
-
-      case 'win32': {
-        // Windows: native messaging hosts are registered in the Windows Registry.
-        // We cannot read registry values from Node.js without native modules,
-        // so we check common filesystem paths where hosts may also be installed.
-        const localAppData = process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local');
-        dirs.push(path.join(localAppData, 'Google', 'Chrome', 'User Data', 'NativeMessagingHosts'));
-        break;
-      }
-    }
-
-    return dirs.map(d => ({ path: d, exists: fs.existsSync(d) }));
+    return this.detectionAdapter.getNativeMessagingDirs();
   }
 
   /**
@@ -119,59 +98,46 @@ export class NativeMessagingSetup {
    * Reads each .json manifest file and checks if the referenced binary exists.
    */
   detectHosts(): NativeMessagingHost[] {
-    const dirs = this.getNativeMessagingDirs();
     const hosts: NativeMessagingHost[] = [];
     const seenNames = new Set<string>();
 
-    for (const dir of dirs) {
-      if (!dir.exists) continue;
-
+    for (const location of this.detectionAdapter.getManifestLocations()) {
       try {
-        const files = fs.readdirSync(dir.path)
-          .filter(f => f.endsWith('.json'));
+        const manifest = JSON.parse(fs.readFileSync(location.manifestPath, 'utf-8'));
 
-        for (const file of files) {
-          const manifestPath = path.join(dir.path, file);
-          try {
-            const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+        if (!manifest.name || typeof manifest.name !== 'string') continue;
+        if (seenNames.has(manifest.name)) continue;
+        seenNames.add(manifest.name);
 
-            if (!manifest.name || typeof manifest.name !== 'string') continue;
-            if (seenNames.has(manifest.name)) continue;
-            seenNames.add(manifest.name);
+        const binaryPath = manifest.path || '';
+        const binaryExists = binaryPath ? fs.existsSync(binaryPath) : false;
 
-            const binaryPath = manifest.path || '';
-            const binaryExists = binaryPath ? fs.existsSync(binaryPath) : false;
-
-            const allowedExtensions: string[] = [];
-            if (Array.isArray(manifest.allowed_origins)) {
-              for (const origin of manifest.allowed_origins) {
-                // Format: "chrome-extension://extensionid/"
-                const match = typeof origin === 'string' ? origin.match(/chrome-extension:\/\/([a-p]{32})\/?/) : null;
-                if (match) allowedExtensions.push(match[1]);
-              }
-            }
-            if (Array.isArray(manifest.allowed_extensions)) {
-              for (const ext of manifest.allowed_extensions) {
-                if (typeof ext === 'string' && !allowedExtensions.includes(ext)) {
-                  allowedExtensions.push(ext);
-                }
-              }
-            }
-
-            hosts.push({
-              name: manifest.name,
-              description: manifest.description || '',
-              binaryPath,
-              binaryExists,
-              allowedExtensions,
-              manifestPath,
-            });
-          } catch {
-            // Invalid JSON or unreadable file — skip
+        const allowedExtensions: string[] = [];
+        if (Array.isArray(manifest.allowed_origins)) {
+          for (const origin of manifest.allowed_origins) {
+            // Format: "chrome-extension://extensionid/"
+            const match = typeof origin === 'string' ? origin.match(/chrome-extension:\/\/([a-p]{32})\/?/) : null;
+            if (match) allowedExtensions.push(match[1]);
           }
         }
+        if (Array.isArray(manifest.allowed_extensions)) {
+          for (const ext of manifest.allowed_extensions) {
+            if (typeof ext === 'string' && !allowedExtensions.includes(ext)) {
+              allowedExtensions.push(ext);
+            }
+          }
+        }
+
+        hosts.push({
+          name: manifest.name,
+          description: manifest.description || '',
+          binaryPath,
+          binaryExists,
+          allowedExtensions,
+          manifestPath: location.manifestPath,
+        });
       } catch {
-        // Directory not readable — skip
+        // Invalid JSON or unreadable file — skip
       }
     }
 
@@ -203,7 +169,7 @@ export class NativeMessagingSetup {
     // Actual Tandem userData: ~/Library/Application Support/Tandem Browser/
     // We copy every manifest found in Chrome/Chromium dirs into the Tandem dir so
     // that Electron's internal Chromium code finds them automatically.
-    this.mirrorManifestsToTandemDir();
+    this.detectionAdapter.mirrorManifestsToTandemDir();
 
     // Attempt to configure each existing directory
     let apiChecked = false;

--- a/src/extensions/tests/extensions.test.ts
+++ b/src/extensions/tests/extensions.test.ts
@@ -6,8 +6,14 @@ import { GALLERY_DEFAULTS } from '../gallery-defaults';
 import { UpdateChecker } from '../update-checker';
 import { ExtensionLoader } from '../loader';
 import { nmProxy } from '../nm-proxy';
+import { NativeMessagingSetup } from '../native-messaging';
+import {
+  createDarwinNativeMessagingDetectionAdapter,
+  createWindowsNativeMessagingDetectionAdapter,
+} from '../../platform/native-messaging';
 import AdmZip from 'adm-zip';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { tandemDir } from '../../utils/paths';
 
@@ -56,6 +62,19 @@ function buildCrx3(zipPayload: Buffer): Buffer {
   headerSize.writeUInt32LE(fakeHeader.length, 0);
 
   return Buffer.concat([magic, version, headerSize, fakeHeader, zipPayload]);
+}
+
+function writeNativeMessagingManifest(root: string, name: string, binaryPath: string): string {
+  const manifestPath = path.join(root, `${name}.json`);
+  fs.mkdirSync(root, { recursive: true });
+  fs.writeFileSync(manifestPath, JSON.stringify({
+    name,
+    description: `${name} fixture`,
+    path: binaryPath,
+    type: 'stdio',
+    allowed_origins: ['chrome-extension://aeblfdkhhhdcdjpifhhbdiojplfjncoa/'],
+  }), 'utf-8');
+  return manifestPath;
 }
 
 // ─── UpdateChecker Version Comparison Tests ─────────────────────────────────
@@ -509,6 +528,62 @@ describe('Gallery Defaults', () => {
 });
 
 // ─── Chrome Importer Tests ────────────────────────────────────────────────────
+
+describe('Native messaging platform detection', () => {
+  it('keeps macOS native messaging directories unchanged through the adapter', () => {
+    const dirs = createDarwinNativeMessagingDetectionAdapter()
+      .getNativeMessagingDirs()
+      .map((dir) => dir.path);
+
+    expect(dirs).toEqual([
+      '/Library/Google/Chrome/NativeMessagingHosts',
+      path.join(os.homedir(), 'Library', 'Application Support', 'Google', 'Chrome', 'NativeMessagingHosts'),
+      path.join(os.homedir(), 'Library', 'Application Support', 'Chromium', 'NativeMessagingHosts'),
+      path.join(os.homedir(), 'Library', 'Application Support', 'Tandem Browser', 'NativeMessagingHosts'),
+      path.join(os.homedir(), 'Library', 'Application Support', 'tandem-browser', 'NativeMessagingHosts'),
+      path.join(os.homedir(), 'Library', 'Application Support', 'Electron', 'NativeMessagingHosts'),
+    ]);
+  });
+
+  it('detects Windows hosts from HKCU/HKLM registry manifests plus the filesystem fallback', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'tandem-native-messaging-'));
+    const registryDir = path.join(root, 'registry');
+    const fallbackDir = path.join(root, 'Chrome', 'User Data', 'NativeMessagingHosts');
+    const binaryPath = path.join(root, 'fixture-host.exe');
+    fs.writeFileSync(binaryPath, 'fixture binary', 'utf-8');
+
+    const hkcuManifest = writeNativeMessagingManifest(registryDir, 'com.tandem.hkcu', binaryPath);
+    const hklmManifest = writeNativeMessagingManifest(registryDir, 'com.tandem.hklm', binaryPath);
+    writeNativeMessagingManifest(fallbackDir, 'com.tandem.filesystem', binaryPath);
+    const registryReads: string[] = [];
+
+    try {
+      const adapter = createWindowsNativeMessagingDetectionAdapter({
+        chromeUserDataNativeMessagingDir: fallbackDir,
+        registryReader: (hive, subkey) => {
+          registryReads.push(`${hive}\\${subkey}`);
+          return hive === 'HKCU' ? [hkcuManifest] : [hklmManifest];
+        },
+      });
+      const setup = new NativeMessagingSetup(adapter);
+
+      const hosts = setup.detectHosts();
+
+      expect(registryReads).toEqual([
+        'HKCU\\Software\\Google\\Chrome\\NativeMessagingHosts',
+        'HKLM\\Software\\Google\\Chrome\\NativeMessagingHosts',
+      ]);
+      expect(hosts.map((host) => host.name)).toEqual([
+        'com.tandem.hkcu',
+        'com.tandem.hklm',
+        'com.tandem.filesystem',
+      ]);
+      expect(hosts.every((host) => host.binaryExists)).toBe(true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
 
 describe('Chrome Importer', () => {
   it('detects correct Chrome extensions path for current platform', () => {

--- a/src/extensions/tests/native-messaging.test.ts
+++ b/src/extensions/tests/native-messaging.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import { NativeMessagingSetup } from '../native-messaging';
+import type { NativeMessagingDetectionAdapter } from '../native-messaging';
+
+const emptyDetectionAdapter: NativeMessagingDetectionAdapter = {
+  getNativeMessagingDirs: () => [],
+  getManifestLocations: () => [],
+  mirrorManifestsToTandemDir: () => {},
+};
 
 describe('NativeMessagingSetup host access', () => {
   it('accepts known runtime IDs for hosts that publish the Chrome Web Store ID', () => {
-    const setup = new NativeMessagingSetup();
+    const setup = new NativeMessagingSetup(emptyDetectionAdapter);
     (setup as unknown as {
       hosts: Array<{
         name: string;

--- a/src/platform/capabilities.ts
+++ b/src/platform/capabilities.ts
@@ -71,7 +71,7 @@ const CAPABILITY_PROFILES: Record<PlatformId, PlatformSupportProfile> = {
       stealthUa: { status: 'supported', notes: 'Windows source runs present a Chrome-on-Windows UA persona.' },
       chromeBookmarkHistoryImport: { status: 'supported', notes: 'Windows Chrome bookmark and history import scans LOCALAPPDATA/Google/Chrome/User Data profiles.' },
       chromeCookieImport: unsupportedCapability('Windows Chrome cookie import is not implemented; encrypted cookies require DPAPI support and no dependency was added in phase 8.'),
-      nativeMessagingHostDetection: { status: 'partial', notes: 'Filesystem fallback exists; registry reader planned in windows-support phase 9.' },
+      nativeMessagingHostDetection: { status: 'supported', notes: 'Windows native messaging host detection reads Chrome registry keys and keeps the filesystem fallback.' },
       voiceTranscription: unsupportedCapability('Windows Whisper fallback planned in windows-support phase 10.'),
       videoRecorderSystemAudio: unsupportedCapability('Windows WASAPI loopback planned in windows-support phase 11.'),
       keyboardShortcutsLabels: { status: 'partial', notes: 'Cross-platform labels finalized in windows-support phase 12.' },

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -1,7 +1,12 @@
 import { getPlatformCapabilities, normalizePlatform } from './capabilities';
 import type { PlatformId } from './errors';
 import { createDarwinChromeImportAdapter, createLinuxChromeImportAdapter, createUnsupportedChromeImportAdapter, createWindowsChromeImportAdapter } from './chrome-import';
-import { createDarwinNativeMessagingAdapter, createUnsupportedNativeMessagingAdapter } from './native-messaging';
+import {
+  createDarwinNativeMessagingAdapter,
+  createLinuxNativeMessagingAdapter,
+  createUnsupportedNativeMessagingAdapter,
+  createWindowsNativeMessagingAdapter,
+} from './native-messaging';
 import { createDarwinPathsAdapter, createLinuxPathsAdapter, createUnsupportedPathsAdapter, createWindowsPathsAdapter } from './paths';
 import { createProcessAdapter } from './process';
 import { createDarwinSecretsAdapter, createUnsupportedSecretsAdapter } from './secrets';
@@ -59,7 +64,11 @@ function createStubPlatform(id: PlatformId): PlatformAdapter {
       : id === 'linux'
         ? createLinuxChromeImportAdapter()
         : createUnsupportedChromeImportAdapter(id),
-    nativeMessaging: createUnsupportedNativeMessagingAdapter(id),
+    nativeMessaging: id === 'win32'
+      ? createWindowsNativeMessagingAdapter()
+      : id === 'linux'
+        ? createLinuxNativeMessagingAdapter()
+        : createUnsupportedNativeMessagingAdapter(id),
     voice: createUnsupportedVoiceAdapter(id),
     videoAudio: createUnsupportedVideoAudioAdapter(id),
     windowChrome: id === 'win32'

--- a/src/platform/native-messaging/index.ts
+++ b/src/platform/native-messaging/index.ts
@@ -1,18 +1,247 @@
-import type * as NativeMessagingModule from '../../extensions/native-messaging';
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { createLogger } from '../../utils/logger';
 import { NotImplementedError, type PlatformId } from '../errors';
 import type { NativeMessagingAdapter } from '../types';
+import type {
+  NativeMessagingDetectionAdapter,
+  NativeMessagingManifestLocation,
+} from '../../extensions/native-messaging';
+import { NativeMessagingSetup } from '../../extensions/native-messaging';
 
-export function createDarwinNativeMessagingAdapter(): NativeMessagingAdapter {
+const log = createLogger('NativeMessagingPlatform');
+
+type RegistryHive = 'HKCU' | 'HKLM';
+type WindowsRegistryReader = (hive: RegistryHive, subkey: string) => string[];
+
+const WINDOWS_NATIVE_MESSAGING_SUBKEY = 'Software\\Google\\Chrome\\NativeMessagingHosts';
+
+interface NativeMessagingDetectionOptions {
+  dirs: string[];
+  mirrorToTandemDir?: {
+    targetDir: string;
+    sourceDirs: string[];
+  };
+  registryLocations?: () => NativeMessagingManifestLocation[];
+}
+
+export interface WindowsNativeMessagingAdapterOptions {
+  chromeUserDataNativeMessagingDir?: string;
+  registryReader?: WindowsRegistryReader;
+}
+
+function createDetectionAdapter(options: NativeMessagingDetectionOptions): NativeMessagingDetectionAdapter {
   return {
-    createSetup: () => {
-      const { NativeMessagingSetup } = require('../../extensions/native-messaging') as typeof NativeMessagingModule;
-      return new NativeMessagingSetup();
+    getNativeMessagingDirs: () => options.dirs.map((dir) => ({ path: dir, exists: fs.existsSync(dir) })),
+    getManifestLocations: () => {
+      const filesystemLocations = options.dirs
+        .filter((dir) => fs.existsSync(dir))
+        .flatMap((dir) => listManifestFiles(dir));
+
+      return [
+        ...(options.registryLocations?.() ?? []),
+        ...filesystemLocations,
+      ];
+    },
+    mirrorManifestsToTandemDir: () => {
+      if (!options.mirrorToTandemDir) return;
+      mirrorManifestsToTandemDir(options.mirrorToTandemDir.targetDir, options.mirrorToTandemDir.sourceDirs);
     },
   };
 }
 
+function listManifestFiles(dir: string): NativeMessagingManifestLocation[] {
+  try {
+    return fs.readdirSync(dir)
+      .filter((file) => file.endsWith('.json'))
+      .map((file) => ({
+        manifestPath: path.join(dir, file),
+        source: 'filesystem' as const,
+      }));
+  } catch {
+    return [];
+  }
+}
+
+function mirrorManifestsToTandemDir(targetDir: string, sourceDirs: string[]): void {
+  const existingSourceDirs = sourceDirs
+    .filter((dir) => dir !== targetDir && fs.existsSync(dir));
+
+  if (existingSourceDirs.length === 0) return;
+
+  try {
+    fs.mkdirSync(targetDir, { recursive: true });
+  } catch {
+    log.warn('Native messaging: failed to create Tandem NativeMessagingHosts directory');
+    return;
+  }
+
+  let mirrored = 0;
+  for (const srcDir of existingSourceDirs) {
+    try {
+      const files = fs.readdirSync(srcDir).filter((file) => file.endsWith('.json'));
+      for (const file of files) {
+        const src = path.join(srcDir, file);
+        const dst = path.join(targetDir, file);
+        try {
+          const srcStat = fs.statSync(src);
+          let needsCopy = true;
+          try {
+            const dstStat = fs.statSync(dst);
+            needsCopy = srcStat.mtimeMs > dstStat.mtimeMs;
+          } catch {
+            // Destination does not exist.
+          }
+          if (needsCopy) {
+            fs.copyFileSync(src, dst);
+            mirrored++;
+          }
+        } catch {
+          // Skip unreadable files.
+        }
+      }
+    } catch {
+      // Skip unreadable directories.
+    }
+  }
+
+  if (mirrored > 0) {
+    log.info(`Native messaging: mirrored ${mirrored} manifest(s) to ${targetDir}`);
+  }
+}
+
+function createSetupWithDetectionAdapter(detectionAdapter: NativeMessagingDetectionAdapter): NativeMessagingAdapter {
+  return {
+    createDetectionAdapter: () => detectionAdapter,
+    createSetup: () => {
+      return new NativeMessagingSetup(detectionAdapter);
+    },
+  };
+}
+
+export function createDarwinNativeMessagingDetectionAdapter(): NativeMessagingDetectionAdapter {
+  const chromeUserDir = path.join(os.homedir(), 'Library', 'Application Support', 'Google', 'Chrome', 'NativeMessagingHosts');
+  const chromiumUserDir = path.join(os.homedir(), 'Library', 'Application Support', 'Chromium', 'NativeMessagingHosts');
+  const tandemDir = path.join(os.homedir(), 'Library', 'Application Support', 'Tandem Browser', 'NativeMessagingHosts');
+
+  return createDetectionAdapter({
+    dirs: [
+      '/Library/Google/Chrome/NativeMessagingHosts',
+      chromeUserDir,
+      chromiumUserDir,
+      tandemDir,
+      path.join(os.homedir(), 'Library', 'Application Support', 'tandem-browser', 'NativeMessagingHosts'),
+      path.join(os.homedir(), 'Library', 'Application Support', 'Electron', 'NativeMessagingHosts'),
+    ],
+    mirrorToTandemDir: {
+      targetDir: tandemDir,
+      sourceDirs: [
+        chromeUserDir,
+        '/Library/Google/Chrome/NativeMessagingHosts',
+        chromiumUserDir,
+      ],
+    },
+  });
+}
+
+export function createLinuxNativeMessagingDetectionAdapter(): NativeMessagingDetectionAdapter {
+  return createDetectionAdapter({
+    dirs: [
+      '/etc/opt/chrome/native-messaging-hosts',
+      path.join(os.homedir(), '.config', 'google-chrome', 'NativeMessagingHosts'),
+      path.join(os.homedir(), '.config', 'chromium', 'NativeMessagingHosts'),
+    ],
+  });
+}
+
+export function createWindowsNativeMessagingDetectionAdapter(
+  options: WindowsNativeMessagingAdapterOptions = {},
+): NativeMessagingDetectionAdapter {
+  const nativeMessagingDir = options.chromeUserDataNativeMessagingDir ??
+    path.join(windowsChromeBasePath(), 'NativeMessagingHosts');
+  const registryReader = options.registryReader ?? readWindowsRegistryManifestPaths;
+
+  return createDetectionAdapter({
+    dirs: [nativeMessagingDir],
+    registryLocations: () => {
+      const locations: NativeMessagingManifestLocation[] = [];
+      for (const hive of ['HKCU', 'HKLM'] as const) {
+        for (const manifestPath of registryReader(hive, WINDOWS_NATIVE_MESSAGING_SUBKEY)) {
+          if (manifestPath.trim().length === 0) continue;
+          locations.push({
+            manifestPath,
+            source: 'registry',
+            registryKey: `${hive}\\${WINDOWS_NATIVE_MESSAGING_SUBKEY}`,
+          });
+        }
+      }
+      return locations;
+    },
+  });
+}
+
+function windowsChromeBasePath(): string {
+  const localAppData = process.env.LOCALAPPDATA?.trim() || path.join(os.homedir(), 'AppData', 'Local');
+  return path.join(localAppData, 'Google', 'Chrome', 'User Data');
+}
+
+function readWindowsRegistryManifestPaths(hive: RegistryHive, subkey: string): string[] {
+  const root = hive === 'HKCU' ? 'HKEY_CURRENT_USER' : 'HKEY_LOCAL_MACHINE';
+  const registryPath = `${root}\\${subkey}`;
+  const script = [
+    `$root = 'Registry::${registryPath}'`,
+    '$paths = @()',
+    'Get-ChildItem -LiteralPath $root -ErrorAction SilentlyContinue | ForEach-Object {',
+    "  $value = $_.GetValue('')",
+    '  if ($value -is [string] -and $value.Trim().Length -gt 0) { $paths += $value }',
+    '}',
+    'ConvertTo-Json -InputObject $paths -Compress',
+  ].join('; ');
+
+  try {
+    const output = execFileSync('powershell.exe', [
+      '-NoProfile',
+      '-NonInteractive',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-Command',
+      script,
+    ], {
+      encoding: 'utf-8',
+      windowsHide: true,
+      timeout: 5000,
+    }).trim();
+
+    if (!output) return [];
+    const parsed = JSON.parse(output) as unknown;
+    if (Array.isArray(parsed)) {
+      return parsed.filter((value): value is string => typeof value === 'string');
+    }
+    return typeof parsed === 'string' ? [parsed] : [];
+  } catch {
+    return [];
+  }
+}
+
+export function createDarwinNativeMessagingAdapter(): NativeMessagingAdapter {
+  return createSetupWithDetectionAdapter(createDarwinNativeMessagingDetectionAdapter());
+}
+
+export function createWindowsNativeMessagingAdapter(options: WindowsNativeMessagingAdapterOptions = {}): NativeMessagingAdapter {
+  return createSetupWithDetectionAdapter(createWindowsNativeMessagingDetectionAdapter(options));
+}
+
+export function createLinuxNativeMessagingAdapter(): NativeMessagingAdapter {
+  return createSetupWithDetectionAdapter(createLinuxNativeMessagingDetectionAdapter());
+}
+
 export function createUnsupportedNativeMessagingAdapter(platform: PlatformId): NativeMessagingAdapter {
   return {
+    createDetectionAdapter: () => {
+      throw new NotImplementedError('NativeMessaging', platform, 'phase-9');
+    },
     createSetup: () => {
       throw new NotImplementedError('NativeMessaging', platform, 'phase-9');
     },

--- a/src/platform/tests/platform.test.ts
+++ b/src/platform/tests/platform.test.ts
@@ -79,7 +79,9 @@ describe('selectPlatform', () => {
     expect(platform.capabilities.capabilities.appStartup.status).toBe('unsupported');
     expect(platform.capabilities.capabilities.windowChrome.status).toBe('supported');
     expect(platform.capabilities.capabilities.userDataDirectory.status).toBe('supported');
+    expect(platform.capabilities.capabilities.nativeMessagingHostDetection.status).toBe('supported');
     expect(() => platform.chromeImport.getUnavailableStatus()).not.toThrow();
+    expect(() => platform.nativeMessaging.createDetectionAdapter().getNativeMessagingDirs()).not.toThrow();
     expect(platform.windowChrome.getBrowserWindowOptions()).toMatchObject({
       frame: false,
     });

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -4,6 +4,7 @@ import type { ChromeImporter, ChromeImportStatus } from '../import/chrome-import
 import type {
   NativeMessagingHost,
   NativeMessagingHostAccessDecision,
+  NativeMessagingDetectionAdapter,
   NativeMessagingStatus,
 } from '../extensions/native-messaging';
 import type { PlatformId } from './errors';
@@ -42,6 +43,7 @@ export interface ChromeImportAdapter {
 }
 
 export interface NativeMessagingAdapter {
+  createDetectionAdapter(): NativeMessagingDetectionAdapter;
   createSetup(): {
     getNativeMessagingDirs(): { path: string; exists: boolean }[];
     detectHosts(): NativeMessagingHost[];


### PR DESCRIPTION
## Summary

Windows support Phase 9 moves native messaging host discovery behind the platform adapter and adds read-only Windows Chrome registry detection.

## What Changed

- Added Windows native messaging detection for `HKCU\Software\Google\Chrome\NativeMessagingHosts` and `HKLM\Software\Google\Chrome\NativeMessagingHosts`.
- Kept the existing Windows filesystem fallback under `%LOCALAPPDATA%\Google\Chrome\User Data\NativeMessagingHosts`.
- Preserved macOS and Linux directory scanning behavior in platform-specific adapters.
- Routed `ExtensionManager` native messaging setup through `selectPlatform().nativeMessaging`.
- Bumped the app version to `1.7.0` and updated changelog/version references.

## macOS Safety

macOS behavior is preserved by moving the existing native messaging directory list verbatim into the Darwin adapter and pinning that list with a regression test. No macOS stealth, session, or extension loading behavior was intentionally changed.

## Validation

- `npm run verify` passed: compile, lint, Vitest, and consistency check.
- Windows smoke via compiled adapter detected 3 native messaging hosts on this machine, including `com.anthropic.claude_browser_extension` with an existing binary.
- `npm start` smoke stayed running for 20 seconds without an early crash.

## Notes

- No new dependency was added; Windows registry reads use a small PowerShell shell-out from Node.
- Registry access is read-only. The implementation does not write registry keys.
- Private/local Windows planning files remain gitignored and were not staged.