### PR TITLE
[codex] Add Windows packaging targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Tandem Browser will be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+- chore: Add unsigned local Windows electron-builder targets for x64 NSIS and
+  portable artifacts with target-specific `setup` and `portable` artifact
+  names, while leaving the existing macOS packaging config unchanged.
+
 ## [v1.9.0] - 2026-05-04
 
 Windows support Phase 12. Tandem now keeps Electron shortcut accelerators on

--- a/package.json
+++ b/package.json
@@ -100,6 +100,30 @@
         "zip"
       ]
     },
+    "win": {
+      "target": [
+        {
+          "target": "nsis",
+          "arch": [
+            "x64"
+          ]
+        },
+        {
+          "target": "portable",
+          "arch": [
+            "x64"
+          ]
+        }
+      ],
+      "artifactName": "tandem-browser-${version}-${arch}.${ext}",
+      "signAndEditExecutable": false
+    },
+    "nsis": {
+      "artifactName": "tandem-browser-${version}-${arch}-setup.${ext}"
+    },
+    "portable": {
+      "artifactName": "tandem-browser-${version}-${arch}-portable.${ext}"
+    },
     "linux": {
       "category": "Utility"
     }


### PR DESCRIPTION
## Summary

- Add unsigned local Windows electron-builder packaging targets for x64 NSIS and portable builds.
- Add target-specific Windows artifact names so the installer and portable executable do not collide.
- Leave the existing macOS packaging config unchanged.

## Signing Status

Windows builds are intentionally unsigned in this phase. Robin chose not to configure Windows code signing yet, so this PR does not add certificate paths, passwords, Azure Trusted Signing, signing secrets, publish config, or release upload behavior. `win.signAndEditExecutable` is disabled for the unsigned local Windows build path so the build does not depend on signing helper extraction or credentials.

## Platform Impact

macOS remains Tier 1 and unchanged: the existing `mac` block still targets `dmg` and `zip`, and this PR only adds Windows packaging configuration alongside it. Linux remains untouched.

## Validation

- `npm run verify` passed: compile, lint, Vitest, and consistency checks are green.
- `npx electron-builder --win --x64 --publish=never` passed locally with `CSC_IDENTITY_AUTO_DISCOVERY=false`.
- Produced local ignored artifacts:
  - `release/tandem-browser-1.9.0-x64-setup.exe`
  - `release/tandem-browser-1.9.0-x64-portable.exe`
- `Get-AuthenticodeSignature` reports both Windows artifacts as `NotSigned`, which is expected for this phase.
- Confirmed generated artifacts and private Windows planning docs are ignored and were not staged or pushed.

## Notes

No dependencies were added. No app version bump was made because this is a `chore:` packaging configuration phase, not a shipped feature or fix.