### PR TITLE
[codex] Document Windows video audio blocker

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -37,6 +37,7 @@ Last updated: May 4, 2026
 - [x] HAR export for the network inspector
 - [ ] Design and build the `Personal News` experience; the sidebar currently has a placeholder slot, but the actual panel and feed model are not implemented yet
 - [x] Built-in video recorder with Application and Region capture modes, tab audio + mic toggle, MP4 output via ffmpeg; replaces AudioCaptureManager
+- [ ] Windows video recorder: find a proven system-audio capture path for the current `ffmpeg-static` binary or switch to an approved ffmpeg build strategy; Phase 11 proved DirectShow microphone capture works, but this machine has no DirectShow loopback/system-audio device and the bundled binary has no WASAPI input.
 - [ ] Linux video recorder: implement desktop audio capture via PulseAudio/Pipewire monitor sources; current implementation captures mic audio but not webview/tab audio due to Electron process isolation limitations on Linux
 
 ### Maintenance Sweep

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -46,7 +46,7 @@
 | Chrome cookie import | partial | unsupported | partial | Windows encrypted cookie import requires DPAPI support and is intentionally not implemented in phase 8; no risky dependency was added. |
 | Native messaging host detection | supported | supported | supported | Windows reads Chrome native messaging host registry keys under HKCU/HKLM and keeps the filesystem fallback. |
 | Voice transcription | supported | partial | partial | Windows source runs can use user-installed `whisper.exe` on `PATH`; Tandem does not bundle Whisper or download models. |
-| Video recorder with system audio | supported | unsupported | partial | Windows WASAPI loopback planned in windows-support phase 11. |
+| Video recorder with system audio | supported | unsupported | partial | Windows phase 11 spike found that the current `ffmpeg-static` binary exposes DirectShow capture but no WASAPI input, and this machine has no DirectShow loopback/system-audio device. |
 | Keyboard shortcuts and labels | supported | partial | supported | Cross-platform labels finalized in windows-support phase 12. |
 | Secrets at rest | supported | unsupported | supported | Unified `safeStorage` adapter planned in windows-support phase 5. |
 | User data directory | supported | unsupported | supported | Windows `%APPDATA%` path planned in windows-support phase 4. |


### PR DESCRIPTION
## Summary
- Records the Windows Support Phase 11 ffmpeg spike outcome without claiming product support.
- Keeps Windows video recorder system audio marked `unsupported` because loopback capture was not proven.
- Adds the blocker to `TODO.md` so the next implementation attempt has a clear starting point.

## Spike Results
- Tandem resolves ffmpeg to `C:\dev\tandem-browser\node_modules\ffmpeg-static\ffmpeg.exe`.
- `ffmpeg -hide_banner -devices` showed `dshow`, `gdigrab`, `lavfi`, and `vfwcap`; it did not show a WASAPI input device.
- `ffmpeg -hide_banner -list_devices true -f dshow -i dummy` listed only `Microphone Array (Realtek(R) Audio)` and `Headset (OpenRun Pro 2 by Shokz)` as audio devices.
- WASAPI attempt failed: `ffmpeg -hide_banner -f wasapi -i default -t 2 -y %TEMP%\tandem-wasapi-spike.mp4` returned `Unknown input format: 'wasapi'`.
- DirectShow loopback attempt failed: `ffmpeg -hide_banner -f dshow -t 2 -i "audio=Stereo Mix (Realtek(R) Audio)" -c:a aac -y %TEMP%\tandem-stereo-mix-spike.mp4` returned `Could not find audio only device with name [Stereo Mix (Realtek(R) Audio)]`.
- DirectShow microphone sanity check succeeded: `ffmpeg -hide_banner -f dshow -t 2 -i "audio=Microphone Array (Realtek(R) Audio)" -c:a aac -y %TEMP%\tandem-dshow-mic-spike.mp4`; ffmpeg reported an AAC audio stream in the resulting MP4.

## macOS Safety
- No recorder code changed.
- macOS recorder behavior remains unchanged because this PR only updates public tracking docs.

## Validation
- `npm run verify`: passed (`tsc`, preload bundle, ESLint, 144 Vitest files / 2922 tests, consistency check).
- Manual Windows ffmpeg spike completed as documented above.

## Notes
- No new dependencies were added.
- No version or changelog bump was made because Phase 11 product support did not land.
- Private/local Windows planning files remain gitignored and were not staged or pushed.