### PR TITLE
[codex] chore: fix Windows release notes fence

### DIFF
--- a/.github/workflows/release-win.yml
+++ b/.github/workflows/release-win.yml
@@ -125,9 +125,9 @@ jobs:
 
           ## SHA256 checksums
 
-          ````text
+          ~~~text
           $hashBlock
-          ````
+          ~~~
 
           ## Notes
 


### PR DESCRIPTION
## Summary

Fixes the generated Windows release notes Markdown fence for future version tags.

The v1.10.0 release workflow published correctly, but PowerShell treated the backtick fence as escaped text and collapsed the release body code fence. I manually fixed the published v1.10.0 notes and this PR changes the workflow template to use tilde fences instead.

## Validation

- `actionlint .github/workflows/release-win.yml` passed locally.
- Verified the published `v1.10.0` GitHub Release body now has a valid SHA256 code block.

## macOS safety

Workflow text generation only. No macOS runtime or release behavior changes.