### PR TITLE
[codex] add agent-aware Wingman chat channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,22 @@ All notable changes to Tandem Browser will be documented in this file.
 
 ## Unreleased
 
-No unreleased changes yet.
+### Added
+
+- **OpenClaw-free Wingman chat path** (`shell/chat/tandem-local-backend.js`,
+  `src/api/routes/media.ts`, `src/mcp/tools/chat.ts`) - adds a built-in
+  Tandem local chat backend so MCP/API agents can read Robin's Wingman chat
+  messages and reply into the panel without requiring OpenClaw on the host.
+  OpenClaw remains available as a separate backend and the shell falls back to
+  Tandem local chat when the gateway is not reachable.
+
+### Changed
+
+- **Wingman chat channel selector** (`shell/js/wingman/chat.js`,
+  `shell/chat/tandem-local-backend.js`) - now shows only chat channels for
+  agents configured in Connected Agents, so a lone Codex binding no longer
+  exposes stale OpenClaw/Claude tabs or lets the legacy Claude polling backend
+  mirror the Codex conversation.
 
 ## [v1.10.0] - 2026-05-05
 

--- a/TODO.md
+++ b/TODO.md
@@ -52,6 +52,7 @@ Last updated: May 5, 2026
 
 - [ ] Finish Cloudflare human mode phases 4-5 so challenge-sensitive tabs pause cleanly for the human and resume conservatively after `cf_clearance`; phase 3 now gates ScriptGuard and resource monitoring on Cloudflare tabs
 - [x] Make Wingman `openclaw` mode gateway-first for sends, sign a real OpenClaw device identity for the WebSocket handshake, and persist gateway replies into Tandem chat history so stock Tandem no longer depends on a local OpenClaw tandem-chat skill
+- [x] Add a built-in Tandem local Wingman chat backend so MCP/API agents can read and reply in the panel without requiring OpenClaw on the host, while keeping the OpenClaw gateway backend available when installed
 - [x] Split `src/main.ts` bootstrap and teardown wiring into dedicated `src/bootstrap/` modules so manager composition stops growing in one file
 - [x] Extract the largest shell surfaces out of `shell/index.html` and `shell/css/main.css` so sidebar logic, modal helpers, and stylesheet sections stop living in single inline or monolithic files
 - [x] Split the Wingman and ClaroNote renderer surfaces out of `shell/js/main.js` into dedicated shell modules with explicit shared state instead of file-scope coupling

--- a/shell/chat/tandem-local-backend.js
+++ b/shell/chat/tandem-local-backend.js
@@ -1,0 +1,207 @@
+/**
+ * TandemLocalBackend - Wingman chat over Tandem's own HTTP API.
+ *
+ * This keeps the Wingman panel useful without a local OpenClaw install. Agents
+ * can read Robin's messages through MCP/HTTP and reply back into the same
+ * local chat history.
+ */
+class TandemLocalBackend {
+  constructor() {
+    this.id = 'tandem';
+    this.name = 'Tandem Local';
+    this.icon = 'T';
+
+    this._connected = false;
+    this._pollTimer = null;
+    this._pollInterval = 1500;
+    this._lastSeenId = 0;
+    this._apiBase = window.tandemApi?.baseUrl() || window.__TANDEM_API_BASE__ || 'http://127.0.0.1:8765';
+    this._primaryAgent = null;
+    this._connectedAgents = [];
+
+    this._messageCallbacks = [];
+    this._typingCallbacks = [];
+    this._connectionCallbacks = [];
+  }
+
+  async connect() {
+    try {
+      const res = await fetch(`${this._apiBase}/chat/status`);
+      if (!res.ok) {
+        this._setConnected(false);
+        return;
+      }
+      const status = await res.json();
+      this._applyStatus(status);
+      this._setConnected(true);
+      await this._loadHistory();
+      this._startPolling();
+    } catch (e) {
+      console.warn('[TandemLocalBackend] API not reachable:', e.message);
+      this._setConnected(false);
+    }
+  }
+
+  async disconnect() {
+    this._stopPolling();
+    this._setConnected(false);
+  }
+
+  isConnected() {
+    return this._connected;
+  }
+
+  async sendMessage(text) {
+    if (!text) return false;
+    try {
+      const res = await fetch(`${this._apiBase}/chat/messages`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text, from: 'user' })
+      });
+      if (!res.ok) return false;
+      const data = await res.json();
+      const msg = data.message || {};
+      this._trackSeen(msg);
+      this._emit('message', this._toUiMessage(msg));
+      return true;
+    } catch (e) {
+      console.warn('[TandemLocalBackend] Send failed:', e.message);
+      this._setConnected(false);
+      return false;
+    }
+  }
+
+  onMessage(cb) { this._messageCallbacks.push(cb); }
+  onTyping(cb) { this._typingCallbacks.push(cb); }
+  onConnectionChange(cb) { this._connectionCallbacks.push(cb); }
+
+  async loadHistory(onMessages) {
+    const messages = await this._fetchHistory(50);
+    if (typeof onMessages === 'function') {
+      onMessages(messages);
+    }
+  }
+
+  getPrimaryAgent() {
+    return this._primaryAgent;
+  }
+
+  getConnectedAgents() {
+    return [...this._connectedAgents];
+  }
+
+  _startPolling() {
+    this._stopPolling();
+    this._pollTimer = setInterval(() => this._poll(), this._pollInterval);
+  }
+
+  _stopPolling() {
+    if (this._pollTimer) {
+      clearInterval(this._pollTimer);
+      this._pollTimer = null;
+    }
+  }
+
+  async _poll() {
+    try {
+      const res = await fetch(`${this._apiBase}/chat/messages?since_id=${this._lastSeenId}`);
+      if (!res.ok) {
+        this._setConnected(false);
+        return;
+      }
+      if (!this._connected) this._setConnected(true);
+
+      const data = await res.json();
+      const messages = data.messages || [];
+      for (const msg of messages) {
+        this._trackSeen(msg);
+        if (msg.from !== 'user') {
+          this._emit('message', this._toUiMessage(msg));
+        }
+      }
+    } catch {
+      this._setConnected(false);
+    }
+  }
+
+  async _loadHistory() {
+    const messages = await this._fetchHistory(50);
+    if (messages.length > 0) {
+      this._emit('historyReload', messages);
+    }
+  }
+
+  async _fetchHistory(limit) {
+    try {
+      const res = await fetch(`${this._apiBase}/chat/messages?limit=${limit}`);
+      if (!res.ok) return [];
+      const data = await res.json();
+      const messages = data.messages || [];
+      const parsed = [];
+      for (const msg of messages) {
+        this._trackSeen(msg);
+        parsed.push(this._toUiMessage(msg));
+      }
+      return parsed;
+    } catch (e) {
+      console.warn('[TandemLocalBackend] History load failed:', e.message);
+      return [];
+    }
+  }
+
+  _toUiMessage(msg) {
+    const from = msg?.from || 'wingman';
+    const fallbackLabel = from === 'wingman' ? this._primaryAgent?.label : undefined;
+    const source = from === 'user' ? 'user' : (from === 'wingman' && this._primaryAgent?.type ? this._primaryAgent.type : from);
+    return {
+      id: msg?.id?.toString?.() || crypto.randomUUID(),
+      role: from === 'user' ? 'user' : 'assistant',
+      text: msg?.text || '',
+      source,
+      actorLabel: msg?.actorLabel || fallbackLabel,
+      timestamp: msg?.timestamp || Date.now(),
+      image: msg?.image
+    };
+  }
+
+  _applyStatus(status) {
+    this._connectedAgents = Array.isArray(status?.connectedAgents)
+      ? status.connectedAgents.filter((agent) => agent && typeof agent.type === 'string')
+      : [];
+
+    const primary = status?.primaryAgent;
+    if (primary && typeof primary.label === 'string' && primary.label.trim()) {
+      this._primaryAgent = {
+        id: primary.id || null,
+        label: primary.label.trim(),
+        type: primary.type || 'agent'
+      };
+      this.name = this._primaryAgent.label;
+    } else {
+      this._primaryAgent = null;
+      this.name = 'Tandem Local';
+    }
+  }
+
+  _trackSeen(msg) {
+    if (typeof msg?.id === 'number' && msg.id > this._lastSeenId) {
+      this._lastSeenId = msg.id;
+    }
+  }
+
+  _setConnected(connected) {
+    if (this._connected !== connected) {
+      this._connected = connected;
+      for (const cb of this._connectionCallbacks) cb(connected);
+    }
+  }
+
+  _emit(type, data) {
+    if (type === 'message' || type === 'historyReload') {
+      for (const cb of this._messageCallbacks) cb(data, type);
+    } else if (type === 'typing') {
+      for (const cb of this._typingCallbacks) cb(data);
+    }
+  }
+}

--- a/shell/index.html
+++ b/shell/index.html
@@ -393,6 +393,7 @@
   <script src="js/api-auth.js"></script>
 
   <!-- Chat Router + Backends (Phase 3) + DualMode (Phase 5) -->
+  <script src="chat/tandem-local-backend.js"></script>
   <script src="chat/openclaw-backend.js"></script>
   <script src="chat/claude-activity-backend.js"></script>
   <script src="chat/router.js"></script>

--- a/shell/js/wingman/chat-streaming.js
+++ b/shell/js/wingman/chat-streaming.js
@@ -43,7 +43,20 @@ export function createStreamingRenderer({ messagesEl }) {
     return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\n/g, '<br>');
   }
 
-  function appendMessage(role, text, timestamp, source, image) {
+  function labelForSource(sourceClass, actorLabel) {
+    if (actorLabel && typeof actorLabel === 'string') return actorLabel;
+    if (sourceClass === 'claude') return 'Claude';
+    if (sourceClass === 'codex') return 'Codex';
+    if (sourceClass === 'openclaw') return 'OpenClaw';
+    if (sourceClass === 'tandem') return 'Tandem';
+    return 'Wingman';
+  }
+
+  function classForSource(sourceClass) {
+    return String(sourceClass || 'openclaw').toLowerCase().replace(/[^a-z0-9_-]/g, '-');
+  }
+
+  function appendMessage(role, text, timestamp, source, image, actorLabel) {
     const sourceClass = source || 'openclaw';
     let cls, name;
     if (role === 'user') {
@@ -51,19 +64,20 @@ export function createStreamingRenderer({ messagesEl }) {
       name = 'You';
     } else if (sourceClass === 'claude') {
       cls = 'claude';
-      name = 'Claude';
+      name = labelForSource(sourceClass, actorLabel);
     } else {
       cls = 'wingman';
-      name = 'Wingman';
+      name = labelForSource(sourceClass, actorLabel);
     }
     const el = document.createElement('div');
-    el.className = `chat-msg ${cls} source-${source || sourceClass}`;
+    el.className = `chat-msg ${cls} source-${classForSource(source || sourceClass)}`;
     el.innerHTML = `<div class="msg-from">${escapeHtml(name)}</div><div class="msg-text">${escapeHtml(text)}</div><div class="msg-time">${formatTime(timestamp)}</div>`;
     // Add image if present
     if (image) {
       const msgText = el.querySelector('.msg-text');
       const img = document.createElement('img');
-      img.src = `http://localhost:8765/chat/image/${image}`;
+      const apiBase = window.tandemApi?.baseUrl() || window.__TANDEM_API_BASE__ || 'http://127.0.0.1:8765';
+      img.src = `${apiBase}/chat/image/${image}`;
       img.className = 'chat-msg-image';
       img.addEventListener('click', () => window.open(img.src, '_blank'));
       img.onerror = () => { img.style.display = 'none'; };
@@ -104,7 +118,7 @@ export function createStreamingRenderer({ messagesEl }) {
 
       if (Array.isArray(msg)) {
         for (const historyMsg of msg) {
-          const el = appendMessage(historyMsg.role, historyMsg.text, historyMsg.timestamp, historyMsg.source, historyMsg.image);
+          const el = appendMessage(historyMsg.role, historyMsg.text, historyMsg.timestamp, historyMsg.source, historyMsg.image, historyMsg.actorLabel);
           el.dataset.fromHistory = 'true';
         }
       }
@@ -139,7 +153,7 @@ export function createStreamingRenderer({ messagesEl }) {
       let streamData = streamingMessages.get(currentConversationId);
       if (!streamData) {
         // Create new streaming message element - always insert at the very end
-        const element = appendMessage(msg.role, msg.text, msg.timestamp, msg.source, msg.image);
+        const element = appendMessage(msg.role, msg.text, msg.timestamp, msg.source, msg.image, msg.actorLabel);
         streamData = {
           element,
           startTime: Date.now(),
@@ -180,7 +194,7 @@ export function createStreamingRenderer({ messagesEl }) {
       }
       // Only append a new element if this is NOT a final event (final reuses the streaming element)
       if (!msg._final) {
-        appendMessage(msg.role, msg.text, msg.timestamp, msg.source, msg.image);
+        appendMessage(msg.role, msg.text, msg.timestamp, msg.source, msg.image, msg.actorLabel);
         if (backendId === 'openclaw' && msg.text) {
           void persistChatMessage('wingman', msg.text, msg.image);
         }
@@ -213,7 +227,7 @@ export function createStreamingRenderer({ messagesEl }) {
 
       if (Array.isArray(msg)) {
         for (const m of msg) {
-          const el = appendMessage(m.role, m.text, m.timestamp, m.source, m.image);
+          const el = appendMessage(m.role, m.text, m.timestamp, m.source, m.image, m.actorLabel);
           el.dataset.fromHistory = 'true';
         }
 
@@ -240,7 +254,7 @@ export function createStreamingRenderer({ messagesEl }) {
 
       if (!streamData) {
         // Create new streaming message element
-        const element = appendMessage(msg.role, msg.text, msg.timestamp, msg.source, msg.image);
+        const element = appendMessage(msg.role, msg.text, msg.timestamp, msg.source, msg.image, msg.actorLabel);
         streamData = {
           element,
           startTime: Date.now(),
@@ -279,7 +293,7 @@ export function createStreamingRenderer({ messagesEl }) {
         void persistChatMessage('wingman', msg.text);
       }
       if (!msg._final) {
-        appendMessage(msg.role, msg.text, msg.timestamp, msg.source, msg.image);
+        appendMessage(msg.role, msg.text, msg.timestamp, msg.source, msg.image, msg.actorLabel);
         if (backendId === 'openclaw' && msg.text) {
           void persistChatMessage('wingman', msg.text, msg.image);
         }

--- a/shell/js/wingman/chat.js
+++ b/shell/js/wingman/chat.js
@@ -7,8 +7,8 @@
  *   (Kept as window binding for classic scripts and main-process IPC.)
  *
  * External globals used (loaded via classic <script> tags in shell/index.html
- * BEFORE this module): ChatRouter, OpenClawBackend, ClaudeActivityBackend,
- * DualMode. They are not ES modules, so they must be referenced as bare
+ * BEFORE this module): ChatRouter, TandemLocalBackend, OpenClawBackend,
+ * ClaudeActivityBackend, DualMode. They are not ES modules, so they must be referenced as bare
  * identifiers rather than imported.
  *
  * initChat() return shape matches prior `chatRouter` object:
@@ -35,11 +35,30 @@ export function initChat() {
   const typingEl = document.getElementById('typing-indicator');
   const wsDot = document.getElementById('ws-dot');
   const wsStatusText = document.getElementById('ws-status-text');
+  const backendSelector = document.getElementById('chat-backend-selector');
 
   // Safety check
   if (!messagesEl || !inputEl || !sendBtn || !typingEl || !wsDot || !wsStatusText) {
     console.error('[chatRouter] Missing required DOM elements, chat will not initialize');
     return { ensureConnected() { }, disconnect() { } };
+  }
+
+  if (backendSelector && backendSelector.children.length === 0) {
+    backendSelector.innerHTML = `
+      <button class="backend-option" id="btn-backend-tandem" title="Use Tandem's built-in MCP/API chat">
+        <span class="backend-dot" id="dot-tandem"></span><span>Tandem</span>
+      </button>
+      <button class="backend-option" id="btn-backend-openclaw" title="Use the local OpenClaw gateway">
+        <span class="backend-dot" id="dot-openclaw"></span><span>OpenClaw</span>
+      </button>
+      <button class="backend-option" id="btn-backend-claude" title="Use MCP activity polling">
+        <span class="backend-dot" id="dot-claude"></span><span>Claude</span>
+      </button>
+      <button class="backend-option" id="btn-backend-both" title="Send to every connected backend">
+        <span class="backend-dot" id="dot-both"></span><span>All</span>
+      </button>
+    `;
+    backendSelector.style.display = 'none';
   }
 
   const renderer = createStreamingRenderer({ messagesEl });
@@ -63,9 +82,11 @@ export function initChat() {
   // ── Router setup ──
 
   const router = new ChatRouter();
+  const tandemBackend = new TandemLocalBackend();
   const openclawBackend = new OpenClawBackend();
   const claudeBackend = new ClaudeActivityBackend();
 
+  router.register(tandemBackend);
   router.register(openclawBackend);
   router.register(claudeBackend);
 
@@ -73,18 +94,61 @@ export function initChat() {
   // Must happen AFTER backends are registered — the DualMode constructor
   // iterates router.getAllBackends().
   const dualMode = new DualMode(router);
-  let currentMode = 'openclaw'; // 'openclaw' | 'claude' | 'both'
+  let currentMode = 'tandem'; // 'tandem' | 'openclaw' | 'claude' | 'both'
 
   // ── Backend selector UI ──
 
+  const btnTD = document.getElementById('btn-backend-tandem');
   const btnOC = document.getElementById('btn-backend-openclaw');
   const btnCL = document.getElementById('btn-backend-claude');
   const btnBoth = document.getElementById('btn-backend-both');
+  const dotTD = document.getElementById('dot-tandem');
   const dotOC = document.getElementById('dot-openclaw');
   const dotCL = document.getElementById('dot-claude');
   const dotBoth = document.getElementById('dot-both');
 
+  function setBackendOptionVisible(button, visible) {
+    if (!button) return;
+    button.style.display = visible ? 'flex' : 'none';
+  }
+
+  function hasConfiguredAgent(...types) {
+    const agents = tandemBackend.getConnectedAgents?.() || [];
+    return agents.some((agent) => types.includes(agent.type));
+  }
+
+  function updateVisibleChannels() {
+    const primary = tandemBackend.getPrimaryAgent?.();
+    const showTandem = Boolean(primary);
+    const showOpenClaw = hasConfiguredAgent('openclaw');
+    const showClaude = hasConfiguredAgent('claude', 'claude-code');
+    const visibleCount = [showTandem, showOpenClaw, showClaude].filter(Boolean).length;
+
+    setBackendOptionVisible(btnTD, showTandem);
+    setBackendOptionVisible(btnOC, showOpenClaw);
+    setBackendOptionVisible(btnCL, showClaude);
+    setBackendOptionVisible(btnBoth, visibleCount > 1);
+
+    if (backendSelector) {
+      backendSelector.style.display = visibleCount > 0 ? 'flex' : 'none';
+    }
+
+    if (currentMode === 'openclaw' && !showOpenClaw) switchBackend('tandem');
+    if (currentMode === 'claude' && !showClaude) switchBackend('tandem');
+    if (currentMode === 'both' && visibleCount <= 1) switchBackend('tandem');
+  }
+
+  function updateTandemChannelLabel() {
+    const primary = tandemBackend.getPrimaryAgent?.();
+    const label = primary?.label || 'Tandem';
+    const labelEl = btnTD?.querySelector('span:last-child');
+    if (labelEl) labelEl.textContent = label;
+  }
+
   function updateBackendUI(activeId) {
+    updateTandemChannelLabel();
+    updateVisibleChannels();
+    if (btnTD) btnTD.classList.toggle('active', activeId === 'tandem');
     if (btnOC) btnOC.classList.toggle('active', activeId === 'openclaw');
     if (btnCL) btnCL.classList.toggle('active', activeId === 'claude');
     if (btnBoth) btnBoth.classList.toggle('active', activeId === 'both');
@@ -115,6 +179,8 @@ export function initChat() {
       }
       if (activeId === 'claude') {
         inputEl.placeholder = 'Message to Claude...';
+      } else if (activeId === 'tandem') {
+        inputEl.placeholder = 'Message to Tandem Wingman...';
       } else {
         inputEl.placeholder = 'Message to Wingman...';
       }
@@ -127,6 +193,8 @@ export function initChat() {
         typingText.textContent = 'AI is thinking...';
       } else if (activeId === 'claude') {
         typingText.textContent = 'Claude is thinking...';
+      } else if (activeId === 'tandem') {
+        typingText.textContent = 'Tandem Wingman is thinking...';
       } else {
         typingText.textContent = 'Wingman is typing...';
       }
@@ -157,7 +225,7 @@ export function initChat() {
       // Load combined history — OpenClaw first, then Claude
       openclawBackend.loadHistory((msgs) => {
         for (const m of msgs) {
-          const el = appendMessage(m.role, m.text, m.timestamp, m.source, m.image);
+          const el = appendMessage(m.role, m.text, m.timestamp, m.source, m.image, m.actorLabel);
           el.dataset.fromHistory = 'true';
         }
         // Re-add local user messages
@@ -172,7 +240,19 @@ export function initChat() {
       if (id === 'openclaw') {
         openclawBackend.loadHistory((msgs) => {
           for (const m of msgs) {
-            const el = appendMessage(m.role, m.text, m.timestamp, m.source, m.image);
+            const el = appendMessage(m.role, m.text, m.timestamp, m.source, m.image, m.actorLabel);
+            el.dataset.fromHistory = 'true';
+          }
+          // Re-add local user messages
+          for (const localMsg of localRobinMessages) {
+            const el = appendMessage(localMsg.role, localMsg.text, localMsg.timestamp, localMsg.source, localMsg.image);
+            el.dataset.localMessage = 'true';
+          }
+        });
+      } else if (id === 'tandem') {
+        tandemBackend.loadHistory((msgs) => {
+          for (const m of msgs) {
+            const el = appendMessage(m.role, m.text, m.timestamp, m.source, m.image, m.actorLabel);
             el.dataset.fromHistory = 'true';
           }
           // Re-add local user messages
@@ -196,6 +276,7 @@ export function initChat() {
     }).catch(() => { });
   }
 
+  if (btnTD) btnTD.addEventListener('click', () => switchBackend('tandem'));
   if (btnOC) btnOC.addEventListener('click', () => switchBackend('openclaw'));
   if (btnCL) btnCL.addEventListener('click', () => switchBackend('claude'));
   if (btnBoth) btnBoth.addEventListener('click', () => switchBackend('both'));
@@ -203,12 +284,15 @@ export function initChat() {
   // ── Connection status dots ──
 
   router.onConnectionChange((connected, backendId) => {
-    if (backendId === 'openclaw') {
+    if (backendId === 'tandem') {
+      updateTandemChannelLabel();
+      if (dotTD) dotTD.classList.toggle('connected', connected);
+    } else if (backendId === 'openclaw') {
       if (dotOC) dotOC.classList.toggle('connected', connected);
     } else if (backendId === 'claude') {
       if (dotCL) dotCL.classList.toggle('connected', connected);
     }
-    if (dotBoth) dotBoth.classList.toggle('connected', openclawBackend.isConnected() && claudeBackend.isConnected());
+    if (dotBoth) dotBoth.classList.toggle('connected', tandemBackend.isConnected() || openclawBackend.isConnected() || claudeBackend.isConnected());
 
     // Update status bar for current mode
     if (currentMode === 'both') {
@@ -377,7 +461,7 @@ export function initChat() {
           appendMessage('assistant', '⚠️ Wingman could not reach OpenClaw.', Date.now(), 'wingman');
         }
       } else {
-        // For Claude, needs WebSocket connection
+        // Local and Claude backends both expose their own connection state.
         if (!backend || !backend.isConnected()) return;
         await router.sendMessage(text);
       }
@@ -398,26 +482,47 @@ export function initChat() {
 
   // ── Initialize ──
 
-  // Load saved backend from config, fallback to openclaw
+  // Load saved backend from config. OpenClaw stays supported, but a missing
+  // gateway falls back to Tandem's built-in MCP/API chat.
   router.connectAll();
   fetch('http://localhost:8765/config')
     .then(r => r.json())
     .then(cfg => {
       const saved = cfg.general && cfg.general.activeBackend;
-      if (saved === 'claude') switchBackend('claude');
+      if (saved === 'tandem') switchBackend('tandem');
+      else if (saved === 'claude') {
+        switchBackend('claude');
+        setTimeout(() => {
+          const primary = tandemBackend.getPrimaryAgent?.();
+          if (currentMode === 'claude' && primary && primary.type !== 'claude-code') {
+            switchBackend('tandem');
+          }
+        }, 1500);
+      }
       else if (saved === 'both') switchBackend('both');
-      else switchBackend('openclaw');
+      else {
+        switchBackend('openclaw');
+        setTimeout(() => {
+          if (currentMode === 'openclaw' && !openclawBackend.isConnected() && tandemBackend.isConnected()) {
+            switchBackend('tandem');
+          }
+        }, 4500);
+      }
     })
-    .catch(() => switchBackend('openclaw'));
+    .catch(() => switchBackend('tandem'));
 
   // Listen for incoming Wingman messages pushed via POST /chat API
   if (window.tandem && window.tandem.onChatMessage) {
     window.tandem.onChatMessage((msg) => {
       // msg: {id, from, text, timestamp, image}
       // Skip user messages — already shown optimistically in the UI
+      if (msg.clear) {
+        clearStreaming();
+        return;
+      }
       if (msg.from === 'user') return;
       const source = msg.from; // 'wingman' or 'claude'
-      appendMessage('assistant', msg.text, msg.timestamp, source, msg.image);
+      appendMessage('assistant', msg.text, msg.timestamp, source, msg.image, msg.actorLabel);
       if (messagesEl) messagesEl.scrollTop = messagesEl.scrollHeight;
     });
   }

--- a/src/api/routes/media.ts
+++ b/src/api/routes/media.ts
@@ -12,6 +12,54 @@ interface ScreenshotRegion {
   height: number;
 }
 
+function normalizeChatSender(from: unknown): string {
+  if (typeof from !== 'string') return 'wingman';
+  const normalized = from.trim().toLowerCase().replace(/[^a-z0-9_-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
+  return normalized || 'wingman';
+}
+
+function deriveActorLabel(sender: string, explicitLabel: unknown): string | undefined {
+  if (typeof explicitLabel === 'string' && explicitLabel.trim()) {
+    return explicitLabel.trim().slice(0, 80);
+  }
+  if (sender === 'user') return undefined;
+  if (sender === 'codex') return 'Codex';
+  if (sender === 'claude') return 'Claude';
+  if (sender === 'openclaw') return 'OpenClaw';
+  if (sender === 'wingman') return undefined;
+  return sender
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+    .slice(0, 80);
+}
+
+function getPrimaryChatAgent(ctx: RouteContext): { id: string; label: string; type: string } | null {
+  const paired = ctx.pairingManager
+    .listBindings()
+    .filter(binding => binding.state === 'paired');
+  const local = paired.find(binding => binding.bindingKind === 'local') ?? paired[0];
+  if (!local) return null;
+  return {
+    id: local.id,
+    label: local.agentLabel,
+    type: local.agentType,
+  };
+}
+
+function parseChatLimit(rawLimit: unknown): number {
+  const limit = parseInt(String(rawLimit ?? ''), 10);
+  if (!Number.isFinite(limit) || limit <= 0) return 50;
+  return Math.min(limit, 200);
+}
+
+function parseSinceId(rawSinceId: unknown): number | null {
+  const sinceId = parseInt(String(rawSinceId ?? ''), 10);
+  if (!Number.isFinite(sinceId) || sinceId <= 0) return null;
+  return sinceId;
+}
+
 function renderGooglePhotosAuthPage(opts: { ok: boolean; title: string; message: string; detail?: string }): string {
   return `<!doctype html>
 <html>
@@ -94,34 +142,106 @@ export function registerMediaRoutes(router: Router, ctx: RouteContext): void {
   // ═══════════════════════════════════════════════
 
   /** Get chat messages (supports ?since_id= for polling) */
-  router.get('/chat', (req: Request, res: Response) => {
+  const getChatMessages = (req: Request, res: Response) => {
     try {
-      const sinceId = parseInt(req.query.since_id as string);
-      if (sinceId && !isNaN(sinceId)) {
+      const sinceId = parseSinceId(req.query.since_id);
+      if (sinceId) {
         const messages = ctx.panelManager.getChatMessagesSince(sinceId);
         res.json({ messages });
       } else {
-        const limit = parseInt(req.query.limit as string) || 50;
+        const limit = parseChatLimit(req.query.limit);
         const messages = ctx.panelManager.getChatMessages(limit);
         res.json({ messages });
       }
     } catch (e) {
       handleRouteError(res, e);
     }
-  });
+  };
+  router.get('/chat', getChatMessages);
+  router.get('/chat/messages', getChatMessages);
 
   /** Send chat message (default: wingman, 'from' param allows robin/claude) */
-  router.post('/chat', (req: Request, res: Response) => {
-    const { text, from, image } = req.body;
+  const postChatMessage = (req: Request, res: Response) => {
+    const { text, from, image, actorLabel, agentType } = req.body;
     if (!text && !image) { res.status(400).json({ error: 'text or image required' }); return; }
-    const sender: 'user' | 'wingman' | 'claude' = (from === 'user') ? 'user' : (from === 'claude') ? 'claude' : 'wingman';
+    const primaryAgent = getPrimaryChatAgent(ctx);
+    const sender = normalizeChatSender(from ?? primaryAgent?.type);
+    const resolvedActorLabel = deriveActorLabel(sender, actorLabel ?? (sender === primaryAgent?.type ? primaryAgent?.label : undefined));
     try {
       let savedImage: string | undefined;
       if (image) {
         savedImage = ctx.panelManager.saveImage(image);
       }
-      const msg = ctx.panelManager.addChatMessage(sender, text || '', savedImage);
+      const msg = ctx.panelManager.addChatMessage(sender, text || '', savedImage, {
+        actorLabel: resolvedActorLabel,
+        agentType: typeof agentType === 'string' ? agentType : primaryAgent?.type,
+      });
       res.json({ ok: true, message: msg });
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  };
+  router.post('/chat', postChatMessage);
+  router.post('/chat/messages', postChatMessage);
+
+  /** Clear chat messages for the local Tandem chat bus. */
+  const deleteChatMessages = (_req: Request, res: Response) => {
+    try {
+      ctx.panelManager.clearChatMessages();
+      res.json({ ok: true, cleared: true });
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  };
+  router.delete('/chat', deleteChatMessages);
+  router.delete('/chat/messages', deleteChatMessages);
+
+  /** Wait briefly for new chat messages without forcing MCP clients to poll tightly. */
+  router.get('/chat/wait', async (req: Request, res: Response) => {
+    const sinceId = parseSinceId(req.query.since_id) ?? 0;
+    const timeoutMs = Math.min(parseInt(String(req.query.timeout_ms ?? '30000'), 10) || 30_000, 30_000);
+    const startedAt = Date.now();
+
+    try {
+      while (Date.now() - startedAt < timeoutMs) {
+        const messages = ctx.panelManager.getChatMessagesSince(sinceId);
+        if (messages.length > 0) {
+          res.json({ messages, timedOut: false });
+          return;
+        }
+        await new Promise(resolve => setTimeout(resolve, 250));
+      }
+      res.json({ messages: [], timedOut: true });
+    } catch (e) {
+      handleRouteError(res, e);
+    }
+  });
+
+  /** Local chat bus health/status for renderer backends and agents. */
+  router.get('/chat/status', (_req: Request, res: Response) => {
+    try {
+      const recent = ctx.panelManager.getChatMessages(1);
+      const lastMessageId = recent[0]?.id ?? 0;
+      const connectedAgents = ctx.pairingManager
+        .listBindings()
+        .filter(binding => binding.state === 'paired')
+        .map(binding => ({
+          id: binding.id,
+          label: binding.agentLabel,
+          type: binding.agentType,
+          bindingKind: binding.bindingKind,
+          transportModes: binding.transportModes,
+          lastUsedAt: binding.lastUsedAt,
+        }));
+      const primaryAgent = getPrimaryChatAgent(ctx);
+      res.json({
+        ok: true,
+        backend: 'tandem',
+        available: true,
+        lastMessageId,
+        primaryAgent,
+        connectedAgents,
+      });
     } catch (e) {
       handleRouteError(res, e);
     }

--- a/src/api/tests/helpers.ts
+++ b/src/api/tests/helpers.ts
@@ -120,6 +120,7 @@ export function createMockContext(): RouteContext {
       getChatMessages: vi.fn().mockReturnValue([]),
       getChatMessagesSince: vi.fn().mockReturnValue([]),
       addChatMessage: vi.fn().mockReturnValue({ id: 1, from: 'wingman', text: '', ts: Date.now() }),
+      clearChatMessages: vi.fn(),
       saveImage: vi.fn().mockReturnValue('image.png'),
       getImagePath: vi.fn().mockReturnValue('/tmp/image.png'),
       setWingmanTyping: vi.fn(),

--- a/src/api/tests/routes/media.test.ts
+++ b/src/api/tests/routes/media.test.ts
@@ -106,6 +106,17 @@ describe('Media Routes', () => {
       expect(ctx.panelManager.getChatMessages).toHaveBeenCalledWith(10);
     });
 
+    it('supports /chat/messages as the local chat bus alias', async () => {
+      const fakeMessages = [{ id: 1, from: 'user', text: 'local', ts: 1000 }];
+      vi.mocked(ctx.panelManager.getChatMessages).mockReturnValue(fakeMessages as any);
+
+      const res = await request(app).get('/chat/messages?limit=5');
+
+      expect(res.status).toBe(200);
+      expect(res.body.messages).toEqual(fakeMessages);
+      expect(ctx.panelManager.getChatMessages).toHaveBeenCalledWith(5);
+    });
+
     it('supports ?since_id= for polling', async () => {
       const newMessages = [{ id: 3, from: 'user', text: 'new', ts: 2000 }];
       vi.mocked(ctx.panelManager.getChatMessagesSince).mockReturnValue(newMessages as any);
@@ -150,7 +161,10 @@ describe('Media Routes', () => {
       expect(res.status).toBe(200);
       expect(res.body.ok).toBe(true);
       expect(res.body.message).toEqual(fakeMsg);
-      expect(ctx.panelManager.addChatMessage).toHaveBeenCalledWith('wingman', 'hello', undefined);
+      expect(ctx.panelManager.addChatMessage).toHaveBeenCalledWith('wingman', 'hello', undefined, {
+        actorLabel: undefined,
+        agentType: undefined,
+      });
     });
 
     it('maps from=user to sender user', async () => {
@@ -158,7 +172,10 @@ describe('Media Routes', () => {
         .post('/chat')
         .send({ text: 'hi', from: 'user' });
 
-      expect(ctx.panelManager.addChatMessage).toHaveBeenCalledWith('user', 'hi', undefined);
+      expect(ctx.panelManager.addChatMessage).toHaveBeenCalledWith('user', 'hi', undefined, {
+        actorLabel: undefined,
+        agentType: undefined,
+      });
     });
 
     it('maps from=claude to sender claude', async () => {
@@ -166,15 +183,21 @@ describe('Media Routes', () => {
         .post('/chat')
         .send({ text: 'hi', from: 'claude' });
 
-      expect(ctx.panelManager.addChatMessage).toHaveBeenCalledWith('claude', 'hi', undefined);
+      expect(ctx.panelManager.addChatMessage).toHaveBeenCalledWith('claude', 'hi', undefined, {
+        actorLabel: 'Claude',
+        agentType: undefined,
+      });
     });
 
-    it('maps unknown from value to wingman', async () => {
+    it('accepts arbitrary agent source values', async () => {
       await request(app)
         .post('/chat')
-        .send({ text: 'hi', from: 'unknown' });
+        .send({ text: 'hi', from: 'codex' });
 
-      expect(ctx.panelManager.addChatMessage).toHaveBeenCalledWith('wingman', 'hi', undefined);
+      expect(ctx.panelManager.addChatMessage).toHaveBeenCalledWith('codex', 'hi', undefined, {
+        actorLabel: 'Codex',
+        agentType: undefined,
+      });
     });
 
     it('sends a message with an image', async () => {
@@ -185,7 +208,10 @@ describe('Media Routes', () => {
         .send({ text: 'look at this', image: 'data:image/png;base64,abc' });
 
       expect(ctx.panelManager.saveImage).toHaveBeenCalledWith('data:image/png;base64,abc');
-      expect(ctx.panelManager.addChatMessage).toHaveBeenCalledWith('wingman', 'look at this', 'saved.png');
+      expect(ctx.panelManager.addChatMessage).toHaveBeenCalledWith('wingman', 'look at this', 'saved.png', {
+        actorLabel: undefined,
+        agentType: undefined,
+      });
     });
 
     it('sends a message with image only (no text)', async () => {
@@ -195,7 +221,21 @@ describe('Media Routes', () => {
         .post('/chat')
         .send({ image: 'data:image/png;base64,abc' });
 
-      expect(ctx.panelManager.addChatMessage).toHaveBeenCalledWith('wingman', '', 'saved.png');
+      expect(ctx.panelManager.addChatMessage).toHaveBeenCalledWith('wingman', '', 'saved.png', {
+        actorLabel: undefined,
+        agentType: undefined,
+      });
+    });
+
+    it('supports POST /chat/messages as the local chat bus alias', async () => {
+      await request(app)
+        .post('/chat/messages')
+        .send({ text: 'hi from robin', from: 'user' });
+
+      expect(ctx.panelManager.addChatMessage).toHaveBeenCalledWith('user', 'hi from robin', undefined, {
+        actorLabel: undefined,
+        agentType: undefined,
+      });
     });
 
     it('returns 400 when neither text nor image is provided', async () => {
@@ -218,6 +258,35 @@ describe('Media Routes', () => {
 
       expect(res.status).toBe(500);
       expect(res.body.error).toBe('chat send error');
+    });
+  });
+
+  describe('GET /chat/status', () => {
+    it('returns local chat bus status', async () => {
+      vi.mocked(ctx.panelManager.getChatMessages).mockReturnValue([{ id: 12, from: 'user', text: 'last', timestamp: 1000 }] as any);
+
+      const res = await request(app).get('/chat/status');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        ok: true,
+        backend: 'tandem',
+        available: true,
+        lastMessageId: 12,
+        primaryAgent: null,
+        connectedAgents: [],
+      });
+      expect(ctx.panelManager.getChatMessages).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('DELETE /chat/messages', () => {
+    it('clears local chat history', async () => {
+      const res = await request(app).delete('/chat/messages');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ ok: true, cleared: true });
+      expect(ctx.panelManager.clearChatMessages).toHaveBeenCalled();
     });
   });
 

--- a/src/config/manager.ts
+++ b/src/config/manager.ts
@@ -29,7 +29,7 @@ export interface TandemConfig {
     wingmanPanelPosition: 'left' | 'right';
     wingmanPanelDefaultOpen: boolean;
     showBookmarksBar: boolean;
-    activeBackend: 'openclaw' | 'claude';
+    activeBackend: 'tandem' | 'openclaw' | 'claude' | 'both';
     agentName: string;
     agentDisplayName: string;
     quickLinks: QuickLinkConfig[];
@@ -132,7 +132,7 @@ const DEFAULT_CONFIG: TandemConfig = {
     wingmanPanelPosition: 'right',
     wingmanPanelDefaultOpen: false,
     showBookmarksBar: true,
-    activeBackend: 'openclaw',
+    activeBackend: 'tandem',
     agentName: 'Wingman',
     agentDisplayName: 'AI Wingman',
     quickLinks: DEFAULT_QUICK_LINKS,

--- a/src/config/tests/config.test.ts
+++ b/src/config/tests/config.test.ts
@@ -43,7 +43,7 @@ describe('ConfigManager', () => {
       expect(config.general.wingmanPanelPosition).toBe('right');
       expect(config.general.wingmanPanelDefaultOpen).toBe(false);
       expect(config.general.showBookmarksBar).toBe(true);
-      expect(config.general.activeBackend).toBe('openclaw');
+      expect(config.general.activeBackend).toBe('tandem');
       expect(config.general.agentName).toBe('Wingman');
       expect(config.general.agentDisplayName).toBe('AI Wingman');
       expect(config.general.quickLinks).toHaveLength(6);

--- a/src/ipc/handlers.ts
+++ b/src/ipc/handlers.ts
@@ -173,10 +173,12 @@ export function registerIpcHandlers(deps: IpcDeps): void {
   });
 
   ipcMain.handle(IpcChannels.CHAT_PERSIST_MESSAGE, async (_event, data: {
-    from: 'user' | 'wingman' | 'claude';
+    from: string;
     text?: string;
     image?: string;
     notifyWebhook?: boolean;
+    actorLabel?: string;
+    agentType?: string;
   }) => {
     const text = typeof data?.text === 'string' ? data.text : '';
     const image = typeof data?.image === 'string' ? data.image : undefined;
@@ -194,6 +196,8 @@ export function registerIpcHandlers(deps: IpcDeps): void {
       {
         notifyWebhook: data.notifyWebhook,
         emitIpc: false,
+        actorLabel: data.actorLabel,
+        agentType: data.agentType,
       },
     );
     return { ok: true, message: msg };

--- a/src/mcp/tests/chat.test.ts
+++ b/src/mcp/tests/chat.test.ts
@@ -33,7 +33,7 @@ describe('MCP chat tools', () => {
       mockApiCall.mockResolvedValueOnce({});
       const result = await handler({ text: 'Hello Robin' });
       expectTextContent(result, 'Message sent: "Hello Robin"');
-      expect(mockApiCall).toHaveBeenCalledWith('POST', '/chat', { text: 'Hello Robin', from: 'wingman' });
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/chat', { text: 'Hello Robin' });
     });
 
     it('uses the MCP connector source in chat messages', async () => {
@@ -61,6 +61,63 @@ describe('MCP chat tools', () => {
       mockApiCall.mockResolvedValueOnce({ messages: [] });
       const result = await handler({ limit: 10 });
       expectTextContent(result, '(0 messages)');
+    });
+  });
+
+  describe('tandem_chat_reply', () => {
+    const handler = getHandler(tools, 'tandem_chat_reply');
+
+    it('replies through the local Tandem chat route', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      const result = await handler({ text: 'I can answer here now' });
+      expectTextContent(result, 'Reply sent: "I can answer here now"');
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/chat/messages', { text: 'I can answer here now' });
+    });
+  });
+
+  describe('tandem_chat_wait_for_message', () => {
+    const handler = getHandler(tools, 'tandem_chat_wait_for_message');
+
+    it('formats new messages returned by long poll', async () => {
+      mockApiCall.mockResolvedValueOnce({
+        messages: [{ id: 2, from: 'user', text: 'are you there?', timestamp: 1700000000000 }],
+        timedOut: false,
+      });
+
+      const result = await handler({ sinceId: 1, timeoutMs: 1000 });
+      const text = expectTextContent(result, 'New chat messages (1)');
+      expect(text).toContain('#2');
+      expect(text).toContain('user: are you there?');
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/chat/wait?since_id=1&timeout_ms=1000');
+    });
+
+    it('reports timeout with no messages', async () => {
+      mockApiCall.mockResolvedValueOnce({ messages: [], timedOut: true });
+      const result = await handler({ sinceId: 5, timeoutMs: 1000 });
+      expectTextContent(result, 'No new chat messages before timeout.');
+    });
+  });
+
+  describe('tandem_chat_set_typing', () => {
+    const handler = getHandler(tools, 'tandem_chat_set_typing');
+
+    it('sets typing status', async () => {
+      mockApiCall.mockResolvedValueOnce({});
+      const result = await handler({ typing: true });
+      expectTextContent(result, 'Typing indicator enabled.');
+      expect(mockApiCall).toHaveBeenCalledWith('POST', '/chat/typing', { typing: true });
+    });
+  });
+
+  describe('tandem_chat_status', () => {
+    const handler = getHandler(tools, 'tandem_chat_status');
+
+    it('returns local chat bus status', async () => {
+      mockApiCall.mockResolvedValueOnce({ available: true, backend: 'tandem', lastMessageId: 7 });
+      const result = await handler({});
+      const text = expectTextContent(result, 'Tandem chat status: available');
+      expect(text).toContain('lastMessageId: 7');
+      expect(mockApiCall).toHaveBeenCalledWith('GET', '/chat/status');
     });
   });
 

--- a/src/mcp/tools/chat.ts
+++ b/src/mcp/tools/chat.ts
@@ -3,6 +3,11 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { apiCall, getMcpSource, logActivity } from '../api-client.js';
 import { coerceShape } from '../coerce.js';
 
+function buildAgentChatBody(text: string): { text: string; from?: string } {
+  const source = getMcpSource();
+  return source === 'wingman' ? { text } : { text, from: source };
+}
+
 export function registerChatTools(server: McpServer): void {
   server.tool(
     'tandem_send_message',
@@ -11,8 +16,20 @@ export function registerChatTools(server: McpServer): void {
       text: z.string().describe('Message text to display'),
     },
     async ({ text }) => {
-      await apiCall('POST', '/chat', { text, from: getMcpSource() });
+      await apiCall('POST', '/chat', buildAgentChatBody(text));
       return { content: [{ type: 'text', text: `Message sent: "${text.substring(0, 100)}"` }] };
+    }
+  );
+
+  server.tool(
+    'tandem_chat_reply',
+    'Reply into the Wingman chat panel as the connected agent through Tandem local chat',
+    {
+      text: z.string().describe('Reply text to display in the Wingman chat'),
+    },
+    async ({ text }) => {
+      await apiCall('POST', '/chat/messages', buildAgentChatBody(text));
+      return { content: [{ type: 'text', text: `Reply sent: "${text.substring(0, 100)}"` }] };
     }
   );
 
@@ -33,6 +50,57 @@ export function registerChatTools(server: McpServer): void {
       }
 
       return { content: [{ type: 'text', text }] };
+    }
+  );
+
+  server.tool(
+    'tandem_chat_wait_for_message',
+    'Wait for new Wingman chat messages after a known message id',
+    coerceShape({
+      sinceId: z.number().optional().default(0).describe('Only return messages with id greater than this value'),
+      timeoutMs: z.number().optional().default(30000).describe('Maximum wait in milliseconds, capped by Tandem'),
+    }),
+    async ({ sinceId, timeoutMs }) => {
+      const data = await apiCall('GET', `/chat/wait?since_id=${sinceId}&timeout_ms=${timeoutMs}`);
+      const messages: Array<{ id: number; from: string; text: string; timestamp: number }> = data.messages || [];
+
+      if (messages.length === 0) {
+        return { content: [{ type: 'text', text: data.timedOut ? 'No new chat messages before timeout.' : 'No new chat messages.' }] };
+      }
+
+      let text = `New chat messages (${messages.length}):\n\n`;
+      for (const msg of messages) {
+        const time = new Date(msg.timestamp).toLocaleTimeString();
+        text += `#${msg.id} [${time}] ${msg.from}: ${msg.text}\n`;
+      }
+
+      return { content: [{ type: 'text', text }] };
+    }
+  );
+
+  server.tool(
+    'tandem_chat_set_typing',
+    'Set the Wingman typing indicator in the chat panel',
+    {
+      typing: z.boolean().describe('Whether the Wingman typing indicator should be shown'),
+    },
+    async ({ typing }) => {
+      await apiCall('POST', '/chat/typing', { typing });
+      return { content: [{ type: 'text', text: `Typing indicator ${typing ? 'enabled' : 'disabled'}.` }] };
+    }
+  );
+
+  server.tool(
+    'tandem_chat_status',
+    'Get Tandem local chat bus status for MCP/API Wingman chat',
+    async () => {
+      const data = await apiCall('GET', '/chat/status');
+      return {
+        content: [{
+          type: 'text',
+          text: `Tandem chat status: ${data.available ? 'available' : 'unavailable'} (backend: ${data.backend || 'unknown'}, lastMessageId: ${data.lastMessageId ?? 0})`,
+        }],
+      };
     }
   );
 

--- a/src/panel/manager.ts
+++ b/src/panel/manager.ts
@@ -20,15 +20,20 @@ export interface ActivityEvent {
 
 export interface ChatMessage {
   id: number;
-  from: 'user' | 'wingman' | 'claude';
+  from: string;
   text: string;
   timestamp: number;
   image?: string;  // relative filename in ~/.tandem/chat-images/
+  actorLabel?: string;
+  agentType?: string;
+  clear?: boolean;
 }
 
 export interface AddChatMessageOptions {
   notifyWebhook?: boolean;
   emitIpc?: boolean;
+  actorLabel?: string;
+  agentType?: string;
 }
 
 // ─── Manager ────────────────────────────────────────────────────────
@@ -114,7 +119,7 @@ export class PanelManager {
 
   /** Add a chat message */
   addChatMessage(
-    from: 'user' | 'wingman' | 'claude',
+    from: string,
     text: string,
     image?: string,
     opts: AddChatMessageOptions = {},
@@ -125,6 +130,8 @@ export class PanelManager {
       text,
       timestamp: Date.now(),
       image,
+      actorLabel: opts.actorLabel,
+      agentType: opts.agentType,
     };
     this.chatMessages.push(msg);
     this.saveChatHistory();
@@ -154,6 +161,22 @@ export class PanelManager {
   /** Get messages since a given ID (for polling) */
   getChatMessagesSince(sinceId: number): ChatMessage[] {
     return this.chatMessages.filter(m => m.id > sinceId);
+  }
+
+  /** Clear local chat history and notify the renderer to reload an empty view. */
+  clearChatMessages(): void {
+    this.chatMessages = [];
+    this.chatCounter = 0;
+    this.saveChatHistory();
+    if (this.win && !this.win.isDestroyed() && !this.win.webContents.isDestroyed()) {
+      this.win.webContents.send(IpcChannels.CHAT_MESSAGE, {
+        id: 0,
+        from: 'system',
+        text: '',
+        timestamp: Date.now(),
+        clear: true,
+      });
+    }
   }
 
   /** Set Wingman typing indicator */
@@ -282,6 +305,9 @@ export class PanelManager {
 
   private getReplySenderLabel(from: ChatMessage['from']): string {
     if (from === 'claude') return 'Claude';
+    if (from === 'codex') return 'Codex';
+    if (from === 'openclaw') return 'OpenClaw';
+    if (from && from !== 'wingman') return from;
     return 'Wingman';
   }
 

--- a/src/preload/panel.ts
+++ b/src/preload/panel.ts
@@ -28,10 +28,12 @@ export function createPanelApi() {
     },
     sendChatImage: (text: string, image: string) => ipcRenderer.invoke(IpcChannels.CHAT_SEND_IMAGE, { text, image }),
     persistChatMessage: (data: {
-      from: 'user' | 'wingman' | 'claude';
+      from: string;
       text?: string;
       image?: string;
       notifyWebhook?: boolean;
+      actorLabel?: string;
+      agentType?: string;
     }) => ipcRenderer.invoke(IpcChannels.CHAT_PERSIST_MESSAGE, data),
     onWingmanAlert: (callback: (data: { title: string; body: string }) => void) => {
       const handler = (_event: Electron.IpcRendererEvent, data: { title: string; body: string }) => callback(data);


### PR DESCRIPTION
## Summary

- Adds a built-in Tandem local Wingman chat backend so MCP/API agents can read and reply in the panel without OpenClaw installed on the host.
- Makes the Wingman chat selector agent-aware: only channels for paired Connected Agents are shown, and a lone Codex binding is labeled Codex instead of being mirrored through Claude.
- Adds local chat bus API aliases/status/wait/clear routes and MCP chat tools for reply, wait, typing, and status while preserving OpenClaw and Claude backends for configured agents.

## Validation

- `npx tsc` — passed with zero errors.
- `npx vitest run src/config/tests/config.test.ts src/api/tests/routes/media.test.ts src/mcp/tests/chat.test.ts` — 136 tests passed.
- Manual: Tandem Wingman chat showed only Codex when Codex was the only connected agent, accepted Robin messages, and rendered Codex replies through the Tandem local chat bus.

## Notes

- Draft PR because this workspace also has separate local Agent API port/bootstrap changes that are intentionally excluded from this PR.
- Before merge, this `feat:` PR should get the normal release/version bump required by the repo policy.