### PR TITLE
feat: windows manual updater

### DIFF
--- a/.github/workflows/release-win.yml
+++ b/.github/workflows/release-win.yml
@@ -41,6 +41,19 @@ jobs:
       - name: Build unsigned NSIS and portable artifacts
         run: npx electron-builder --win nsis portable --x64 --publish never
 
+      - name: Verify Windows update metadata was generated
+        shell: pwsh
+        run: |
+          $metadata = Join-Path $PWD 'release\latest.yml'
+          if (-not (Test-Path $metadata)) {
+            throw 'latest.yml was not generated for the Windows update feed.'
+          }
+
+          $metadataText = Get-Content $metadata -Raw
+          if ($metadataText -notmatch 'tandem-browser-.+-x64-setup\.exe') {
+            throw 'latest.yml does not reference the Windows NSIS setup artifact.'
+          }
+
       - name: Verify artifacts are unsigned
         shell: pwsh
         run: |
@@ -65,9 +78,10 @@ jobs:
           Status: unsigned
           Code signing: deferred
           Distribution: GitHub Actions workflow artifact only
-          Auto-update feed: not generated
+          Auto-update feed: generated for validation only, not published
 
           These artifacts are for release-pipeline validation and are not an official public Windows release.
+          Production Windows auto-update remains blocked until Windows code signing is configured and end-to-end update installation is verified.
           '@ | Set-Content -Encoding UTF8 release\UNSIGNED-WINDOWS-BUILD.txt
 
       - name: Upload unsigned Windows artifacts
@@ -78,5 +92,7 @@ jobs:
           retention-days: 14
           path: |
             release/tandem-browser-*-x64-setup.exe
+            release/tandem-browser-*-x64-setup.exe.blockmap
             release/tandem-browser-*-x64-portable.exe
+            release/latest.yml
             release/UNSIGNED-WINDOWS-BUILD.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,44 @@ All notable changes to Tandem Browser will be documented in this file.
   portable artifacts with target-specific `setup` and `portable` artifact
   names, while leaving the existing macOS packaging config unchanged.
 
+## [v1.10.0] - 2026-05-05
+
+Windows support Phase 15. Tandem now has a Windows-only manual update path that
+checks GitHub Releases through `electron-updater`, lets the user choose whether
+to download an available update, and only installs after an explicit restart
+confirmation. Production Windows auto-update remains blocked until Windows
+installers are signed and an end-to-end update installation is verified.
+
+### Added
+
+- **Windows updater adapter** (`src/platform/updates/`) - adds a Windows-gated
+  `electron-updater` integration with `autoDownload` and automatic install on
+  quit disabled.
+- **Manual update menu action** (`src/menu/app-menu.ts`) - shows **Check for
+  Updates** only on platforms whose adapter supports updater checks.
+- **Windows update metadata** (`package.json`,
+  `.github/workflows/release-win.yml`) - configures GitHub Releases as the
+  Windows update source and verifies `latest.yml` is generated for unsigned
+  workflow artifacts.
+
+### Changed
+
+- **Version references** (`package.json`, `package-lock.json`, `README.md`,
+  `PROJECT.md`, `docs/index.html`) - bumped Tandem Browser to `1.10.0`.
+- **Platform support tracking** (`docs/platform-support.md`,
+  `src/platform/capabilities.ts`) - records Windows auto-update as partial
+  until signed Windows releases and end-to-end update installation are verified.
+
+### Technical Details
+
+- The updater module lives behind the platform adapter boundary; macOS update
+  behavior and macOS release configuration are untouched.
+- The Windows release workflow still uses `--publish never`; it uploads
+  `latest.yml` as a short-lived GitHub Actions artifact only and does not create
+  or publish a GitHub Release.
+- Windows update signature verification is not disabled. Unsigned artifacts are
+  not production-ready update payloads.
+
 ## [v1.9.0] - 2026-05-04
 
 Windows support Phase 12. Tandem now keeps Electron shortcut accelerators on

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -31,7 +31,7 @@ The security layer exists because when an AI has access to your browser, your th
 Data stays local. Sessions are isolated. Nothing leaves the machine through Tandem Browser without going through a filter first.
 
 **GitHub:** `hydro13/tandem-browser`  
-**Current version:** `1.9.0`
+**Current version:** `1.10.0`
 **Repository status:** Public developer preview  
 **Started:** February 11, 2026
 

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ contributors, not yet a polished mass-user release.
 - Secondary platform: Linux
 - Windows: validated as a remote agent host (VS Code + Claude Code over Tailscale)
 - Binaries: signed & notarized macOS Apple Silicon builds published on [GitHub Releases](https://github.com/hydro13/tandem-browser/releases), starting at v1.0.0
-- Current version: `1.9.0`
+- Current version: `1.10.0`
 - Package metadata: [package.json](package.json)
 
 ## Community

--- a/TODO.md
+++ b/TODO.md
@@ -72,7 +72,7 @@ Last updated: May 4, 2026
 ### Distribution and UX
 
 - [ ] Full multi-profile UX on top or the existing `SessionManager` isolation model
-- [ ] Auto-updater integration (`electron-updater`); `release/` still contains an old `0.1.0` manifest
+- [ ] Windows auto-update production readiness: Phase 15 added the Windows-only manual `electron-updater` check path and `latest.yml` workflow metadata, but real user update installation remains blocked until signed Windows installers are published through GitHub Releases and end-to-end update installation is verified.
 - [ ] Production-ready DMG build for macOS with current naming and metadata
 - [ ] AppImage build for Linux
 - [ ] Documentation site

--- a/docs/index.html
+++ b/docs/index.html
@@ -325,7 +325,7 @@ footer a:hover{color:var(--text2)}
 </header>
 
 <div class="hero">
-<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v1.9.0</div>
+<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v1.10.0</div>
 <p class="hero-lead">Tandem Browser is the <strong>open-source, local-first browser for AI agents</strong> — where the AI lives inside your real browser session, sharing your tabs, cookies, and DOM, ready to ask for your help the moment it gets stuck.</p>
 <h1>The browser becomes a <em>programmable workspace</em> where human intent and AI capability meet.</h1>
 <p>Tandem Browser is built around a simple shift: the AI is not a sidebar talking <em>about</em> your browser, it is <em>inside</em> it. Same tabs, same cookies, same logged-in sessions, same page you are looking at right now. Reading the accessibility tree, watching the network, writing live styles, handing back to you when something needs a human. It turns the web that already exists into something agents can actually operate on — no per-site API, no RPA rig, no screenshot loop. The real browser, as a shared human-AI symbiotic runtime.</p>

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -39,7 +39,7 @@
 |------------|-------|---------|-------|-------|
 | App startup (`npm start` from source) | supported | unsupported | partial | Windows blocked by Unix-only start script; fixed in windows-support phase 2. |
 | Signed installer | supported | unsupported | unsupported | Windows unsigned release-build workflow artifacts exist for pipeline validation; signing remains deferred and public Windows release remains unannounced. |
-| Auto-update | supported | unsupported | unsupported | Windows feed planned in windows-support phase 15. |
+| Auto-update | supported | partial | unsupported | Windows has a manual `electron-updater` check path and generated `latest.yml` workflow metadata, but production auto-update remains blocked until Windows installers are signed and end-to-end update installation is verified. |
 | Custom titlebar / window chrome | supported | supported | supported | Windows source runs use frameless shell-owned controls; public Windows release remains unannounced. |
 | Stealth UA matches host OS | supported | supported | partial | Windows source runs present Chrome on Windows; public Windows release remains unannounced. |
 | Chrome bookmark + history import | supported | supported | partial | Windows source runs scan `%LOCALAPPDATA%\Google\Chrome\User Data\<Profile>\` for bookmark and history import. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tandem-browser",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tandem-browser",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -16,6 +16,7 @@
         "adm-zip": "^0.5.16",
         "better-sqlite3": "^12.6.2",
         "cors": "^2.8.5",
+        "electron-updater": "^6.8.3",
         "express": "^4.21.0",
         "ffmpeg-static": "^5.3.0",
         "turndown": "^7.2.2",
@@ -3559,7 +3560,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-flatten": {
@@ -3869,7 +3869,6 @@
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
       "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -4967,6 +4966,69 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-updater": {
+      "version": "6.8.3",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.3.tgz",
+      "integrity": "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.5.1",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-updater/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/electron-updater/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -6154,7 +6216,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -6651,7 +6712,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6783,7 +6843,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/levn": {
@@ -7082,6 +7141,19 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/log-symbols": {
@@ -8528,7 +8600,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
       "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -9273,6 +9344,12 @@
       "bin": {
         "semver": "bin/semver"
       }
+    },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-browser",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "Local-first Electron browser with a 253-tool MCP server, MCP/HTTP control surfaces, and built-in security controls",
   "main": "dist/main.js",
   "author": "Tandem Browser contributors",
@@ -49,6 +49,7 @@
     "adm-zip": "^0.5.16",
     "better-sqlite3": "^12.6.2",
     "cors": "^2.8.5",
+    "electron-updater": "^6.8.3",
     "express": "^4.21.0",
     "ffmpeg-static": "^5.3.0",
     "turndown": "^7.2.2",
@@ -116,7 +117,14 @@
         }
       ],
       "artifactName": "tandem-browser-${version}-${arch}.${ext}",
-      "signAndEditExecutable": false
+      "signAndEditExecutable": false,
+      "publish": [
+        {
+          "provider": "github",
+          "owner": "hydro13",
+          "repo": "tandem-browser"
+        }
+      ]
     },
     "nsis": {
       "artifactName": "tandem-browser-${version}-${arch}-setup.${ext}"

--- a/src/main.ts
+++ b/src/main.ts
@@ -937,6 +937,7 @@ async function startAPI(win: BrowserWindow): Promise<void> {
 
 
 void app.whenReady().then(async () => {
+  const platform = selectPlatform();
   const win = await createWindow();
   await startAPI(win);
   buildAppMenu({
@@ -948,6 +949,7 @@ void app.whenReady().then(async () => {
     pipManager: runtime?.pipManager ?? null,
     configManager: runtime?.configManager ?? null,
     videoRecorderManager: runtime?.videoRecorderManager ?? null,
+    updater: platform.updater,
   });
 
   // Keep shortcuts always registered while app is running
@@ -967,6 +969,7 @@ void app.whenReady().then(async () => {
           pipManager: runtime?.pipManager ?? null,
           configManager: runtime?.configManager ?? null,
           videoRecorderManager: runtime?.videoRecorderManager ?? null,
+          updater: platform.updater,
         });
       }).catch((err) => {
         log.error('Failed to recreate window:', err);

--- a/src/menu/app-menu.ts
+++ b/src/menu/app-menu.ts
@@ -7,6 +7,7 @@ import type { VoiceManager } from '../voice/recognition';
 import type { PiPManager } from '../pip/manager';
 import type { ConfigManager } from '../config/manager';
 import type { VideoRecorderManager } from '../video/recorder';
+import type { UpdaterAdapter } from '../platform/types';
 import { IpcChannels } from '../shared/ipc-channels';
 import { commandOrControlAccelerator } from '../platform/shortcuts';
 
@@ -19,11 +20,20 @@ export interface MenuDeps {
   pipManager: PiPManager | null;
   configManager: ConfigManager | null;
   videoRecorderManager: VideoRecorderManager | null;
+  updater: UpdaterAdapter | null;
 }
 
 export function buildAppMenu(deps: MenuDeps): void {
   const send = (action: string) => deps.mainWindow?.webContents.send(IpcChannels.SHORTCUT, action);
   const acc = commandOrControlAccelerator;
+  const updateMenuItems: Electron.MenuItemConstructorOptions[] = deps.updater?.isSupported()
+    ? [
+        { label: 'Check for Updates', click: () => {
+          void deps.updater?.checkForUpdates({ mainWindow: deps.mainWindow });
+        }},
+        { type: 'separator' },
+      ]
+    : [];
 
   const template: Electron.MenuItemConstructorOptions[] = [
     {
@@ -81,6 +91,7 @@ export function buildAppMenu(deps: MenuDeps): void {
     {
       label: 'Help',
       submenu: [
+        ...updateMenuItems,
         { label: 'Keyboard Shortcuts', accelerator: acc('Shift+/'), click: () => send('show-shortcuts') },
         { type: 'separator' },
         { label: 'Show Onboarding', click: () => send('show-onboarding') },

--- a/src/platform/capabilities.ts
+++ b/src/platform/capabilities.ts
@@ -66,7 +66,7 @@ const CAPABILITY_PROFILES: Record<PlatformId, PlatformSupportProfile> = {
     capabilities: {
       appStartup: unsupportedCapability('Blocked by Unix-only start script until windows-support phase 2.'),
       signedInstaller: unsupportedCapability('Windows installer planned in windows-support phases 13-14.'),
-      autoUpdate: unsupportedCapability('Windows update feed planned in windows-support phase 15.'),
+      autoUpdate: { status: 'partial', notes: 'Manual electron-updater checks and latest.yml generation exist; production update installation remains blocked until Windows installers are signed and end-to-end update installation is verified.' },
       windowChrome: { status: 'supported', notes: 'Frameless custom titlebar with shell controls is implemented for source runs.' },
       stealthUa: { status: 'supported', notes: 'Windows source runs present a Chrome-on-Windows UA persona.' },
       chromeBookmarkHistoryImport: { status: 'supported', notes: 'Windows Chrome bookmark and history import scans LOCALAPPDATA/Google/Chrome/User Data profiles.' },

--- a/src/platform/index.ts
+++ b/src/platform/index.ts
@@ -12,6 +12,7 @@ import { createProcessAdapter } from './process';
 import { createDarwinSecretsAdapter, createUnsupportedSecretsAdapter } from './secrets';
 import { createDarwinStealthUaAdapter, createUnsupportedStealthUaAdapter, createWindowsStealthUaAdapter } from './stealth-ua';
 import type { PlatformAdapter } from './types';
+import { createUnsupportedUpdaterAdapter, createWindowsUpdaterAdapter } from './updates';
 import { createDarwinVideoAudioAdapter, createUnsupportedVideoAudioAdapter } from './video-audio';
 import { createDarwinVoiceAdapter, createLinuxVoiceAdapter, createUnsupportedVoiceAdapter, createWindowsVoiceAdapter } from './voice';
 import {
@@ -51,6 +52,7 @@ function createDarwinPlatform(): PlatformAdapter {
     windowChrome: createDarwinWindowChromeAdapter(),
     stealthUa: createDarwinStealthUaAdapter(),
     secrets: createDarwinSecretsAdapter(),
+    updater: createUnsupportedUpdaterAdapter(id),
   };
 }
 
@@ -91,6 +93,9 @@ function createStubPlatform(id: PlatformId): PlatformAdapter {
         ? createDarwinStealthUaAdapter()
         : createUnsupportedStealthUaAdapter(id),
     secrets: createUnsupportedSecretsAdapter(id),
+    updater: id === 'win32'
+      ? createWindowsUpdaterAdapter()
+      : createUnsupportedUpdaterAdapter(id),
   };
 }
 

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -1,4 +1,4 @@
-import type { Session } from 'electron';
+import type { BrowserWindow, Session } from 'electron';
 import type { ConfigManager } from '../config/manager';
 import type { ChromeImporter, ChromeImportStatus } from '../import/chrome-importer';
 import type {
@@ -85,6 +85,11 @@ export interface SecretsAdapter {
   loadOrCreateInstallSecret(): string;
 }
 
+export interface UpdaterAdapter {
+  isSupported(): boolean;
+  checkForUpdates(options?: { mainWindow?: BrowserWindow | null }): Promise<void>;
+}
+
 export interface PlatformAdapter {
   id: PlatformId;
   capabilities: PlatformSupportProfile;
@@ -97,6 +102,7 @@ export interface PlatformAdapter {
   windowChrome: WindowChromeAdapter;
   stealthUa: StealthUaAdapter;
   secrets: SecretsAdapter;
+  updater: UpdaterAdapter;
 }
 
 export interface StealthUaBrandVersion {

--- a/src/platform/updates/index.ts
+++ b/src/platform/updates/index.ts
@@ -1,0 +1,122 @@
+import type { BrowserWindow, MessageBoxOptions } from 'electron';
+import { NotImplementedError, type PlatformId } from '../errors';
+import type { UpdaterAdapter } from '../types';
+
+const GITHUB_UPDATE_SOURCE = 'GitHub Releases';
+
+let updateCheckRunning = false;
+
+async function showMessageBox(
+  mainWindow: BrowserWindow | null | undefined,
+  options: MessageBoxOptions
+): Promise<Electron.MessageBoxReturnValue> {
+  const { dialog } = await import('electron');
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    return dialog.showMessageBox(mainWindow, options);
+  }
+  return dialog.showMessageBox(options);
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+export function createWindowsUpdaterAdapter(): UpdaterAdapter {
+  return {
+    isSupported: () => true,
+    checkForUpdates: async ({ mainWindow } = {}) => {
+      if (updateCheckRunning) {
+        await showMessageBox(mainWindow, {
+          type: 'info',
+          title: 'Update Check',
+          message: 'Tandem Browser is already checking for updates.',
+          buttons: ['OK'],
+        });
+        return;
+      }
+
+      updateCheckRunning = true;
+      try {
+        const { app } = await import('electron');
+        if (!app.isPackaged) {
+          await showMessageBox(mainWindow, {
+            type: 'info',
+            title: 'Update Check',
+            message: 'Update checks are available in packaged Windows builds.',
+            detail: 'Source runs do not include the packaged update metadata required to check GitHub Releases.',
+            buttons: ['OK'],
+          });
+          return;
+        }
+
+        const { autoUpdater } = await import('electron-updater');
+        autoUpdater.autoDownload = false;
+        autoUpdater.autoInstallOnAppQuit = false;
+        autoUpdater.allowPrerelease = false;
+
+        const checkResult = await autoUpdater.checkForUpdates();
+        if (!checkResult || !checkResult.isUpdateAvailable) {
+          await showMessageBox(mainWindow, {
+            type: 'info',
+            title: 'No Updates Available',
+            message: 'Tandem Browser is up to date.',
+            detail: `Checked ${GITHUB_UPDATE_SOURCE}.`,
+            buttons: ['OK'],
+          });
+          return;
+        }
+
+        const version = checkResult.updateInfo.version;
+        const downloadChoice = await showMessageBox(mainWindow, {
+          type: 'info',
+          title: 'Update Available',
+          message: `Tandem Browser ${version} is available.`,
+          detail: `The update was found on ${GITHUB_UPDATE_SOURCE}. Download it now?`,
+          buttons: ['Download Update', 'Later'],
+          defaultId: 0,
+          cancelId: 1,
+        });
+        if (downloadChoice.response !== 0) {
+          return;
+        }
+
+        await autoUpdater.downloadUpdate();
+
+        const installChoice = await showMessageBox(mainWindow, {
+          type: 'info',
+          title: 'Update Downloaded',
+          message: `Tandem Browser ${version} is ready to install.`,
+          detail: 'Install and restart Tandem Browser now, or finish your work and restart later.',
+          buttons: ['Install and Restart', 'Later'],
+          defaultId: 0,
+          cancelId: 1,
+        });
+        if (installChoice.response === 0) {
+          autoUpdater.quitAndInstall(false, true);
+        }
+      } catch (error) {
+        await showMessageBox(mainWindow, {
+          type: 'error',
+          title: 'Update Check Failed',
+          message: 'Tandem Browser could not check for updates.',
+          detail: getErrorMessage(error),
+          buttons: ['OK'],
+        });
+      } finally {
+        updateCheckRunning = false;
+      }
+    },
+  };
+}
+
+export function createUnsupportedUpdaterAdapter(platform: PlatformId): UpdaterAdapter {
+  return {
+    isSupported: () => false,
+    checkForUpdates: async () => {
+      throw new NotImplementedError('Auto-update', platform, 'phase-15');
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Add an approved `electron-updater` dependency for Windows manual update checks.
- Add a Windows-only platform updater adapter and show **Check for Updates** only when the selected platform supports updater checks.
- Configure the Windows electron-builder publish provider for GitHub Releases so packaged Windows builds know where to check for updates.
- Update the Windows release workflow to verify and upload `latest.yml` plus the NSIS blockmap as short-lived workflow artifacts only.
- Bump the app version to `1.10.0` and update platform support docs to mark Windows auto-update as partial.

## Architecture decision

Tandem uses electron-builder with the NSIS Windows target, so `electron-updater` is the appropriate updater path. Electron's built-in `autoUpdater` is not used because its traditional Windows path is Squirrel.Windows/MSIX-oriented rather than NSIS-oriented.

The runtime path is intentionally manual:

- `autoDownload = false`
- `autoInstallOnAppQuit = false`
- user chooses whether to download
- user chooses whether to install and restart
- Windows update signature verification stays enabled

## Signing and release safety

Windows artifacts are still unsigned. This PR does not claim production-ready Windows auto-update. It wires the signed-ready path and feed metadata, but production update installation remains blocked until Windows code signing is configured and an installed Windows client is verified updating from one GitHub Release to a newer GitHub Release.

The Windows release workflow still runs with `--publish never`; it does not publish a GitHub Release and does not generate an official public Windows release.

## macOS safety

macOS update behavior and macOS release configuration are untouched. The menu entry is shown through the platform adapter only when updater checks are supported; the macOS adapter remains unsupported for this new path.

## Tested

- `npm run verify` - passed (`compile`, `lint`, `vitest`, consistency check)
- `npx electron-builder --win nsis portable --x64 --publish never` - generated unsigned Windows setup, portable, blockmap, and `latest.yml`
- `Get-AuthenticodeSignature` on generated Windows setup and portable artifacts - both `NotSigned`
- `actionlint .github/workflows/release-win.yml` - passed
- Workflow metadata PowerShell check - `latest.yml` references the NSIS setup artifact
- `npm start` smoke - ran for 15 seconds without an early nonzero exit

## Not included

- No macOS updater changes
- No GitHub Release publishing
- No signing secrets or signing config
- No generated artifacts committed
- No private Windows planning docs committed