### PR TITLE
[codex] Windows support phase 12 shortcut labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to Tandem Browser will be documented in this file.
 
 ## Unreleased
 
+## [v1.9.0] - 2026-05-04
+
+Windows support Phase 12. Tandem now keeps Electron shortcut accelerators on
+`CommandOrControl` while rendering visible shortcut labels per platform, so
+macOS labels stay unchanged and Windows source runs show `Ctrl+...`.
+
+### Added
+
+- **Shortcut label helpers** (`src/platform/shortcuts/`,
+  `shell/js/shortcut-labels.js`) - centralize accelerator construction and
+  rendered shortcut labels for shell pages.
+- **Shortcut label coverage** (`src/platform/tests/platform.test.ts`) - pins
+  the existing macOS labels with a snapshot and verifies Windows `Ctrl+...`
+  rendering.
+
+### Changed
+
+- **Application and context menus** (`src/menu/app-menu.ts`,
+  `src/ipc/handlers.ts`, `src/context-menu/menu-builder.ts`) - now use
+  `CommandOrControl` accelerator strings.
+- **Shell shortcut surfaces** (`shell/index.html`, `shell/help.html`,
+  `shell/settings.html`) - render hardcoded macOS shortcut text as
+  platform-aware labels at runtime.
+- **Platform support matrix** (`docs/platform-support.md`,
+  `src/platform/capabilities.ts`) - marks Windows shortcut labels as supported
+  for source runs.
+
+### Technical Details
+
+- Conflict detection behavior is unchanged; its shortcut normalization now also
+  accepts `CommandOrControl+...` inputs.
+- No new dependency was added.
+
 ## [v1.8.0] - 2026-05-04
 
 Windows support Phase 10. Tandem now routes native speech transcription through

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -31,7 +31,7 @@ The security layer exists because when an AI has access to your browser, your th
 Data stays local. Sessions are isolated. Nothing leaves the machine through Tandem Browser without going through a filter first.
 
 **GitHub:** `hydro13/tandem-browser`  
-**Current version:** `1.8.0`
+**Current version:** `1.9.0`
 **Repository status:** Public developer preview  
 **Started:** February 11, 2026
 

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ contributors, not yet a polished mass-user release.
 - Secondary platform: Linux
 - Windows: validated as a remote agent host (VS Code + Claude Code over Tailscale)
 - Binaries: signed & notarized macOS Apple Silicon builds published on [GitHub Releases](https://github.com/hydro13/tandem-browser/releases), starting at v1.0.0
-- Current version: `1.8.0`
+- Current version: `1.9.0`
 - Package metadata: [package.json](package.json)
 
 ## Community

--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@ Last updated: May 4, 2026
 
 ## Current Snapshot
 
-- Current app version: `1.8.0`
+- Current app version: `1.9.0`
 - MCP server: 253 tools (full API parity + awareness)
 - The codebase scope is larger than this backlog summary and includes major subsystems such as `sidebar`, `workspaces`, `pinboards`, `sync`, `headless`, and `sessions`.
 - Scheduled browsing already exists in baseline form via `WatchManager` and the `/watch/*` API routes.
@@ -94,6 +94,10 @@ Last updated: May 4, 2026
 
 ## Recently Completed
 
+- [x] Windows support Phase 12: centralized shortcut accelerator and label
+  handling, switched Electron menus to `CommandOrControl` accelerator strings,
+  preserved macOS shortcut labels, and rendered Windows shortcut labels as
+  `Ctrl+...`.
 - [x] Windows support Phase 10: moved voice backend selection into the platform
   voice adapter, preserved the macOS Apple Speech path, added Windows
   `whisper.exe` PATH detection for opt-in Whisper transcription, and returns a

--- a/docs/index.html
+++ b/docs/index.html
@@ -325,7 +325,7 @@ footer a:hover{color:var(--text2)}
 </header>
 
 <div class="hero">
-<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v1.8.0</div>
+<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v1.9.0</div>
 <p class="hero-lead">Tandem Browser is the <strong>open-source, local-first browser for AI agents</strong> — where the AI lives inside your real browser session, sharing your tabs, cookies, and DOM, ready to ask for your help the moment it gets stuck.</p>
 <h1>The browser becomes a <em>programmable workspace</em> where human intent and AI capability meet.</h1>
 <p>Tandem Browser is built around a simple shift: the AI is not a sidebar talking <em>about</em> your browser, it is <em>inside</em> it. Same tabs, same cookies, same logged-in sessions, same page you are looking at right now. Reading the accessibility tree, watching the network, writing live styles, handing back to you when something needs a human. It turns the web that already exists into something agents can actually operate on — no per-site API, no RPA rig, no screenshot loop. The real browser, as a shared human-AI symbiotic runtime.</p>

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -47,7 +47,7 @@
 | Native messaging host detection | supported | supported | supported | Windows reads Chrome native messaging host registry keys under HKCU/HKLM and keeps the filesystem fallback. |
 | Voice transcription | supported | partial | partial | Windows source runs can use user-installed `whisper.exe` on `PATH`; Tandem does not bundle Whisper or download models. |
 | Video recorder with system audio | supported | unsupported | partial | Windows phase 11 spike found that the current `ffmpeg-static` binary exposes DirectShow capture but no WASAPI input, and this machine has no DirectShow loopback/system-audio device. |
-| Keyboard shortcuts and labels | supported | partial | supported | Cross-platform labels finalized in windows-support phase 12. |
+| Keyboard shortcuts and labels | supported | supported | supported | Windows source runs show platform-aware `Ctrl` labels while preserving Electron `CommandOrControl` accelerators. |
 | Secrets at rest | supported | unsupported | supported | Unified `safeStorage` adapter planned in windows-support phase 5. |
 | User data directory | supported | unsupported | supported | Windows `%APPDATA%` path planned in windows-support phase 4. |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tandem-browser",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tandem-browser",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-browser",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Local-first Electron browser with a 253-tool MCP server, MCP/HTTP control surfaces, and built-in security controls",
   "main": "dist/main.js",
   "author": "Tandem Browser contributors",

--- a/shell/help.html
+++ b/shell/help.html
@@ -7,6 +7,7 @@
        stamp data-theme before the inline <style> blocks are processed by the
        parser. Sync XHR is deprecated (console warning), but it's the only way
        to avoid a dark→light flash. Fails silently if the API isn't up. -->
+  <script src="js/shortcut-labels.js"></script>
   <script>
     (function () {
       try {

--- a/shell/index.html
+++ b/shell/index.html
@@ -417,6 +417,7 @@
   <!-- <script src="js/claronote.js"></script> -->
   <script src="js/extensions.js"></script>
   <script src="js/video-recorder.js"></script>
+  <script src="js/shortcut-labels.js"></script>
   <script src="js/shortcut-router.js"></script>
 
   <!-- Keyboard Shortcuts Overlay -->

--- a/shell/js/shortcut-labels.js
+++ b/shell/js/shortcut-labels.js
@@ -1,0 +1,85 @@
+(() => {
+  const SKIP_TEXT_TAGS = new Set(['SCRIPT', 'STYLE', 'TEXTAREA', 'INPUT', 'CODE', 'PRE']);
+
+  function getCommandOrControlLabel(platform) {
+    return platform === 'darwin' ? 'Cmd' : 'Ctrl';
+  }
+
+  function labelShortcutText(text, platform) {
+    const modifier = getCommandOrControlLabel(platform);
+    let labelled = text
+      .replace(/CommandOrControl\+/gi, `${modifier}+`)
+      .replace(/CmdOrCtrl\+/gi, `${modifier}+`)
+      .replace(/Command\+/gi, `${modifier}+`)
+      .replace(/Cmd\+/gi, `${modifier}+`);
+
+    if (platform !== 'darwin') {
+      labelled = labelled
+        .replace(/⌘⇧/g, `${modifier}+Shift+`)
+        .replace(/⌘/g, `${modifier}+`);
+    }
+
+    return labelled;
+  }
+
+  async function detectPlatform() {
+    if (window.tandem?.getPlatform) {
+      try {
+        return await window.tandem.getPlatform();
+      } catch {
+        // Fall through to browser-provided hints.
+      }
+    }
+
+    const userAgentPlatform = navigator.userAgentData?.platform || navigator.platform || '';
+    return /mac/i.test(userAgentPlatform) ? 'darwin' : 'win32';
+  }
+
+  function applyShortcutLabels(root, platform) {
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+      acceptNode(node) {
+        const parent = node.parentElement;
+        if (!parent || SKIP_TEXT_TAGS.has(parent.tagName)) {
+          return NodeFilter.FILTER_REJECT;
+        }
+        return /Cmd\+|CommandOrControl\+|CmdOrCtrl\+|Command\+|⌘/.test(node.nodeValue || '')
+          ? NodeFilter.FILTER_ACCEPT
+          : NodeFilter.FILTER_SKIP;
+      },
+    });
+
+    const textNodes = [];
+    while (walker.nextNode()) {
+      textNodes.push(walker.currentNode);
+    }
+
+    for (const node of textNodes) {
+      node.nodeValue = labelShortcutText(node.nodeValue || '', platform);
+    }
+
+    for (const element of root.querySelectorAll('[title]')) {
+      const title = element.getAttribute('title') || '';
+      element.setAttribute('title', labelShortcutText(title, platform));
+    }
+  }
+
+  async function initShortcutLabels() {
+    const platform = await detectPlatform();
+    applyShortcutLabels(document.body, platform);
+  }
+
+  window.tandemShortcutLabels = {
+    applyShortcutLabels,
+    detectPlatform,
+    getCommandOrControlLabel,
+    labelShortcutText,
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+      void initShortcutLabels();
+    }, { once: true });
+  } else {
+    void initShortcutLabels();
+  }
+})();

--- a/shell/settings.html
+++ b/shell/settings.html
@@ -1119,6 +1119,7 @@
   </div>
 
   <script src="js/api-auth.js"></script>
+  <script src="js/shortcut-labels.js"></script>
   <script>
     const API = 'http://localhost:8765';
     const quickLinksList = document.getElementById('cfg-quickLinks');

--- a/src/context-menu/menu-builder.ts
+++ b/src/context-menu/menu-builder.ts
@@ -159,7 +159,7 @@ export class ContextMenuBuilder {
 
     menu.append(new MenuItem({
       label: 'Copy',
-      accelerator: 'CmdOrCtrl+C',
+      accelerator: 'CommandOrControl+C',
       click: () => { if (!wc.isDestroyed()) wc.copy(); },
     }));
 
@@ -183,13 +183,13 @@ export class ContextMenuBuilder {
 
     menu.append(new MenuItem({
       label: 'Undo',
-      accelerator: 'CmdOrCtrl+Z',
+      accelerator: 'CommandOrControl+Z',
       enabled: params.editFlags.canUndo,
       click: guard(() => wc.undo()),
     }));
     menu.append(new MenuItem({
       label: 'Redo',
-      accelerator: 'CmdOrCtrl+Shift+Z',
+      accelerator: 'CommandOrControl+Shift+Z',
       enabled: params.editFlags.canRedo,
       click: guard(() => wc.redo()),
     }));
@@ -198,25 +198,25 @@ export class ContextMenuBuilder {
 
     menu.append(new MenuItem({
       label: 'Cut',
-      accelerator: 'CmdOrCtrl+X',
+      accelerator: 'CommandOrControl+X',
       enabled: params.editFlags.canCut,
       click: guard(() => wc.cut()),
     }));
     menu.append(new MenuItem({
       label: 'Copy',
-      accelerator: 'CmdOrCtrl+C',
+      accelerator: 'CommandOrControl+C',
       enabled: params.editFlags.canCopy,
       click: guard(() => wc.copy()),
     }));
     menu.append(new MenuItem({
       label: 'Paste',
-      accelerator: 'CmdOrCtrl+V',
+      accelerator: 'CommandOrControl+V',
       enabled: params.editFlags.canPaste,
       click: guard(() => wc.paste()),
     }));
     menu.append(new MenuItem({
       label: 'Paste as Plain Text',
-      accelerator: 'CmdOrCtrl+Shift+V',
+      accelerator: 'CommandOrControl+Shift+V',
       enabled: params.editFlags.canPaste,
       click: guard(() => wc.pasteAndMatchStyle()),
     }));
@@ -230,7 +230,7 @@ export class ContextMenuBuilder {
 
     menu.append(new MenuItem({
       label: 'Select All',
-      accelerator: 'CmdOrCtrl+A',
+      accelerator: 'CommandOrControl+A',
       enabled: params.editFlags.canSelectAll,
       click: guard(() => wc.selectAll()),
     }));
@@ -314,7 +314,7 @@ export class ContextMenuBuilder {
     }));
     menu.append(new MenuItem({
       label: 'Reload',
-      accelerator: 'CmdOrCtrl+R',
+      accelerator: 'CommandOrControl+R',
       click: () => { if (!wc.isDestroyed()) wc.reload(); },
     }));
   }
@@ -325,12 +325,12 @@ export class ContextMenuBuilder {
   private addToolItems(menu: Menu, params: ContextMenuParams, wc: WebContents): void {
     menu.append(new MenuItem({
       label: 'Save As...',
-      accelerator: 'CmdOrCtrl+S',
+      accelerator: 'CommandOrControl+S',
       click: () => { this.handleSaveAs(wc).catch(e => log.warn('Save As failed:', e.message)); },
     }));
     menu.append(new MenuItem({
       label: 'Print...',
-      accelerator: 'CmdOrCtrl+P',
+      accelerator: 'CommandOrControl+P',
       click: () => { if (!wc.isDestroyed()) wc.print(); },
     }));
 
@@ -338,7 +338,7 @@ export class ContextMenuBuilder {
 
     menu.append(new MenuItem({
       label: 'View Page Source',
-      accelerator: 'CmdOrCtrl+U',
+      accelerator: 'CommandOrControl+U',
       click: () => {
         if (wc.isDestroyed()) return;
         const url = wc.getURL();
@@ -347,7 +347,7 @@ export class ContextMenuBuilder {
     }));
     menu.append(new MenuItem({
       label: 'Inspect Element',
-      accelerator: 'CmdOrCtrl+Shift+I',
+      accelerator: 'CommandOrControl+Shift+I',
       click: () => { if (!wc.isDestroyed()) wc.inspectElement(params.x, params.y); },
     }));
   }
@@ -452,7 +452,7 @@ export class ContextMenuBuilder {
     const isBookmarkedNow = this.deps.bookmarkManager.isBookmarked(pageUrl);
     menu.append(new MenuItem({
       label: isBookmarkedNow ? 'Remove Bookmark' : 'Bookmark this Page',
-      accelerator: 'CmdOrCtrl+D',
+      accelerator: 'CommandOrControl+D',
       click: () => {
         const currentlyBookmarked = this.deps.bookmarkManager.isBookmarked(pageUrl);
         if (currentlyBookmarked) {
@@ -504,7 +504,7 @@ export class ContextMenuBuilder {
     } else if (params.selectionText) {
       menu.append(new MenuItem({
         label: 'Copy',
-        accelerator: 'CmdOrCtrl+C',
+        accelerator: 'CommandOrControl+C',
         click: () => { if (!wc.isDestroyed()) wc.copy(); },
       }));
     }
@@ -543,7 +543,7 @@ export class ContextMenuBuilder {
     this.addSeparator(menu);
     menu.append(new MenuItem({
       label: 'Inspect Element',
-      accelerator: 'CmdOrCtrl+Shift+I',
+      accelerator: 'CommandOrControl+Shift+I',
       click: () => { if (!wc.isDestroyed()) wc.inspectElement(params.x, params.y); },
     }));
   }
@@ -561,7 +561,7 @@ export class ContextMenuBuilder {
 
     menu.append(new MenuItem({
       label: 'New Tab',
-      accelerator: 'CmdOrCtrl+T',
+      accelerator: 'CommandOrControl+T',
       click: () => this.deps.tabManager.openTab(),
     }));
 
@@ -666,7 +666,7 @@ export class ContextMenuBuilder {
 
     menu.append(new MenuItem({
       label: 'Close Tab',
-      accelerator: 'CmdOrCtrl+W',
+      accelerator: 'CommandOrControl+W',
       click: () => this.deps.tabManager.closeTab(tabId),
     }));
     menu.append(new MenuItem({
@@ -692,7 +692,7 @@ export class ContextMenuBuilder {
 
     menu.append(new MenuItem({
       label: 'Reopen Closed Tab',
-      accelerator: 'CmdOrCtrl+Shift+T',
+      accelerator: 'CommandOrControl+Shift+T',
       enabled: this.deps.tabManager.hasClosedTabs(),
       click: () => this.deps.tabManager.reopenClosedTab(),
     }));

--- a/src/extensions/conflict-detector.ts
+++ b/src/extensions/conflict-detector.ts
@@ -53,7 +53,7 @@ const TANDEM_SHORTCUTS: TandemShortcut[] = [
   { key: 'Ctrl+Shift+S', action: 'Quick Screenshot' },
   { key: 'Ctrl+Shift+C', action: 'ClaroNote Record' },
   { key: 'Ctrl+Shift+/', action: 'Keyboard Shortcuts' },
-  // Cmd+1-9 tab switching
+  // CommandOrControl+1-9 tab switching
   { key: 'Ctrl+1', action: 'Switch to Tab 1' },
   { key: 'Ctrl+2', action: 'Switch to Tab 2' },
   { key: 'Ctrl+3', action: 'Switch to Tab 3' },
@@ -291,6 +291,7 @@ export class ConflictDetector {
  */
 function normalizeShortcut(shortcut: string): string {
   return shortcut
+    .replace(/CommandOrControl\+/gi, 'Ctrl+')
     .replace(/Command\+/gi, 'Ctrl+')
     .replace(/MacCtrl\+/gi, 'Ctrl+')
     .replace(/Cmd\+/gi, 'Ctrl+')

--- a/src/ipc/handlers.ts
+++ b/src/ipc/handlers.ts
@@ -31,6 +31,7 @@ import { IpcChannels } from '../shared/ipc-channels';
 import { buildOwnershipContextForTab, buildOwnershipContextForTabId } from '../tabs/runtime-context';
 import { wingmanAlert } from '../notifications/alert';
 import { selectPlatform } from '../platform';
+import { commandOrControlAccelerator } from '../platform/shortcuts';
 
 const log = createLogger('IpcHandlers');
 
@@ -675,6 +676,7 @@ export function registerIpcHandlers(deps: IpcDeps): void {
   // App menu popup (frameless window on Linux)
   ipcMain.on(IpcChannels.SHOW_APP_MENU, (_event, data: { x: number; y: number }) => {
     const send = (action: string) => _win.webContents.send(IpcChannels.SHORTCUT, action);
+    const acc = commandOrControlAccelerator;
     
     const template: Electron.MenuItemConstructorOptions[] = [
       {
@@ -685,7 +687,7 @@ export function registerIpcHandlers(deps: IpcDeps): void {
             click: () => send('show-about'),
           },
           { type: 'separator' },
-          { label: 'Settings', accelerator: 'CmdOrCtrl+,', click: () => send('open-settings') },
+          { label: 'Settings', accelerator: acc(','), click: () => send('open-settings') },
           { type: 'separator' },
           { label: 'Quit', role: 'quit' as const },
         ],
@@ -693,13 +695,13 @@ export function registerIpcHandlers(deps: IpcDeps): void {
       {
         label: 'File',
         submenu: [
-          { label: 'New Tab', accelerator: 'CmdOrCtrl+T', click: () => send('new-tab') },
-          { label: 'Close Tab', accelerator: 'CmdOrCtrl+W', click: () => send('close-tab') },
+          { label: 'New Tab', accelerator: acc('T'), click: () => send('new-tab') },
+          { label: 'Close Tab', accelerator: acc('W'), click: () => send('close-tab') },
           { type: 'separator' },
-          { label: 'Bookmark Page', accelerator: 'CmdOrCtrl+D', click: () => send('bookmark-page') },
+          { label: 'Bookmark Page', accelerator: acc('D'), click: () => send('bookmark-page') },
           { label: 'Bookmark Manager', click: () => send('open-bookmarks') },
-          { label: 'History', accelerator: 'CmdOrCtrl+Y', click: () => send('open-history') },
-          { label: 'Find in Page', accelerator: 'CmdOrCtrl+F', click: () => send('find-in-page') },
+          { label: 'History', accelerator: acc('Y'), click: () => send('open-history') },
+          { label: 'Find in Page', accelerator: acc('F'), click: () => send('find-in-page') },
         ],
       },
       {
@@ -717,11 +719,11 @@ export function registerIpcHandlers(deps: IpcDeps): void {
       {
         label: 'View',
         submenu: [
-          { label: 'Reload', accelerator: 'CmdOrCtrl+R', click: () => send('reload') },
+          { label: 'Reload', accelerator: acc('R'), click: () => send('reload') },
           { type: 'separator' },
-          { label: 'Zoom In', accelerator: 'CmdOrCtrl+=', click: () => send('zoom-in') },
-          { label: 'Zoom Out', accelerator: 'CmdOrCtrl+-', click: () => send('zoom-out') },
-          { label: 'Reset Zoom', accelerator: 'CmdOrCtrl+0', click: () => send('zoom-reset') },
+          { label: 'Zoom In', accelerator: acc('='), click: () => send('zoom-in') },
+          { label: 'Zoom Out', accelerator: acc('-'), click: () => send('zoom-out') },
+          { label: 'Reset Zoom', accelerator: acc('0'), click: () => send('zoom-reset') },
           { type: 'separator' },
           { role: 'togglefullscreen' as const },
         ],
@@ -729,11 +731,11 @@ export function registerIpcHandlers(deps: IpcDeps): void {
       {
         label: 'Wingman',
         submenu: [
-          { label: 'Toggle Panel', accelerator: 'CmdOrCtrl+K', click: () => send('toggle-panel') },
-          { label: 'Voice Input', accelerator: 'CmdOrCtrl+Shift+M', click: () => send('voice-input') },
+          { label: 'Toggle Panel', accelerator: acc('K'), click: () => send('toggle-panel') },
+          { label: 'Voice Input', accelerator: acc('Shift+M'), click: () => send('voice-input') },
           { type: 'separator' },
-          { label: 'Draw Mode', accelerator: 'CmdOrCtrl+Shift+D', click: () => send('toggle-draw') },
-          { label: 'Quick Screenshot', accelerator: 'CmdOrCtrl+Shift+S', click: () => send('quick-screenshot') },
+          { label: 'Draw Mode', accelerator: acc('Shift+D'), click: () => send('toggle-draw') },
+          { label: 'Quick Screenshot', accelerator: acc('Shift+S'), click: () => send('quick-screenshot') },
         ],
       },
       {
@@ -746,7 +748,7 @@ export function registerIpcHandlers(deps: IpcDeps): void {
       {
         label: 'Help',
         submenu: [
-          { label: 'Keyboard Shortcuts', accelerator: 'CmdOrCtrl+?', click: () => send('show-shortcuts') },
+          { label: 'Keyboard Shortcuts', accelerator: acc('?'), click: () => send('show-shortcuts') },
         ],
       },
     ];

--- a/src/menu/app-menu.ts
+++ b/src/menu/app-menu.ts
@@ -8,6 +8,7 @@ import type { PiPManager } from '../pip/manager';
 import type { ConfigManager } from '../config/manager';
 import type { VideoRecorderManager } from '../video/recorder';
 import { IpcChannels } from '../shared/ipc-channels';
+import { commandOrControlAccelerator } from '../platform/shortcuts';
 
 export interface MenuDeps {
   mainWindow: BrowserWindow | null;
@@ -22,12 +23,13 @@ export interface MenuDeps {
 
 export function buildAppMenu(deps: MenuDeps): void {
   const send = (action: string) => deps.mainWindow?.webContents.send(IpcChannels.SHORTCUT, action);
+  const acc = commandOrControlAccelerator;
 
   const template: Electron.MenuItemConstructorOptions[] = [
     {
       label: 'Tandem Browser',
       submenu: [
-        { label: 'Settings', accelerator: 'CmdOrCtrl+,', click: () => send('open-settings') },
+        { label: 'Settings', accelerator: acc(','), click: () => send('open-settings') },
         { type: 'separator' },
         { role: 'hide' },
         { role: 'hideOthers' },
@@ -39,17 +41,17 @@ export function buildAppMenu(deps: MenuDeps): void {
     {
       label: 'File',
       submenu: [
-        { label: 'New Tab', accelerator: 'CmdOrCtrl+T', click: () => send('new-tab') },
-        { label: 'Close Tab', accelerator: 'CmdOrCtrl+W', click: () => send('close-tab') },
-        { label: 'Reopen Closed Tab', accelerator: 'CmdOrCtrl+Shift+T', click: () => {
+        { label: 'New Tab', accelerator: acc('T'), click: () => send('new-tab') },
+        { label: 'Close Tab', accelerator: acc('W'), click: () => send('close-tab') },
+        { label: 'Reopen Closed Tab', accelerator: acc('Shift+T'), click: () => {
           void deps.tabManager?.reopenClosedTab();
         }},
         { type: 'separator' },
-        { label: 'Bookmark Page', accelerator: 'CmdOrCtrl+D', click: () => send('bookmark-page') },
-        { label: 'Toggle Bookmarks Bar', accelerator: 'CmdOrCtrl+Shift+B', click: () => send('toggle-bookmarks-bar') },
+        { label: 'Bookmark Page', accelerator: acc('D'), click: () => send('bookmark-page') },
+        { label: 'Toggle Bookmarks Bar', accelerator: acc('Shift+B'), click: () => send('toggle-bookmarks-bar') },
         { label: 'Bookmark Manager', click: () => send('open-bookmarks') },
-        { label: 'Find in Page', accelerator: 'CmdOrCtrl+F', click: () => send('find-in-page') },
-        { label: 'History', accelerator: 'CmdOrCtrl+Y', click: () => send('open-history') },
+        { label: 'Find in Page', accelerator: acc('F'), click: () => send('find-in-page') },
+        { label: 'History', accelerator: acc('Y'), click: () => send('open-history') },
       ],
     },
     {
@@ -63,15 +65,15 @@ export function buildAppMenu(deps: MenuDeps): void {
         { role: 'paste' },
         { role: 'selectAll' },
         { type: 'separator' },
-        { label: 'Draw Mode', accelerator: 'CmdOrCtrl+Shift+D', click: () => deps.drawManager?.toggleDrawMode() },
+        { label: 'Draw Mode', accelerator: acc('Shift+D'), click: () => deps.drawManager?.toggleDrawMode() },
       ],
     },
     {
       label: 'View',
       submenu: [
-        { label: 'Zoom In', accelerator: 'CmdOrCtrl+=', click: () => send('zoom-in') },
-        { label: 'Zoom Out', accelerator: 'CmdOrCtrl+-', click: () => send('zoom-out') },
-        { label: 'Reset Zoom', accelerator: 'CmdOrCtrl+0', click: () => send('zoom-reset') },
+        { label: 'Zoom In', accelerator: acc('='), click: () => send('zoom-in') },
+        { label: 'Zoom Out', accelerator: acc('-'), click: () => send('zoom-out') },
+        { label: 'Reset Zoom', accelerator: acc('0'), click: () => send('zoom-reset') },
         { type: 'separator' },
         { role: 'togglefullscreen' },
       ],
@@ -79,7 +81,7 @@ export function buildAppMenu(deps: MenuDeps): void {
     {
       label: 'Help',
       submenu: [
-        { label: 'Keyboard Shortcuts', accelerator: 'CmdOrCtrl+Shift+/', click: () => send('show-shortcuts') },
+        { label: 'Keyboard Shortcuts', accelerator: acc('Shift+/'), click: () => send('show-shortcuts') },
         { type: 'separator' },
         { label: 'Show Onboarding', click: () => send('show-onboarding') },
         { type: 'separator' },
@@ -88,12 +90,12 @@ export function buildAppMenu(deps: MenuDeps): void {
     },
   ];
 
-  // Add Cmd+1-9 tab switching (hidden menu items)
+  // Add CommandOrControl+1-9 tab switching (hidden menu items)
   const tabSwitchItems: Electron.MenuItemConstructorOptions[] = [];
   for (let i = 1; i <= 9; i++) {
     tabSwitchItems.push({
       label: `Tab ${i}`,
-      accelerator: `CmdOrCtrl+${i}`,
+      accelerator: acc(String(i)),
       visible: false,
       click: () => send(`focus-tab-${i - 1}`),
     });

--- a/src/platform/capabilities.ts
+++ b/src/platform/capabilities.ts
@@ -74,7 +74,7 @@ const CAPABILITY_PROFILES: Record<PlatformId, PlatformSupportProfile> = {
       nativeMessagingHostDetection: { status: 'supported', notes: 'Windows native messaging host detection reads Chrome registry keys and keeps the filesystem fallback.' },
       voiceTranscription: { status: 'partial', notes: 'Windows voice transcription uses whisper.exe when users install Whisper and place it on PATH; Tandem does not bundle Whisper or download models.' },
       videoRecorderSystemAudio: unsupportedCapability('Windows WASAPI loopback planned in windows-support phase 11.'),
-      keyboardShortcutsLabels: { status: 'partial', notes: 'Cross-platform labels finalized in windows-support phase 12.' },
+      keyboardShortcutsLabels: { status: 'supported', notes: 'Windows source runs show platform-aware Ctrl labels while preserving CommandOrControl accelerators.' },
       secretsAtRest: unsupportedCapability('Unified safeStorage adapter planned in windows-support phase 5.'),
       userDataDirectory: { status: 'supported', notes: 'Windows user data resolves to APPDATA/Tandem Browser.' },
     },

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -31,6 +31,11 @@ export type {
 } from './capabilities';
 export { getPlatformCapabilities, normalizePlatform } from './capabilities';
 export type { PlatformAdapter } from './types';
+export {
+  commandOrControlAccelerator,
+  getCommandOrControlLabel,
+  labelShortcutText,
+} from './shortcuts';
 
 function createDarwinPlatform(): PlatformAdapter {
   const id: PlatformId = 'darwin';

--- a/src/platform/shortcuts/index.ts
+++ b/src/platform/shortcuts/index.ts
@@ -1,0 +1,26 @@
+export type ShortcutLabelPlatform = 'darwin' | 'win32' | 'linux' | 'unsupported' | string;
+
+export function commandOrControlAccelerator(keys: string): string {
+  return `CommandOrControl+${keys}`;
+}
+
+export function getCommandOrControlLabel(platform: ShortcutLabelPlatform): 'Cmd' | 'Ctrl' {
+  return platform === 'darwin' ? 'Cmd' : 'Ctrl';
+}
+
+export function labelShortcutText(text: string, platform: ShortcutLabelPlatform): string {
+  const modifier = getCommandOrControlLabel(platform);
+  let labelled = text
+    .replace(/CommandOrControl\+/gi, `${modifier}+`)
+    .replace(/CmdOrCtrl\+/gi, `${modifier}+`)
+    .replace(/Command\+/gi, `${modifier}+`)
+    .replace(/Cmd\+/gi, `${modifier}+`);
+
+  if (platform !== 'darwin') {
+    labelled = labelled
+      .replace(/⌘⇧/g, `${modifier}+Shift+`)
+      .replace(/⌘/g, `${modifier}+`);
+  }
+
+  return labelled;
+}

--- a/src/platform/tests/platform.test.ts
+++ b/src/platform/tests/platform.test.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { NotImplementedError, getPlatformCapabilities, selectPlatform } from '..';
 import { ChromeImporter } from '../../import/chrome-importer';
 import { createDarwinChromeImportAdapter, createWindowsChromeImportAdapter } from '../chrome-import';
+import { commandOrControlAccelerator, labelShortcutText } from '../shortcuts';
 import { createDarwinVoiceAdapter, createWindowsVoiceAdapter, findWindowsWhisperBinary } from '../voice';
 
 function writeChromeBookmarks(bookmarksPath: string): void {
@@ -111,6 +112,15 @@ describe('selectPlatform', () => {
     expect(platform.id).toBe('unsupported');
     expect(platform.capabilities.tier).toBe('unsupported');
     expect(getPlatformCapabilities('freebsd').capabilities.appStartup.status).toBe('unsupported');
+  });
+
+  it('keeps existing macOS shortcut labels unchanged', () => {
+    expect(labelShortcutText('New tab (Cmd+T), Bookmark (⌘D), Screenshot (⌘⇧S)', 'darwin')).toMatchInlineSnapshot('"New tab (Cmd+T), Bookmark (⌘D), Screenshot (⌘⇧S)"');
+  });
+
+  it('renders Windows shortcut labels with Ctrl', () => {
+    expect(commandOrControlAccelerator('Shift+S')).toBe('CommandOrControl+Shift+S');
+    expect(labelShortcutText('New tab (Cmd+T), Bookmark (⌘D), Screenshot (⌘⇧S)', 'win32')).toBe('New tab (Ctrl+T), Bookmark (Ctrl+D), Screenshot (Ctrl+Shift+S)');
   });
 
   it('uses APPDATA/Tandem Browser for Windows user data paths', () => {


### PR DESCRIPTION
## Summary

Windows support Phase 12 centralizes shortcut accelerator and label handling:

- Adds `src/platform/shortcuts/` for `CommandOrControl` accelerator construction and focused label tests.
- Adds `shell/js/shortcut-labels.js` so shell-rendered shortcut labels stay unchanged on macOS and render as `Ctrl+...` on Windows.
- Converts Electron menu and context menu accelerator strings from `CmdOrCtrl` to `CommandOrControl`.
- Keeps extension conflict behavior unchanged, while allowing normalization of `CommandOrControl+...` inputs.
- Bumps the app version to `1.9.0` and updates changelog/version references.

## macOS Safety

macOS remains Tier 1. Existing macOS labels are pinned by a snapshot-style test and the renderer helper leaves existing macOS text/tooltips unchanged, including current `Cmd+...` and symbol labels.

## Windows Impact

Windows source runs now render visible shortcut labels/tooltips as `Ctrl+...` while preserving Electron `CommandOrControl` accelerators. No new shortcuts were added.

## Validation

- `npm run verify` passed: compile, lint, Vitest, and consistency check.
- Vitest: 144 test files passed; 2924 tests passed; 39 skipped.
- Manual Windows source smoke: `npm start` launched Electron and `GET /agent/version` returned `version: 1.9.0`.
- Manual DOM smoke with `jsdom`: macOS labels stayed unchanged and Windows labels rendered as `Ctrl+T`, `Ctrl+D`, and `Ctrl+Shift+S`.

## Notes

- No new dependency was added.
- Phase 11 video/audio blocker is untouched.
- Private local Windows planning files are intentionally not included.