### PR TITLE
[codex] Add unsigned Windows release-build workflow

### DIFF
--- a/.github/workflows/release-win.yml
+++ b/.github/workflows/release-win.yml
@@ -1,0 +1,82 @@
+name: Windows Release Build
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  build-unsigned-windows:
+    name: Build unsigned Windows artifacts
+    runs-on: windows-latest
+
+    env:
+      CSC_IDENTITY_AUTO_DISCOVERY: false
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Rebuild native modules
+        run: npm run rebuild
+
+      - name: Compile application
+        run: npm run compile
+
+      - name: Build unsigned NSIS and portable artifacts
+        run: npx electron-builder --win nsis portable --x64 --publish never
+
+      - name: Verify artifacts are unsigned
+        shell: pwsh
+        run: |
+          $artifacts = Get-ChildItem release -Filter 'tandem-browser-*-x64*.exe'
+          if ($artifacts.Count -eq 0) {
+            throw 'No Windows executable artifacts were produced.'
+          }
+
+          foreach ($artifact in $artifacts) {
+            $signature = Get-AuthenticodeSignature $artifact.FullName
+            if ($signature.Status -ne 'NotSigned') {
+              throw "$($artifact.Name) is $($signature.Status); this workflow must only produce unsigned artifacts."
+            }
+          }
+
+      - name: Write unsigned build notice
+        shell: pwsh
+        run: |
+          @'
+          Tandem Browser Windows release-build artifacts
+
+          Status: unsigned
+          Code signing: deferred
+          Distribution: GitHub Actions workflow artifact only
+          Auto-update feed: not generated
+
+          These artifacts are for release-pipeline validation and are not an official public Windows release.
+          '@ | Set-Content -Encoding UTF8 release\UNSIGNED-WINDOWS-BUILD.txt
+
+      - name: Upload unsigned Windows artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: tandem-browser-windows-unsigned-${{ github.run_id }}
+          if-no-files-found: error
+          retention-days: 14
+          path: |
+            release/tandem-browser-*-x64-setup.exe
+            release/tandem-browser-*-x64-portable.exe
+            release/UNSIGNED-WINDOWS-BUILD.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Tandem Browser will be documented in this file.
 
 ### Changed
 
+- chore: Add a separate Windows release-build workflow that runs on manual
+  dispatch or version tags, builds unsigned x64 NSIS and portable artifacts on a
+  Windows runner, and uploads them only as short-lived GitHub Actions workflow
+  artifacts while signing remains deferred.
 - chore: Add unsigned local Windows electron-builder targets for x64 NSIS and
   portable artifacts with target-specific `setup` and `portable` artifact
   names, while leaving the existing macOS packaging config unchanged.

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -38,7 +38,7 @@
 | Capability | macOS | Windows | Linux | Notes |
 |------------|-------|---------|-------|-------|
 | App startup (`npm start` from source) | supported | unsupported | partial | Windows blocked by Unix-only start script; fixed in windows-support phase 2. |
-| Signed installer | supported | unsupported | unsupported | Windows installer planned in windows-support phase 13–14. |
+| Signed installer | supported | unsupported | unsupported | Windows unsigned release-build workflow artifacts exist for pipeline validation; signing remains deferred and public Windows release remains unannounced. |
 | Auto-update | supported | unsupported | unsupported | Windows feed planned in windows-support phase 15. |
 | Custom titlebar / window chrome | supported | supported | supported | Windows source runs use frameless shell-owned controls; public Windows release remains unannounced. |
 | Stealth UA matches host OS | supported | supported | partial | Windows source runs present Chrome on Windows; public Windows release remains unannounced. |


### PR DESCRIPTION
## Summary

- Add a separate Windows Release Build workflow in `.github/workflows/release-win.yml`.
- Run it on manual dispatch and `v*` tags using a Windows runner.
- Build x64 NSIS and portable artifacts with `electron-builder --publish never`.
- Upload only short-lived GitHub Actions workflow artifacts, including an unsigned-build notice.
- Verify produced `.exe` artifacts are `NotSigned` before upload.

## Signing and release status

Windows code signing is intentionally deferred. This workflow does not require signing secrets, does not create GitHub Release assets, does not publish a public Windows release, and does not generate an auto-update feed.

## macOS safety

The existing `verify.yml` and `codeql.yml` workflows are unchanged. This is a new, isolated Windows-only workflow with read-only repository permissions and no macOS packaging changes.

## Validation

- `actionlint .github/workflows/release-win.yml`: no errors.
- `npm run verify`: passed after rerunning a transient `script-guard` test failure.
- `npx electron-builder --win nsis portable --x64 --publish never`: produced local Windows artifacts.
- `Get-AuthenticodeSignature`: local setup and portable artifacts are `NotSigned`.

## Notes

Generated `release/` artifacts and private local Windows planning docs were not staged or pushed.