### PR TITLE
fix: address bar no longer fights the user (nav clobber + autocomplete re-fill)

### DIFF
--- a/shell/js/tabs.js
+++ b/shell/js/tabs.js
@@ -247,7 +247,9 @@
         }
       }
 
-      if (data.url && tabId === activeTabId) {
+      // Reflect the active tab's live URL — but never while the user is typing
+      // in the address bar, or an in-flight navigation would clobber their input.
+      if (data.url && tabId === activeTabId && document.activeElement !== urlBar) {
         urlBar.value = data.url;
       }
 

--- a/shell/js/url-autocomplete.js
+++ b/shell/js/url-autocomplete.js
@@ -119,7 +119,19 @@
       );
       if (!res.ok) return;
       const data = await res.json();
-      const results = (data.results || []).slice(0, MAX_RESULTS);
+
+      // Canonicalise and de-duplicate: many history rows collapse to the same
+      // clean URL once tracking query strings are stripped. Keep the first
+      // (highest-ranked) of each.
+      const seen = new Set();
+      const results = [];
+      for (const r of (data.results || [])) {
+        const curl = cleanUrl(r.url);
+        if (!curl || seen.has(curl)) continue;
+        seen.add(curl);
+        results.push({ ...r, url: curl });
+        if (results.length >= MAX_RESULTS) break;
+      }
 
       if (results.length === 0) {
         close();
@@ -153,11 +165,11 @@
 
       const titleEl = document.createElement('div');
       titleEl.className = 'url-autocomplete-title';
-      titleEl.innerHTML = highlightMatch(item.title || item.url, lowerQuery);
+      titleEl.innerHTML = highlightMatch(item.title || displayUrl(item.url), lowerQuery);
 
       const urlEl = document.createElement('div');
       urlEl.className = 'url-autocomplete-url';
-      urlEl.innerHTML = highlightMatch(item.url, lowerQuery);
+      urlEl.innerHTML = highlightMatch(displayUrl(item.url), lowerQuery);
 
       el.appendChild(titleEl);
       el.appendChild(urlEl);
@@ -199,9 +211,28 @@
 
     // When navigating with arrows, show the selected URL in the input
     if (urlBar && items[index]) {
-      urlBar.value = items[index].url;
+      urlBar.value = displayUrl(items[index].url);
       urlBar.setSelectionRange(urlBar.value.length, urlBar.value.length);
     }
+  }
+
+  // Canonical form for a suggestion: drop the query string and fragment
+  // (usually tracking noise like ?referrer=...) but keep the meaningful path,
+  // so completions look like Chrome's clean suggestions instead of raw history
+  // URLs. Keeps the protocol so the value stays navigable.
+  function cleanUrl(rawUrl) {
+    try {
+      const u = new URL(rawUrl);
+      const path = u.pathname === '/' ? '' : u.pathname;
+      return u.origin + path;
+    } catch {
+      return String(rawUrl || '').split(/[?#]/)[0];
+    }
+  }
+
+  // Human-readable form for the dropdown / inline box: strip protocol and www.
+  function displayUrl(rawUrl) {
+    return String(rawUrl || '').replace(/^https?:\/\//, '').replace(/^www\./, '');
   }
 
   function applyInlineCompletion(urlBar, typed, topResult) {

--- a/shell/js/url-autocomplete.js
+++ b/shell/js/url-autocomplete.js
@@ -15,6 +15,7 @@
   let debounceTimer = null;
   let originalValue = '';  // what the user actually typed
   let isOpen = false;
+  let lastInputWasDeletion = false;  // suppress inline completion while deleting
 
   function init(urlBar, onNavigate) {
     dropdown = document.createElement('div');
@@ -38,8 +39,11 @@
       }
     });
 
-    urlBar.addEventListener('input', () => {
+    urlBar.addEventListener('input', (e) => {
       originalValue = urlBar.value;
+      // Backspace/Delete must not re-trigger inline completion, or the
+      // suggestion the user just removed reappears on the next keystroke.
+      lastInputWasDeletion = !!(e.inputType && e.inputType.startsWith('delete'));
       scheduleSearch(urlBar);
     });
 
@@ -125,7 +129,10 @@
       items = results;
       selectedIndex = -1;
       renderDropdown(query);
-      applyInlineCompletion(urlBar, query, results[0]);
+      // Still show the dropdown while deleting, but do not auto-fill the input.
+      if (!lastInputWasDeletion) {
+        applyInlineCompletion(urlBar, query, results[0]);
+      }
       isOpen = true;
     } catch (err) {
       if (err.name !== 'AbortError') {


### PR DESCRIPTION
## What does this PR do?

Makes the address bar stop fighting the user, across three related shell-renderer fixes.

### 1. Navigation no longer clobbers typed input (`shell/js/tabs.js`)
`baseUpdateTabMeta()` reflected the active tab's live URL into the address bar on **every** navigation event, unconditionally, overwriting what the user was typing (during redirects, background updates, the Cloudflare reroute, agent-driven navigations). **Fix:** guard with `document.activeElement !== urlBar` — reflect the tab URL only when the bar isn't focused/being edited, like real browsers. Tab-switch refresh is untouched.

### 2. Autocomplete no longer re-fills while deleting (`shell/js/url-autocomplete.js`)
Inline completion re-ran on every `input` event without distinguishing typing from deleting, so backspacing the highlighted completion re-inserted it instantly and the field couldn't be cleared. **Fix:** capture `InputEvent.inputType`; suppress `applyInlineCompletion` on deletions. The dropdown still renders; the input is no longer auto-filled — like Chrome's omnibox.

### 3. Suggestions are cleaned and de-duplicated (`shell/js/url-autocomplete.js`)
Suggestions were raw history URLs, so typing `nu.nl` inline-completed to `nu.nl/?referrer=https%3A%2F%2Fwww.google.com%2F` (a tracking query string), where Chrome suggests the clean `nu.nl`. **Fix:** `cleanUrl()` drops the query string + fragment (keeps origin + meaningful path); `displayUrl()` strips protocol + www for display. Results are canonicalised and de-duplicated by clean URL. Inline completion, the dropdown, and arrow-selection all use the clean form.

Together these deliver the intended Chrome-style behavior: a choice list while typing **plus** a clean inline completion that never fights you.

## How was it tested?

- [x] `npm run verify` — compile + lint + 3027 tests passed + consistency OK
- [x] Live via API against real history: `/history/search?q=nu.nl` returns `https://www.nu.nl/?referrer=...`; the clean+dedupe pipeline yields `nu.nl`.
- Note: shell renderer UI with no unit-test harness for these files; verified by code inspection, lint, live data, and manual use.

## Platform impact

- [x] macOS behavior preserved or not affected — pure renderer JS
- [x] Windows impact checked and documented — same
- [x] Linux impact checked or marked not applicable
- [ ] `docs/platform-support.md` updated — no capability changed
- [x] No new `process.platform` branch outside the platform adapter layer
- [x] No Unix-only shell syntax added to `package.json` scripts

## Notes

- Suggestion breadth is still limited by Tandem's local history (no server-side search-suggestion backend), so fewer entries than Chrome — but each is now clean. A richer suggestion source would be a separate feature.
- `fix:` — a patch bump is due on merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)