### PR TITLE
fix: derive WebGL and colour depth from the OS persona (stealth consistency)

### DIFF
--- a/src/platform/stealth-ua/index.ts
+++ b/src/platform/stealth-ua/index.ts
@@ -1,5 +1,5 @@
 import { NotImplementedError, type PlatformId } from '../errors';
-import type { StealthUaAdapter, StealthUaBrandVersion, StealthUaProfile } from '../types';
+import type { StealthUaAdapter, StealthUaBrandVersion, StealthUaFingerprint, StealthUaProfile } from '../types';
 
 function getChromeMajor(chromeVersion: string): string {
   return chromeVersion.split('.')[0];
@@ -31,6 +31,7 @@ function createProfile(
     bitness: string;
   },
   requestHeaders: { platform: string; platformVersion?: string },
+  fingerprint: StealthUaFingerprint,
 ): StealthUaProfile {
   const chromeMajor = getChromeMajor(chromeVersion);
   return {
@@ -50,8 +51,27 @@ function createProfile(
       fullVersionList: createFullVersionList(chromeVersion),
     },
     requestHeaders,
+    fingerprint,
   };
 }
+
+// A macOS Chrome on Apple Silicon reports its GPU through ANGLE's Metal
+// backend, and Retina displays report 30-bit colour. These must travel with
+// the macOS UA so the persona stays internally consistent.
+const DARWIN_FINGERPRINT: StealthUaFingerprint = {
+  webglVendor: 'Google Inc. (Apple)',
+  webglRenderer: 'ANGLE (Apple, Apple M1, OpenGL 4.1)',
+  colorDepth: 30,
+};
+
+// A Windows Chrome reports its GPU through ANGLE's Direct3D11 backend and a
+// 24-bit colour depth. Intel UHD 630 is one of the most common Windows GPUs,
+// so it blends in rather than forming a distinctive fingerprint.
+const WINDOWS_FINGERPRINT: StealthUaFingerprint = {
+  webglVendor: 'Google Inc. (Intel)',
+  webglRenderer: 'ANGLE (Intel, Intel(R) UHD Graphics 630 Direct3D11 vs_5_0 ps_5_0, D3D11)',
+  colorDepth: 24,
+};
 
 function createDarwinProfile(chromeVersion: string): StealthUaProfile {
   return createProfile(
@@ -64,6 +84,7 @@ function createDarwinProfile(chromeVersion: string): StealthUaProfile {
       bitness: '64',
     },
     { platform: '"macOS"' },
+    DARWIN_FINGERPRINT,
   );
 }
 
@@ -78,6 +99,7 @@ function createWindowsProfile(chromeVersion: string): StealthUaProfile {
       bitness: '64',
     },
     { platform: '"Windows"', platformVersion: '"15.0.0"' },
+    WINDOWS_FINGERPRINT,
   );
 }
 

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -127,10 +127,27 @@ export interface StealthUaRequestHeaders {
   platformVersion?: string;
 }
 
+/**
+ * OS-specific fingerprint surfaces that must match the UA persona. These are
+ * spoofed in the page (WebGL debug renderer info, screen colour depth) and, if
+ * they disagree with the User-Agent / client hints, become a cross-checkable
+ * automation tell. Keeping them on the profile makes the persona a single
+ * source of truth so UA, client hints, WebGL, and screen can never diverge.
+ */
+export interface StealthUaFingerprint {
+  /** UNMASKED_VENDOR_WEBGL (0x9245) value. */
+  webglVendor: string;
+  /** UNMASKED_RENDERER_WEBGL (0x9246) value. */
+  webglRenderer: string;
+  /** screen.colorDepth / screen.pixelDepth (Windows Chrome = 24, macOS = 30). */
+  colorDepth: number;
+}
+
 export interface StealthUaProfile {
   userAgent: string;
   chromeVersion: string;
   chromeMajor: string;
   clientHints: StealthUaClientHints;
   requestHeaders: StealthUaRequestHeaders;
+  fingerprint: StealthUaFingerprint;
 }

--- a/src/stealth/manager.ts
+++ b/src/stealth/manager.ts
@@ -4,7 +4,6 @@ import fs from 'fs';
 import path from 'path';
 import type { RequestDispatcher } from '../network/dispatcher';
 import { selectPlatform } from '../platform';
-import { createDarwinStealthUaAdapter } from '../platform/stealth-ua';
 import type { StealthUaAdapter, StealthUaProfile } from '../platform/types';
 import { createLogger } from '../utils/logger';
 import { tandemDir } from '../utils/paths';
@@ -299,7 +298,7 @@ export class StealthManager {
    */
   static getEarlyScript(
     chromeVersion: string = process.versions.chrome,
-    stealthUa: StealthUaAdapter = createDarwinStealthUaAdapter(),
+    stealthUa: StealthUaAdapter = selectPlatform().stealthUa,
   ): string {
     const profile = stealthUa.getProfile(chromeVersion);
     const brands = JSON.stringify(profile.clientHints.brands);
@@ -393,11 +392,14 @@ export class StealthManager {
   static getStealthScript(
     seed: string = 'tandem-default-seed',
     chromeVersion: string = process.versions.chrome,
-    stealthUa: StealthUaAdapter = createDarwinStealthUaAdapter(),
+    stealthUa: StealthUaAdapter = selectPlatform().stealthUa,
   ): string {
     const profile = stealthUa.getProfile(chromeVersion);
     const brands = JSON.stringify(profile.clientHints.brands);
     const fullVersionList = JSON.stringify(profile.clientHints.fullVersionList);
+    const webglVendor = JSON.stringify(profile.fingerprint.webglVendor);
+    const webglRenderer = JSON.stringify(profile.fingerprint.webglRenderer);
+    const colorDepth = JSON.stringify(profile.fingerprint.colorDepth);
     return `
       // ═══ All stealth patches in one IIFE — no globals leaked to window ═══
       // Idempotency guard: both the session preload and the dom-ready injection
@@ -466,9 +468,11 @@ export class StealthManager {
 
         WebGLRenderingContext.prototype.getParameter = function(param) {
           // UNMASKED_VENDOR_WEBGL (0x9245) and UNMASKED_RENDERER_WEBGL (0x9246)
-          // These come from the WEBGL_debug_renderer_info extension
-          if (param === 0x9245) return 'Google Inc. (Apple)';
-          if (param === 0x9246) return 'ANGLE (Apple, Apple M1, OpenGL 4.1)';
+          // These come from the WEBGL_debug_renderer_info extension. Values come
+          // from the OS persona so they match the User-Agent (a Windows UA with a
+          // macOS GPU string is a cross-checkable automation tell).
+          if (param === 0x9245) return ${webglVendor};
+          if (param === 0x9246) return ${webglRenderer};
           return getParamOrig.call(this, param);
         };
 
@@ -476,8 +480,8 @@ export class StealthManager {
         if (typeof WebGL2RenderingContext !== 'undefined') {
           var getParam2Orig = WebGL2RenderingContext.prototype.getParameter;
           WebGL2RenderingContext.prototype.getParameter = function(param) {
-            if (param === 0x9245) return 'Google Inc. (Apple)';
-            if (param === 0x9246) return 'ANGLE (Apple, Apple M1, OpenGL 4.1)';
+            if (param === 0x9245) return ${webglVendor};
+            if (param === 0x9246) return ${webglRenderer};
             return getParam2Orig.call(this, param);
           };
         }
@@ -501,6 +505,17 @@ export class StealthManager {
         if (typeof WebGL2RenderingContext !== 'undefined') {
           WebGL2RenderingContext.prototype.getSupportedExtensions = function() { return stdExtensions.slice(); };
         }
+      })();
+
+      // ═══ 5.2b Screen colour depth (match OS persona) ═══
+      // Windows Chrome reports 24-bit colour, macOS Retina reports 30-bit. Left
+      // unpatched, the host display's real depth leaks through and can contradict
+      // the User-Agent persona.
+      (function() {
+        try {
+          Object.defineProperty(screen, 'colorDepth', { get: function() { return ${colorDepth}; }, configurable: true });
+          Object.defineProperty(screen, 'pixelDepth', { get: function() { return ${colorDepth}; }, configurable: true });
+        } catch(e) {}
       })();
 
       // ═══ 5.3 Font Enumeration Protection ═══

--- a/src/stealth/tests/manager.test.ts
+++ b/src/stealth/tests/manager.test.ts
@@ -309,6 +309,11 @@ describe('stealth-ua platform adapters', () => {
           "platformVersion": "15.3.0",
           "uaFullVersion": "132.0.6834.160",
         },
+        "fingerprint": {
+          "colorDepth": 30,
+          "webglRenderer": "ANGLE (Apple, Apple M1, OpenGL 4.1)",
+          "webglVendor": "Google Inc. (Apple)",
+        },
         "requestHeaders": {
           "platform": ""macOS"",
         },
@@ -360,6 +365,11 @@ describe('stealth-ua platform adapters', () => {
           "platform": "Windows",
           "platformVersion": "15.0.0",
           "uaFullVersion": "132.0.6834.160",
+        },
+        "fingerprint": {
+          "colorDepth": 24,
+          "webglRenderer": "ANGLE (Intel, Intel(R) UHD Graphics 630 Direct3D11 vs_5_0 ps_5_0, D3D11)",
+          "webglVendor": "Google Inc. (Intel)",
         },
         "requestHeaders": {
           "platform": ""Windows"",
@@ -570,6 +580,43 @@ describe('getStealthScript() — timing protection', () => {
     const script = StealthManager.getStealthScript('seed');
     expect(script).not.toMatch(/Date\.now\s*=\s*function/);
     expect(script).not.toMatch(/origDateNow/);
+  });
+});
+
+describe('getStealthScript() — OS persona fingerprint consistency', () => {
+  // Regression guard: WebGL renderer and screen colour depth must be driven by
+  // the OS persona, not hardcoded. A Windows UA that reports a macOS "Apple M1"
+  // GPU (or 30-bit colour) is a cross-checkable automation tell.
+  it('injects the Windows profile GPU and colour depth for a Windows persona', () => {
+    const win = createWindowsStealthUaAdapter();
+    const script = StealthManager.getStealthScript('seed', undefined, win);
+    expect(script).toContain('Intel(R) UHD Graphics 630');
+    expect(script).toContain('Google Inc. (Intel)');
+    expect(script).toContain('return 24'); // screen.colorDepth
+    // Must NOT leak the macOS GPU into a Windows persona
+    expect(script).not.toContain('Apple M1');
+    expect(script).not.toContain('Google Inc. (Apple)');
+  });
+
+  it('injects the macOS profile GPU and colour depth for a macOS persona', () => {
+    const mac = createDarwinStealthUaAdapter();
+    const script = StealthManager.getStealthScript('seed', undefined, mac);
+    expect(script).toContain('Apple M1');
+    expect(script).toContain('Google Inc. (Apple)');
+    expect(script).toContain('return 30'); // screen.colorDepth
+    expect(script).not.toContain('Intel(R) UHD Graphics 630');
+  });
+
+  it('keeps the WebGL/colour-depth persona aligned with the User-Agent OS', () => {
+    // The one invariant that matters: whatever OS the UA claims, the GPU and
+    // colour depth agree with it.
+    for (const ua of [createWindowsStealthUaAdapter(), createDarwinStealthUaAdapter()]) {
+      const profile = ua.getProfile('132.0.0.0');
+      const script = StealthManager.getStealthScript('seed', undefined, ua);
+      expect(script).toContain(profile.fingerprint.webglRenderer);
+      expect(script).toContain(profile.fingerprint.webglVendor);
+      expect(script).toContain(`return ${profile.fingerprint.colorDepth}`);
+    }
   });
 });
 


### PR DESCRIPTION
## What does this PR do?

Fixes a stealth fingerprint inconsistency found by live-testing the new Electron 41 build against bot.sannysoft.com: the browser presented a **split OS persona** — half Windows, half macOS — which a detection engine can cross-check to identify automation (the "unique/inconsistent fingerprint" AGENTS.md calls game-over).

### Root cause (three sources disagreed about the OS)
- **WebGL** `UNMASKED_VENDOR/RENDERER` were **hardcoded to Apple M1** in the injected stealth script, regardless of the active platform profile.
- **`screen.colorDepth` / `pixelDepth`** were never patched, so the host display's real depth (30-bit, from the macOS host of this Windows VM) leaked through.
- **`getStealthScript()` / `getEarlyScript()` defaulted their adapter to Darwin**, so the no-arg call sites (`main.ts` web-contents-created, `headless`, `watch`) injected **macOS** client hints while `session.setUserAgent()` used the platform-correct **Windows** UA.

Net effect on the Windows build: UA + `navigator.platform` said Windows, but WebGL renderer, colour depth, and `navigator.userAgentData.platform` said macOS.

### The fix (`model-the-domain`: one source of truth)
- Added a `fingerprint` (`webglVendor`, `webglRenderer`, `colorDepth`) to `StealthUaProfile`, set per-OS in the Darwin/Windows adapters. The injected script now reads WebGL and colour depth **from the profile**, so UA, client hints, WebGL, and screen can no longer diverge.
- Static `getStealthScript`/`getEarlyScript` defaults now use `selectPlatform().stealthUa`, fixing every no-arg call site at once.
- **Persona strategy (product-owner decision): persona follows host OS.** Windows host → Intel UHD 630 / Direct3D11 / 24-bit; macOS host → Apple M1 / 30-bit.

## How was it tested?

- [x] `npm run verify` — compile + lint + **3024 tests passed** + consistency OK. 3 new regression tests assert WebGL/colour-depth track the profile and that neither OS persona leaks the other's GPU.
- [x] Manual app check done — rebuilt, restarted, and re-ran bot.sannysoft.com live via the HTTP API. After the fix, `navigator.userAgent`, `navigator.platform`, `navigator.userAgentData.platform`, WebGL vendor (`Google Inc. (Intel)`), WebGL renderer (`Intel UHD 630 Direct3D11`), and `screen.colorDepth` (24) **all consistently report Windows**.

## Platform impact

- [x] macOS behavior preserved or not affected — Darwin profile keeps Apple M1 / 30-bit (now sourced from the profile instead of hardcoded); macOS persona unchanged in value
- [x] Windows impact checked and documented — this is the platform that was broken; now consistent
- [x] Linux impact checked or marked not applicable — Linux stealth adapter is separate/partial; unchanged
- [ ] `docs/platform-support.md` updated — no capability status changed
- [x] No new `process.platform` branch outside the platform adapter layer — persona logic stays in the platform adapters
- [x] No Unix-only shell syntax added to `package.json` scripts

## Notes

- **Security-sensitive (stealth):** this changes the injected fingerprint. Reviewed for value-equivalence on macOS (unchanged) and consistency on Windows (fixed).
- This is a `fix:` — a **patch bump (1.11.0 → 1.11.1)** is due on merge to main (left unbumped on the branch to keep `check-consistency` green across README/PROJECT/docs; the main-side flow owns version propagation).
- **Known remaining gap (out of scope, pre-existing):** the OOPIF early script deliberately omits WebGL masking (GPU readback IPC crashes sandboxed Cloudflare Turnstile frames), so inside those cross-origin frames the real GPU is still visible. Worth a separate, careful look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)