### PR TITLE
fix: never reopen a Cloudflare-challenged tab at the challenge script itself

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -50,6 +50,7 @@ import { selectPlatform } from './platform';
 import { CloudflarePolicyManager } from './cloudflare/policy-manager';
 import {
   CLOUDFLARE_CHALLENGE_SELECTORS,
+  chooseCloudflareRerouteTarget,
   getCloudflareNoTouchPartition,
   isCloudflareChallengeUrl,
   isCloudflareNoTouchPartition,
@@ -318,7 +319,10 @@ async function promoteTabToCloudflareNoTouchSession(webContentsId: number, prefe
     return;
   }
 
-  const targetUrl = preferredUrl || sourceTab.url || null;
+  // Never reopen pointing at a Cloudflare challenge sub-resource (e.g. the
+  // challenge-platform main.js the detector tripped on) — that lands the tab on
+  // the raw challenge script. Reopen at the tab's real destination page.
+  const targetUrl = chooseCloudflareRerouteTarget(sourceTab.url ?? null, preferredUrl);
   const targetPartition = targetUrl ? getCloudflareNoTouchPartition(targetUrl) : null;
   if (!targetUrl || !targetPartition) {
     return;

--- a/src/utils/cloudflare.ts
+++ b/src/utils/cloudflare.ts
@@ -84,6 +84,32 @@ export function isCloudflareChallengeUrl(rawValue: string): boolean {
   );
 }
 
+/**
+ * Choose the page URL to reopen a Cloudflare-challenged tab at, in the no-touch
+ * partition.
+ *
+ * The URL that tripped the detector (`preferredUrl`, i.e. the challenge-detected
+ * event's URL) is frequently a challenge *sub-resource* — the challenge-platform
+ * script (`/cdn-cgi/challenge-platform/.../main.js`) or an intermediate redirect
+ * — not the page the user is trying to reach. Reopening the tab at such a URL
+ * lands it on the raw challenge script instead of the destination page.
+ *
+ * Reopen at the tab's committed page URL first, fall back to the preferred URL,
+ * and never return a Cloudflare challenge URL. Returns null when no safe
+ * destination is available (caller should then not reroute).
+ */
+export function chooseCloudflareRerouteTarget(
+  tabUrl: string | null,
+  preferredUrl: string | null,
+): string | null {
+  for (const candidate of [tabUrl, preferredUrl]) {
+    if (candidate && !isCloudflareChallengeUrl(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
 export function responseHeadersContainCfClearance(responseHeaders: Record<string, string[]>): boolean {
   for (const [key, values] of Object.entries(responseHeaders)) {
     if (key.toLowerCase() !== 'set-cookie' || !Array.isArray(values)) {

--- a/src/utils/tests/cloudflare.test.ts
+++ b/src/utils/tests/cloudflare.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   CLOUDFLARE_CHALLENGE_SELECTORS,
   CLOUDFLARE_NO_TOUCH_PARTITION_PREFIX,
+  chooseCloudflareRerouteTarget,
   getCloudflareNoTouchPartition,
   getCloudflareNoTouchPartitionForOrigin,
   getOriginFromUrl,
@@ -60,5 +61,34 @@ describe('cloudflare utils', () => {
 
   it('exposes the selector list used for DOM probes', () => {
     expect(CLOUDFLARE_CHALLENGE_SELECTORS).toContain('iframe[src*="challenges.cloudflare.com"]');
+  });
+
+  describe('chooseCloudflareRerouteTarget', () => {
+    const page = 'https://www.g2.com/products/anthropic-claude/reviews';
+    const challengeScript = 'https://www.g2.com/cdn-cgi/challenge-platform/scripts/jsd/main.js';
+
+    it('prefers the tab page URL over the detector URL', () => {
+      expect(chooseCloudflareRerouteTarget(page, challengeScript)).toBe(page);
+    });
+
+    it('never returns a challenge sub-resource as the reopen target', () => {
+      // The classic bug: the detector tripped on the challenge script, so it
+      // arrived as preferredUrl. The tab page URL must win.
+      expect(chooseCloudflareRerouteTarget(page, challengeScript)).toBe(page);
+      // Even when the page URL is momentarily the challenge URL, fall through.
+      expect(chooseCloudflareRerouteTarget(challengeScript, page)).toBe(page);
+    });
+
+    it('falls back to the preferred URL when the tab URL is missing', () => {
+      expect(chooseCloudflareRerouteTarget(null, page)).toBe(page);
+    });
+
+    it('returns null when both candidates are challenge URLs (do not reroute)', () => {
+      expect(chooseCloudflareRerouteTarget(challengeScript, challengeScript)).toBeNull();
+    });
+
+    it('returns null when nothing usable is provided', () => {
+      expect(chooseCloudflareRerouteTarget(null, null)).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
## What does this PR do?

Fixes the Cloudflare challenge malfunction where the browser displayed the **raw challenge-platform `main.js` as a document** instead of the destination page.

### Root cause
When a challenge is detected, Tandem reopens the tab in a no-touch partition (stealth/security off) so the challenge solves natively. The reopen target was `preferredUrl || sourceTab.url`, where `preferredUrl` is the URL that tripped the detector. But `isCloudflareChallengeUrl()` matches the challenge-platform **script path**, so a subresource request for `/cdn-cgi/challenge-platform/.../main.js` fires `challenge-detected` with `event.url = main.js`. The tab was then reopened pointing at that script and rendered its source as a document.

### Fix
Add `chooseCloudflareRerouteTarget(tabUrl, preferredUrl)`: prefer the tab's committed page URL, fall back to the preferred URL, and **never return a Cloudflare challenge URL** (returns `null` → caller does not reroute). `promoteTabToCloudflareNoTouchSession` now uses it. The decision is a pure, unit-tested helper.

## How was it tested?

- [x] `npm run verify` — compile + lint + **3032 tests passed** + consistency OK. 6 new unit tests pin `chooseCloudflareRerouteTarget`, including "detector tripped on the script → page URL wins" and "both candidates are challenge URLs → null".
- [x] Manual app check done — live on g2.com after rebuild+restart: the challenge now resolves to the **real page** (title *Best AI Chatbots Software*, full review content) instead of the raw `main.js`. A clean single-open test leaves exactly one working tab, no leftover script tab.

## Platform impact

- [x] macOS behavior preserved or not affected — platform-independent main-process logic
- [x] Windows impact checked and documented — verified live on Windows 11
- [x] Linux impact checked or marked not applicable
- [ ] `docs/platform-support.md` updated — no capability changed
- [x] No new `process.platform` branch outside the platform adapter layer
- [x] No Unix-only shell syntax added to `package.json` scripts

## Notes

- **Security-sensitive (stealth/challenge handling):** changes which URL a challenged tab reopens at; does not change the stealth fingerprint or the no-touch mechanism itself.
- **Separate, deeper concern (not addressed here):** the no-touch partition (`persist:cf-human-<hash>`) is an isolated cookie jar, so clearance obtained there is separate from the user's real `persist:tandem` session. Whether/how that clearance should carry back to the logged-in session is worth its own investigation — flagged for follow-up.
- `fix:` — a patch bump is due on merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)