### PR TITLE
[codex] chore: require Windows verify checks

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -8,7 +8,7 @@ jobs:
   verify:
     name: Verify (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.os != 'macos-latest' }}
+    continue-on-error: ${{ matrix.os == 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Tandem Browser will be documented in this file.
 
 ## Unreleased
 
+### Chore
+
+- chore: Promote the Windows verify matrix job from best-effort to blocking
+  while leaving Linux as the only non-blocking verify platform.
+
 ### Test
 
 - test: Add a Node startup smoke runner that boots Tandem through the

--- a/TODO.md
+++ b/TODO.md
@@ -14,7 +14,7 @@ Last updated: May 5, 2026
 
 ## Current Snapshot
 
-- Current app version: `1.9.0`
+- Current app version: `1.10.0`
 - MCP server: 253 tools (full API parity + awareness)
 - The codebase scope is larger than this backlog summary and includes major subsystems such as `sidebar`, `workspaces`, `pinboards`, `sync`, `headless`, and `sessions`.
 - Scheduled browsing already exists in baseline form via `WatchManager` and the `/watch/*` API routes.
@@ -65,6 +65,7 @@ Last updated: May 5, 2026
 - [ ] Expand the new handoff system beyond the first Activity-tab inbox with a dedicated handoff history/detail view; task-linked ready/resume/approve/reject actions now flow through a shared task↔handoff coordinator
 - [x] Add GitHub Actions verification for `npm run verify` on pushes and pull requests
 - [x] Add Windows and macOS startup smoke coverage in GitHub Actions by booting Tandem and polling `http://127.0.0.1:8765/status`
+- [x] Promote Windows `Verify (windows-latest)` to a blocking GitHub Actions check; Linux remains best-effort
 - [ ] Remove deprecated voice-transcription and live-mode main-process code after the shell-side cleanup lands (PR #TBD): preload bindings `window.tandem.transcribeAudio` and `window.tandem.onLiveModeChanged`, IPC handlers, HTTP route `POST /live/toggle` on port 8765, audio transcription pipeline, and MCP tools `tandem_live_toggle`, `tandem_live_status`, `tandem_audio_start`, `tandem_audio_stop`, `tandem_audio_status`, `tandem_audio_recordings`. The shell no longer references any of these.
 - [ ] Restore image support in Wingman chat by routing image sends through the OpenClaw gateway. The legacy `GET/POST /chat` polling bridge was disabled on 17 March 2026 (commit `ede27d82`) and text sends were migrated to the gateway WebSocket, but the image path was not. Today `IpcChannels.CHAT_SEND_IMAGE` in `src/ipc/handlers.ts` only saves the base64 to `~/.tandem/chat-images/` and fires `PanelManager.fireWebhook()` with a `[image attached]` marker — no bytes or URL travel to OpenClaw. Fix: send images through the same gateway path as text (multimodal payload, or upload via `src/api/routes/media.ts` `media-chat-image` bucket and include the URL in the gateway message). Shell-side, collapse `window.tandem.sendChatImage` into `router.sendMessage(text, { image })`.
 


### PR DESCRIPTION
## Summary

Promotes Windows Support Phase 17 CI behavior.

- Changes `verify.yml` so only Ubuntu remains best-effort with `continue-on-error`.
- Makes `Verify (windows-latest)` blocking in the workflow, matching macOS required behavior.
- Updates `CHANGELOG.md` and `TODO.md` for the CI policy change.

## Branch protection

Updated `main` branch protection through the GitHub API before opening this PR. Required status checks are now:

- `Verify (macos-latest)`
- `Verify (windows-latest)`

Strict status checks remain enabled. macOS protection is unchanged except for adding Windows alongside it.

## Validation

- Confirmed the last 10 `Verify (windows-latest)` jobs were green before promotion.
- `npm run verify` passed locally on Windows.
- `npm run smoke:startup` passed locally on Windows and reached `http://127.0.0.1:8765/status`.
- Confirmed smoke cleanup left no listener on port `8765`.
- `actionlint .github/workflows/verify.yml` passed locally.
- No new dependencies were added.
- Private/local Windows planning files remain ignored and were not staged or pushed.

## macOS safety

This is a workflow-policy change only. No app runtime code, release workflow, signing, updater, platform adapter, or macOS behavior changed. The macOS verify job remains required.