### PR TITLE
[codex] Windows support phase 10 voice transcription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to Tandem Browser will be documented in this file.
 
 ## Unreleased
 
+## [v1.8.0] - 2026-05-04
+
+Windows support Phase 10. Tandem now routes native speech transcription through
+the platform voice adapter, preserving macOS Apple Speech behavior and adding a
+Windows fallback that uses user-installed Whisper when `whisper.exe` is
+available on `PATH`.
+
+### Added
+
+- **Windows voice adapter** (`src/platform/voice/`) - detects `whisper.exe`
+  through Windows-style `PATH` lookup and returns a clear user-facing status
+  when Whisper is not installed.
+- **Voice adapter coverage** (`src/platform/tests/platform.test.ts`) - added
+  regression coverage for the macOS Apple Speech backend, Windows Whisper
+  lookup, and the missing-Whisper error path.
+
+### Changed
+
+- **Speech transcription pipeline** (`src/voice/speech-transcriber.ts`) - moved
+  backend selection out of the shared transcriber and into platform adapters.
+- **IPC speech handlers** (`src/ipc/handlers.ts`) - now call the selected
+  platform voice adapter for backend status and transcription.
+- **Platform support matrix** (`docs/platform-support.md`) - marks Windows voice
+  transcription as partial for source runs with user-installed Whisper.
+
+### Technical Details
+
+- macOS still prefers the bundled or development `tandem-speech` Apple Speech
+  binary and keeps the existing Whisper fallback when Apple Speech is missing.
+- Windows support intentionally does not download models, bundle Whisper, or add
+  Windows audio capture code.
+- No new dependency was added.
+
 ## [v1.7.0] - 2026-05-04
 
 Windows support Phase 9. Tandem now detects Chrome native messaging hosts on

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -31,7 +31,7 @@ The security layer exists because when an AI has access to your browser, your th
 Data stays local. Sessions are isolated. Nothing leaves the machine through Tandem Browser without going through a filter first.
 
 **GitHub:** `hydro13/tandem-browser`  
-**Current version:** `1.7.0`
+**Current version:** `1.8.0`
 **Repository status:** Public developer preview  
 **Started:** February 11, 2026
 

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ contributors, not yet a polished mass-user release.
 - Secondary platform: Linux
 - Windows: validated as a remote agent host (VS Code + Claude Code over Tailscale)
 - Binaries: signed & notarized macOS Apple Silicon builds published on [GitHub Releases](https://github.com/hydro13/tandem-browser/releases), starting at v1.0.0
-- Current version: `1.7.0`
+- Current version: `1.8.0`
 - Package metadata: [package.json](package.json)
 
 ## Community

--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@ Last updated: May 4, 2026
 
 ## Current Snapshot
 
-- Current app version: `1.7.0`
+- Current app version: `1.8.0`
 - MCP server: 253 tools (full API parity + awareness)
 - The codebase scope is larger than this backlog summary and includes major subsystems such as `sidebar`, `workspaces`, `pinboards`, `sync`, `headless`, and `sessions`.
 - Scheduled browsing already exists in baseline form via `WatchManager` and the `/watch/*` API routes.
@@ -93,6 +93,10 @@ Last updated: May 4, 2026
 
 ## Recently Completed
 
+- [x] Windows support Phase 10: moved voice backend selection into the platform
+  voice adapter, preserved the macOS Apple Speech path, added Windows
+  `whisper.exe` PATH detection for opt-in Whisper transcription, and returns a
+  clear Windows status when Whisper is not installed
 - [x] Windows support Phase 9: moved native messaging host detection into the
   native-messaging platform adapter, added read-only Windows Chrome registry
   detection for HKCU/HKLM native messaging hosts, kept the filesystem fallback,

--- a/docs/index.html
+++ b/docs/index.html
@@ -325,7 +325,7 @@ footer a:hover{color:var(--text2)}
 </header>
 
 <div class="hero">
-<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v1.7.0</div>
+<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v1.8.0</div>
 <p class="hero-lead">Tandem Browser is the <strong>open-source, local-first browser for AI agents</strong> — where the AI lives inside your real browser session, sharing your tabs, cookies, and DOM, ready to ask for your help the moment it gets stuck.</p>
 <h1>The browser becomes a <em>programmable workspace</em> where human intent and AI capability meet.</h1>
 <p>Tandem Browser is built around a simple shift: the AI is not a sidebar talking <em>about</em> your browser, it is <em>inside</em> it. Same tabs, same cookies, same logged-in sessions, same page you are looking at right now. Reading the accessibility tree, watching the network, writing live styles, handing back to you when something needs a human. It turns the web that already exists into something agents can actually operate on — no per-site API, no RPA rig, no screenshot loop. The real browser, as a shared human-AI symbiotic runtime.</p>

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -45,7 +45,7 @@
 | Chrome bookmark + history import | supported | supported | partial | Windows source runs scan `%LOCALAPPDATA%\Google\Chrome\User Data\<Profile>\` for bookmark and history import. |
 | Chrome cookie import | partial | unsupported | partial | Windows encrypted cookie import requires DPAPI support and is intentionally not implemented in phase 8; no risky dependency was added. |
 | Native messaging host detection | supported | supported | supported | Windows reads Chrome native messaging host registry keys under HKCU/HKLM and keeps the filesystem fallback. |
-| Voice transcription | supported | unsupported | partial | Windows Whisper fallback planned in windows-support phase 10. |
+| Voice transcription | supported | partial | partial | Windows source runs can use user-installed `whisper.exe` on `PATH`; Tandem does not bundle Whisper or download models. |
 | Video recorder with system audio | supported | unsupported | partial | Windows WASAPI loopback planned in windows-support phase 11. |
 | Keyboard shortcuts and labels | supported | partial | supported | Cross-platform labels finalized in windows-support phase 12. |
 | Secrets at rest | supported | unsupported | supported | Unified `safeStorage` adapter planned in windows-support phase 5. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tandem-browser",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tandem-browser",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-browser",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Local-first Electron browser with a 253-tool MCP server, MCP/HTTP control surfaces, and built-in security controls",
   "main": "dist/main.js",
   "author": "Tandem Browser contributors",

--- a/src/ipc/handlers.ts
+++ b/src/ipc/handlers.ts
@@ -30,6 +30,7 @@ import { createLogger } from '../utils/logger';
 import { IpcChannels } from '../shared/ipc-channels';
 import { buildOwnershipContextForTab, buildOwnershipContextForTabId } from '../tabs/runtime-context';
 import { wingmanAlert } from '../notifications/alert';
+import { selectPlatform } from '../platform';
 
 const log = createLogger('IpcHandlers');
 
@@ -66,6 +67,7 @@ export function syncTabsToContext(tabManager: TabManager, contextBridge: Context
 }
 
 export function registerIpcHandlers(deps: IpcDeps): void {
+  const platform = selectPlatform();
   const {
     win: _win, tabManager, panelManager, drawManager, voiceManager,
     behaviorObserver, siteMemory, formMemory, contextBridge,
@@ -311,15 +313,13 @@ export function registerIpcHandlers(deps: IpcDeps): void {
 
   // ═══ Native Speech Transcription (Apple Speech / Whisper) ═══
   ipcMain.handle(IpcChannels.TRANSCRIBE_AUDIO, async (_event, data: { buffer: ArrayBuffer; language?: string }) => {
-    const { transcribeAudio } = await import('../voice/speech-transcriber');
     const buffer = Buffer.from(data.buffer);
     const language = data.language || 'nl-BE';
-    return transcribeAudio(buffer, language);
+    return platform.voice.transcribeAudio(buffer, language);
   });
 
   ipcMain.handle(IpcChannels.GET_SPEECH_BACKEND, async () => {
-    const { detectBackend } = await import('../voice/speech-transcriber');
-    return { backend: detectBackend() };
+    return { backend: platform.voice.detectBackend() };
   });
 
 

--- a/src/platform/capabilities.ts
+++ b/src/platform/capabilities.ts
@@ -72,7 +72,7 @@ const CAPABILITY_PROFILES: Record<PlatformId, PlatformSupportProfile> = {
       chromeBookmarkHistoryImport: { status: 'supported', notes: 'Windows Chrome bookmark and history import scans LOCALAPPDATA/Google/Chrome/User Data profiles.' },
       chromeCookieImport: unsupportedCapability('Windows Chrome cookie import is not implemented; encrypted cookies require DPAPI support and no dependency was added in phase 8.'),
       nativeMessagingHostDetection: { status: 'supported', notes: 'Windows native messaging host detection reads Chrome registry keys and keeps the filesystem fallback.' },
-      voiceTranscription: unsupportedCapability('Windows Whisper fallback planned in windows-support phase 10.'),
+      voiceTranscription: { status: 'partial', notes: 'Windows voice transcription uses whisper.exe when users install Whisper and place it on PATH; Tandem does not bundle Whisper or download models.' },
       videoRecorderSystemAudio: unsupportedCapability('Windows WASAPI loopback planned in windows-support phase 11.'),
       keyboardShortcutsLabels: { status: 'partial', notes: 'Cross-platform labels finalized in windows-support phase 12.' },
       secretsAtRest: unsupportedCapability('Unified safeStorage adapter planned in windows-support phase 5.'),

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -13,7 +13,7 @@ import { createDarwinSecretsAdapter, createUnsupportedSecretsAdapter } from './s
 import { createDarwinStealthUaAdapter, createUnsupportedStealthUaAdapter, createWindowsStealthUaAdapter } from './stealth-ua';
 import type { PlatformAdapter } from './types';
 import { createDarwinVideoAudioAdapter, createUnsupportedVideoAudioAdapter } from './video-audio';
-import { createDarwinVoiceAdapter, createUnsupportedVoiceAdapter } from './voice';
+import { createDarwinVoiceAdapter, createLinuxVoiceAdapter, createUnsupportedVoiceAdapter, createWindowsVoiceAdapter } from './voice';
 import {
   createDarwinWindowChromeAdapter,
   createLinuxWindowChromeAdapter,
@@ -69,7 +69,11 @@ function createStubPlatform(id: PlatformId): PlatformAdapter {
       : id === 'linux'
         ? createLinuxNativeMessagingAdapter()
         : createUnsupportedNativeMessagingAdapter(id),
-    voice: createUnsupportedVoiceAdapter(id),
+    voice: id === 'win32'
+      ? createWindowsVoiceAdapter()
+      : id === 'linux'
+        ? createLinuxVoiceAdapter()
+        : createUnsupportedVoiceAdapter(id),
     videoAudio: createUnsupportedVideoAudioAdapter(id),
     windowChrome: id === 'win32'
       ? createWindowsWindowChromeAdapter()

--- a/src/platform/tests/platform.test.ts
+++ b/src/platform/tests/platform.test.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { NotImplementedError, getPlatformCapabilities, selectPlatform } from '..';
 import { ChromeImporter } from '../../import/chrome-importer';
 import { createDarwinChromeImportAdapter, createWindowsChromeImportAdapter } from '../chrome-import';
+import { createDarwinVoiceAdapter, createWindowsVoiceAdapter, findWindowsWhisperBinary } from '../voice';
 
 function writeChromeBookmarks(bookmarksPath: string): void {
   fs.writeFileSync(bookmarksPath, JSON.stringify({
@@ -80,8 +81,10 @@ describe('selectPlatform', () => {
     expect(platform.capabilities.capabilities.windowChrome.status).toBe('supported');
     expect(platform.capabilities.capabilities.userDataDirectory.status).toBe('supported');
     expect(platform.capabilities.capabilities.nativeMessagingHostDetection.status).toBe('supported');
+    expect(platform.capabilities.capabilities.voiceTranscription.status).toBe('partial');
     expect(() => platform.chromeImport.getUnavailableStatus()).not.toThrow();
     expect(() => platform.nativeMessaging.createDetectionAdapter().getNativeMessagingDirs()).not.toThrow();
+    expect(() => platform.voice.detectBackend()).not.toThrow();
     expect(platform.windowChrome.getBrowserWindowOptions()).toMatchObject({
       frame: false,
     });
@@ -201,6 +204,39 @@ describe('selectPlatform', () => {
     expect(adapter.getCookieImportSupport()).toMatchObject({
       encryptedStore: false,
       status: 'unsupported',
+    });
+  });
+
+  it('keeps the Darwin voice adapter on Apple Speech when the native binary exists', () => {
+    const adapter = createDarwinVoiceAdapter({
+      resourcesPath: '/Applications/Tandem.app/Contents/Resources',
+      existsSync: (candidate) => candidate === path.join('/Applications/Tandem.app/Contents/Resources', 'native', 'tandem-speech'),
+    });
+
+    expect(adapter.detectBackend()).toBe('apple');
+  });
+
+  it('detects whisper.exe through Windows-style PATH lookup', () => {
+    const whisperPath = path.win32.join('C:\\Tools\\Whisper', 'whisper.exe');
+
+    expect(findWindowsWhisperBinary({
+      env: { Path: 'C:\\Windows\\System32;C:\\Tools\\Whisper' },
+      existsSync: (candidate) => candidate === whisperPath,
+    })).toBe(whisperPath);
+  });
+
+  it('returns a clear Windows voice status when whisper.exe is missing', async () => {
+    const adapter = createWindowsVoiceAdapter({
+      env: { Path: 'C:\\Windows\\System32' },
+      existsSync: () => false,
+    });
+
+    const result = await adapter.transcribeAudio(Buffer.from('fixture'), 'nl-BE');
+
+    expect(adapter.detectBackend()).toBe('none');
+    expect(result).toMatchObject({
+      ok: false,
+      error: expect.stringContaining('whisper.exe on PATH'),
     });
   });
 });

--- a/src/platform/voice/index.ts
+++ b/src/platform/voice/index.ts
@@ -1,18 +1,122 @@
-import type * as SpeechTranscriberModule from '../../voice/speech-transcriber';
+import fs from 'fs';
+import path from 'path';
+import { transcribeAudioWithBackend, type TranscriberBackendSelection } from '../../voice/speech-transcriber';
 import { NotImplementedError, type PlatformId } from '../errors';
 import type { VoiceAdapter } from '../types';
 
-export function createDarwinVoiceAdapter(): VoiceAdapter {
+const WINDOWS_WHISPER_UNAVAILABLE =
+  'Windows voice transcription requires whisper.exe on PATH. Install Whisper yourself, make sure whisper.exe is available on PATH, and restart Tandem. Tandem does not download models or bundle Whisper.';
+
+const UNIX_WHISPER_UNAVAILABLE =
+  'No speech transcription backend available. Install whisper: pip install openai-whisper';
+
+interface VoiceAdapterOptions {
+  existsSync?: (path: string) => boolean;
+  env?: NodeJS.ProcessEnv;
+  resourcesPath?: string;
+  speechBinaryDir?: string;
+}
+
+function fileExists(filePath: string, existsSync: (path: string) => boolean): boolean {
+  try {
+    return existsSync(filePath);
+  } catch {
+    return false;
+  }
+}
+
+function getAppleSpeechBinary(options: VoiceAdapterOptions = {}): string {
+  const existsSync = options.existsSync ?? fs.existsSync;
+  const resourcesPath = options.resourcesPath ?? process.resourcesPath ?? '';
+  const speechBinaryDir = options.speechBinaryDir ?? path.join(__dirname, '..', '..', '..', 'native', 'speech');
+  const bundled = path.join(resourcesPath, 'native', 'tandem-speech');
+  const dev = path.join(speechBinaryDir, 'tandem-speech');
+
+  if (fileExists(bundled, existsSync)) return bundled;
+  if (fileExists(dev, existsSync)) return dev;
+  return '';
+}
+
+function getUnixWhisperBinary(options: VoiceAdapterOptions = {}): string {
+  const existsSync = options.existsSync ?? fs.existsSync;
+  const locations = [
+    '/opt/homebrew/bin/whisper',
+    '/usr/local/bin/whisper',
+    '/usr/bin/whisper',
+  ];
+
+  for (const location of locations) {
+    if (fileExists(location, existsSync)) return location;
+  }
+  return '';
+}
+
+function getWindowsPathValue(env: NodeJS.ProcessEnv): string {
+  const pathKey = Object.keys(env).find((key) => key.toLowerCase() === 'path');
+  return pathKey ? env[pathKey] ?? '' : '';
+}
+
+export function findWindowsWhisperBinary(options: VoiceAdapterOptions = {}): string {
+  const existsSync = options.existsSync ?? fs.existsSync;
+  const env = options.env ?? process.env;
+  const pathValue = getWindowsPathValue(env);
+
+  for (const rawDir of pathValue.split(path.win32.delimiter)) {
+    const dir = rawDir.trim().replace(/^"|"$/g, '');
+    if (!dir) continue;
+
+    const candidate = path.win32.join(dir, 'whisper.exe');
+    if (fileExists(candidate, existsSync)) return candidate;
+  }
+
+  return '';
+}
+
+function createAdapter(selectionFactory: () => TranscriberBackendSelection): VoiceAdapter {
   return {
-    detectBackend: () => {
-      const { detectBackend } = require('../../voice/speech-transcriber') as typeof SpeechTranscriberModule;
-      return detectBackend();
-    },
+    detectBackend: () => selectionFactory().backend,
     transcribeAudio: async (audioBuffer, language) => {
-      const { transcribeAudio } = require('../../voice/speech-transcriber') as typeof SpeechTranscriberModule;
-      return transcribeAudio(audioBuffer, language);
+      return transcribeAudioWithBackend(audioBuffer, selectionFactory(), language);
     },
   };
+}
+
+export function createDarwinVoiceAdapter(options: VoiceAdapterOptions = {}): VoiceAdapter {
+  return createAdapter(() => {
+    const appleBinary = getAppleSpeechBinary(options);
+    if (appleBinary) {
+      return { backend: 'apple', binary: appleBinary };
+    }
+
+    const whisperBinary = getUnixWhisperBinary(options);
+    if (whisperBinary) {
+      return { backend: 'whisper', binary: whisperBinary };
+    }
+
+    return { backend: 'none', unavailableMessage: UNIX_WHISPER_UNAVAILABLE };
+  });
+}
+
+export function createWindowsVoiceAdapter(options: VoiceAdapterOptions = {}): VoiceAdapter {
+  return createAdapter(() => {
+    const whisperBinary = findWindowsWhisperBinary(options);
+    if (whisperBinary) {
+      return { backend: 'whisper', binary: whisperBinary };
+    }
+
+    return { backend: 'none', unavailableMessage: WINDOWS_WHISPER_UNAVAILABLE };
+  });
+}
+
+export function createLinuxVoiceAdapter(options: VoiceAdapterOptions = {}): VoiceAdapter {
+  return createAdapter(() => {
+    const whisperBinary = getUnixWhisperBinary(options);
+    if (whisperBinary) {
+      return { backend: 'whisper', binary: whisperBinary };
+    }
+
+    return { backend: 'none', unavailableMessage: UNIX_WHISPER_UNAVAILABLE };
+  });
 }
 
 export function createUnsupportedVoiceAdapter(platform: PlatformId): VoiceAdapter {

--- a/src/voice/speech-transcriber.ts
+++ b/src/voice/speech-transcriber.ts
@@ -6,44 +6,24 @@ import { createLogger } from '../utils/logger';
 
 const log = createLogger('SpeechTranscriber');
 
-type TranscriberBackend = 'apple' | 'whisper' | 'none';
+export type TranscriberBackend = 'apple' | 'whisper' | 'none';
 
-function getAppleSpeechBinary(): string {
-  // Check bundled binary first, then dev location
-  const bundled = path.join(process.resourcesPath || '', 'native', 'tandem-speech');
-  const dev = path.join(__dirname, '..', '..', 'native', 'speech', 'tandem-speech');
-  if (fs.existsSync(bundled)) return bundled;
-  if (fs.existsSync(dev)) return dev;
-  return '';
+export interface TranscriberBackendSelection {
+  backend: TranscriberBackend;
+  binary?: string;
+  unavailableMessage?: string;
 }
 
-function getWhisperBinary(): string {
-  // Common locations
-  const locations = [
-    '/opt/homebrew/bin/whisper',
-    '/usr/local/bin/whisper',
-    '/usr/bin/whisper',
-  ];
-  for (const loc of locations) {
-    if (fs.existsSync(loc)) return loc;
-  }
-  return '';
-}
-
-export function detectBackend(): TranscriberBackend {
-  if (process.platform === 'darwin' && getAppleSpeechBinary()) return 'apple';
-  if (getWhisperBinary()) return 'whisper';
-  return 'none';
-}
-
-export async function transcribeAudio(
+export async function transcribeAudioWithBackend(
   audioBuffer: Buffer,
+  selection: TranscriberBackendSelection,
   language = 'nl-BE'
 ): Promise<{ ok: boolean; text?: string; error?: string }> {
-  const backend = detectBackend();
-
-  if (backend === 'none') {
-    return { ok: false, error: 'No speech transcription backend available. Install whisper: pip install openai-whisper' };
+  if (selection.backend === 'none' || !selection.binary) {
+    return {
+      ok: false,
+      error: selection.unavailableMessage ?? 'No speech transcription backend available. Install whisper: pip install openai-whisper',
+    };
   }
 
   // Write audio buffer to temp file — use .webm since MediaRecorder outputs webm
@@ -55,11 +35,10 @@ export async function transcribeAudio(
   }
 
   try {
-    if (backend === 'apple') {
-      return await transcribeWithApple(tmpFile, language);
-    } else {
-      return await transcribeWithWhisper(tmpFile, language);
+    if (selection.backend === 'apple') {
+      return await transcribeWithApple(tmpFile, selection.binary, language);
     }
+    return await transcribeWithWhisper(tmpFile, selection.binary, language);
   } finally {
     try { fs.unlinkSync(tmpFile); } catch { /* ignore */ }
   }
@@ -87,8 +66,7 @@ function convertToM4a(inputFile: string): Promise<string> {
   });
 }
 
-async function transcribeWithApple(audioFile: string, language: string): Promise<{ ok: boolean; text?: string; error?: string }> {
-  const binary = getAppleSpeechBinary();
+async function transcribeWithApple(audioFile: string, binary: string, language: string): Promise<{ ok: boolean; text?: string; error?: string }> {
   const appleLanguage = language === 'nl-BE' ? 'nl-NL' : language;
 
   // Convert webm → m4a (Apple Speech doesn't accept webm)
@@ -126,9 +104,8 @@ async function transcribeWithApple(audioFile: string, language: string): Promise
   });
 }
 
-function transcribeWithWhisper(audioFile: string, language: string): Promise<{ ok: boolean; text?: string; error?: string }> {
+function transcribeWithWhisper(audioFile: string, binary: string, language: string): Promise<{ ok: boolean; text?: string; error?: string }> {
   return new Promise((resolve) => {
-    const binary = getWhisperBinary();
     // Map language code: nl-BE → nl
     const whisperLang = language.split('-')[0];
 


### PR DESCRIPTION
## Summary

Windows support Phase 10 moves native voice backend selection into the platform voice adapter. macOS still prefers the bundled/development Apple Speech `tandem-speech` binary and keeps the existing Whisper fallback when Apple Speech is unavailable. Windows source runs now use user-installed Whisper only when `whisper.exe` is available on `PATH`; otherwise the app returns a clear user-facing missing-Whisper status.

## Scope

- Added Windows-style `PATH` detection for `whisper.exe` in `src/platform/voice/`.
- Routed IPC speech backend status and transcription through the selected platform adapter.
- Kept shared transcription execution in `src/voice/speech-transcriber.ts` platform-neutral.
- Marked Windows voice transcription as partial in the platform support matrix.
- Bumped the feat release from `1.7.0` to `1.8.0` and updated public version references.

## macOS Safety

macOS behavior is wrapper-only: the Darwin voice adapter preserves the existing Apple Speech binary lookup order and keeps the prior Unix Whisper fallback. No macOS audio capture, permission, or Apple Speech execution behavior was intentionally changed.

## Windows Notes

Tandem does not download Whisper models, bundle Whisper, or add Windows audio capture code in this phase. Windows audio capture remains Phase 11.

`where.exe whisper.exe` did not find Whisper on this Windows machine, so no short-clip transcription test was possible here. The missing-Whisper path was verified with the compiled Windows adapter and focused tests.

## Validation

- `npx tsc --noEmit`
- `npx vitest run src/platform/tests/platform.test.ts`
- `npm run verify`
- `npm start` smoke test: app stayed running for the smoke window without startup crash, then was shut down
- Compiled adapter check returned `backend: none` with the clear missing-Whisper error when `whisper.exe` was absent

## Private Docs

Local/private Windows planning docs remained gitignored and were not staged or pushed:

- `docs/plans/windows-support-design.md`
- `docs/implementations/windows-support/`