### PR TITLE
refactor: strip hardware-fingerprint spoofing; stealth only hides the AI/Electron

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@
 > Historical release summaries belong in `CHANGELOG.md`.
 > Architecture and product context belong in `PROJECT.md`.
 
-Last updated: May 5, 2026
+Last updated: August 16, 2026
 
 ## Purpose
 
@@ -85,6 +85,28 @@ Last updated: May 5, 2026
 
 ### Stealth and Browser Fidelity
 
+> Stealth philosophy (clarified): the stealth layer exists ONLY to hide that an
+> AI/Electron drives the browser, so sites see a normal Chrome used by a real
+> human. It must NOT spoof or block hardware fingerprinting — the real, stable
+> hardware fingerprint is fine and expected. Spoofing hardware both breaks
+> Cloudflare challenges and makes the fingerprint internally inconsistent (real
+> on challenge sites, fake elsewhere). The hardware-spoofing patches (WebGL,
+> canvas/audio noise, colour depth, CPU/RAM, font enumeration, timing) were
+> removed for this reason.
+
+- [ ] Solve Cloudflare challenges in-place in `persist:tandem` instead of
+      rerouting to the isolated `persist:cf-human-*` no-touch partition. The
+      no-touch reroute (`promoteTabToCloudflareNoTouchSession` in `src/main.ts`)
+      is kept as a **temporary fallback** until in-place solving is proven,
+      tested, and stable. Removing it also fixes the session-isolation problem
+      (logged-in CF sites fall back to a fresh partition) and the missing
+      cf_clearance sync back to the main session.
+- [ ] Retire the now-unused per-install stealth seed infrastructure
+      (`deriveStealthSeed`, `getPartitionSeed`, `partitionSeed`) — it only fed
+      the removed canvas/audio noise, so it is dead in production now.
+- [ ] Re-evaluate the spoofing items below against the clarified philosophy:
+      several (screen resolution, battery, geolocation, JA3) are hardware/
+      environment spoofing that the goal now argues *against*, not for.
 - [ ] Proxy support (SOCKS5 or HTTP, per-tab or global)
 - [ ] User-facing request interception and header rewrite rules
 - [ ] TLS / JA3 fingerprint matching

--- a/src/main.ts
+++ b/src/main.ts
@@ -555,8 +555,7 @@ async function createWindow(): Promise<BrowserWindow> {
   }, COOKIE_FLUSH_INTERVAL_MS);
 
   // Inject stealth script into all webviews via session preload
-  const stealthSeed = stealth.getPartitionSeed();
-  const stealthScript = StealthManager.getStealthScript(stealthSeed);
+  const stealthScript = StealthManager.getStealthScript();
   // Minimal early script for CDP OOPIF injection — omits canvas/audio/timing patches
   // that crash Cloudflare Turnstile's OOPIF (ctx.getImageData() triggers GPU IPC in
   // a sandboxed cross-origin frame, causing V8 crash in challenges.cloudflare.com)

--- a/src/platform/stealth-ua/index.ts
+++ b/src/platform/stealth-ua/index.ts
@@ -1,5 +1,5 @@
 import { NotImplementedError, type PlatformId } from '../errors';
-import type { StealthUaAdapter, StealthUaBrandVersion, StealthUaFingerprint, StealthUaProfile } from '../types';
+import type { StealthUaAdapter, StealthUaBrandVersion, StealthUaProfile } from '../types';
 
 function getChromeMajor(chromeVersion: string): string {
   return chromeVersion.split('.')[0];
@@ -31,7 +31,6 @@ function createProfile(
     bitness: string;
   },
   requestHeaders: { platform: string; platformVersion?: string },
-  fingerprint: StealthUaFingerprint,
 ): StealthUaProfile {
   const chromeMajor = getChromeMajor(chromeVersion);
   return {
@@ -51,58 +50,8 @@ function createProfile(
       fullVersionList: createFullVersionList(chromeVersion),
     },
     requestHeaders,
-    fingerprint,
   };
 }
-
-// Web-safe fonts present on both macOS and Windows. Listing them in both
-// personas is correct — they genuinely exist on both.
-const CROSS_PLATFORM_FONTS = [
-  'Arial', 'Arial Black', 'Comic Sans MS', 'Courier New', 'Georgia', 'Impact',
-  'Tahoma', 'Times New Roman', 'Trebuchet MS', 'Verdana',
-];
-
-// A macOS Chrome on Apple Silicon reports its GPU through ANGLE's Metal
-// backend, and Retina displays report 30-bit colour. The base M1 exposes 8
-// cores. These must travel with the macOS UA so the persona stays internally
-// consistent.
-const DARWIN_FINGERPRINT: StealthUaFingerprint = {
-  webglVendor: 'Google Inc. (Apple)',
-  webglRenderer: 'ANGLE (Apple, Apple M1, OpenGL 4.1)',
-  colorDepth: 30,
-  hardwareConcurrency: 8,
-  deviceMemory: 8,
-  fonts: [
-    ...CROSS_PLATFORM_FONTS,
-    'Courier', 'Helvetica', 'Helvetica Neue', 'Lucida Console', 'Lucida Grande',
-    'Lucida Sans Unicode', 'Monaco', 'Palatino', 'Palatino Linotype', 'Times',
-    'Apple Color Emoji', 'Apple SD Gothic Neo', 'Avenir', 'Avenir Next',
-    'Futura', 'Geneva', 'Gill Sans', 'Menlo', 'Optima', 'San Francisco',
-    'SF Pro', 'SF Mono', 'System Font', '-apple-system', 'BlinkMacSystemFont',
-  ],
-};
-
-// A Windows Chrome reports its GPU through ANGLE's Direct3D11 backend and a
-// 24-bit colour depth. Intel UHD 630 is one of the most common Windows GPUs,
-// so it blends in rather than forming a distinctive fingerprint; it pairs with
-// a mainstream 8-thread CPU, not the host's real core count. Fonts are the
-// standard Windows 10/11 set, including the Segoe UI signature.
-const WINDOWS_FINGERPRINT: StealthUaFingerprint = {
-  webglVendor: 'Google Inc. (Intel)',
-  webglRenderer: 'ANGLE (Intel, Intel(R) UHD Graphics 630 Direct3D11 vs_5_0 ps_5_0, D3D11)',
-  colorDepth: 24,
-  hardwareConcurrency: 8,
-  deviceMemory: 8,
-  fonts: [
-    ...CROSS_PLATFORM_FONTS,
-    'Bahnschrift', 'Calibri', 'Cambria', 'Cambria Math', 'Candara', 'Consolas',
-    'Constantia', 'Corbel', 'Ebrima', 'Franklin Gothic Medium', 'Gabriola',
-    'Gadugi', 'Lucida Console', 'Lucida Sans Unicode', 'Microsoft Sans Serif',
-    'MS Gothic', 'MV Boli', 'Palatino Linotype', 'Segoe Print', 'Segoe Script',
-    'Segoe UI', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Sylfaen', 'Symbol',
-    'Webdings', 'Wingdings', 'Yu Gothic',
-  ],
-};
 
 function createDarwinProfile(chromeVersion: string): StealthUaProfile {
   return createProfile(
@@ -115,7 +64,6 @@ function createDarwinProfile(chromeVersion: string): StealthUaProfile {
       bitness: '64',
     },
     { platform: '"macOS"' },
-    DARWIN_FINGERPRINT,
   );
 }
 
@@ -130,7 +78,6 @@ function createWindowsProfile(chromeVersion: string): StealthUaProfile {
       bitness: '64',
     },
     { platform: '"Windows"', platformVersion: '"15.0.0"' },
-    WINDOWS_FINGERPRINT,
   );
 }
 

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -127,41 +127,10 @@ export interface StealthUaRequestHeaders {
   platformVersion?: string;
 }
 
-/**
- * OS-specific fingerprint surfaces that must match the UA persona. These are
- * spoofed in the page (WebGL debug renderer info, screen colour depth) and, if
- * they disagree with the User-Agent / client hints, become a cross-checkable
- * automation tell. Keeping them on the profile makes the persona a single
- * source of truth so UA, client hints, WebGL, and screen can never diverge.
- */
-export interface StealthUaFingerprint {
-  /** UNMASKED_VENDOR_WEBGL (0x9245) value. */
-  webglVendor: string;
-  /** UNMASKED_RENDERER_WEBGL (0x9246) value. */
-  webglRenderer: string;
-  /** screen.colorDepth / screen.pixelDepth (Windows Chrome = 24, macOS = 30). */
-  colorDepth: number;
-  /**
-   * navigator.hardwareConcurrency. Must stay plausible for the GPU tier: a
-   * mainstream integrated-GPU machine reports ~4-8 cores, not the host's real
-   * count (which, in a VM, can betray the host and contradict the persona).
-   */
-  hardwareConcurrency: number;
-  /** navigator.deviceMemory (GB, quantised: 0.25/0.5/1/2/4/8). */
-  deviceMemory: number;
-  /**
-   * Fonts the OS is allowed to expose via document.fonts.check. Must be the
-   * host OS's real font set — a Windows persona that reports macOS-only fonts
-   * (or lacks Segoe UI) is a cross-checkable tell.
-   */
-  fonts: string[];
-}
-
 export interface StealthUaProfile {
   userAgent: string;
   chromeVersion: string;
   chromeMajor: string;
   clientHints: StealthUaClientHints;
   requestHeaders: StealthUaRequestHeaders;
-  fingerprint: StealthUaFingerprint;
 }

--- a/src/stealth/manager.ts
+++ b/src/stealth/manager.ts
@@ -132,7 +132,6 @@ export class StealthManager {
    */
   private async writeAndRegisterPreload(cloudflarePolicySyncChannel?: string): Promise<void> {
     const stealthScript = StealthManager.getStealthScript(
-      this.partitionSeed,
       this.uaProfile.chromeVersion,
       this.stealthUa,
     );
@@ -390,239 +389,27 @@ export class StealthManager {
    * @param seed - Deterministic seed for consistent noise per session
    */
   static getStealthScript(
-    seed: string = 'tandem-default-seed',
     chromeVersion: string = process.versions.chrome,
     stealthUa: StealthUaAdapter = selectPlatform().stealthUa,
   ): string {
     const profile = stealthUa.getProfile(chromeVersion);
     const brands = JSON.stringify(profile.clientHints.brands);
     const fullVersionList = JSON.stringify(profile.clientHints.fullVersionList);
-    const webglVendor = JSON.stringify(profile.fingerprint.webglVendor);
-    const webglRenderer = JSON.stringify(profile.fingerprint.webglRenderer);
-    const colorDepth = JSON.stringify(profile.fingerprint.colorDepth);
-    const hardwareConcurrency = JSON.stringify(profile.fingerprint.hardwareConcurrency);
-    const deviceMemory = JSON.stringify(profile.fingerprint.deviceMemory);
-    const fonts = JSON.stringify(profile.fingerprint.fonts);
     return `
-      // ═══ All stealth patches in one IIFE — no globals leaked to window ═══
+      // ═══ Make Tandem look like a normal Chrome — nothing more ═══
+      // The ONLY goal is to hide that an AI/Electron drives the browser, never to
+      // spoof or block hardware fingerprinting. Real WebGL, canvas, audio, fonts,
+      // colour depth, CPU/memory and timing are left completely untouched, so the
+      // page sees a real, stable, human fingerprint. We override only the signals
+      // that would reveal automation (webdriver), Electron (window.process/require,
+      // the UA brands), or a non-Chrome runtime (missing window.chrome).
+      //
       // Idempotency guard: both the session preload and the dom-ready injection
       // run this script. The Symbol key is invisible to page JS (not enumerable).
       (function() {
         var _appliedSym = Symbol.for('__tandem_stealth_v1');
         if (window[_appliedSym]) return;
         Object.defineProperty(window, _appliedSym, { value: 1, configurable: false, writable: false, enumerable: false });
-        // Seeded PRNG (mulberry32) — consistent noise per session
-        var __seed = 0;
-        var seedStr = '${seed}';
-        for (var i = 0; i < seedStr.length; i++) {
-          __seed = ((__seed << 5) - __seed + seedStr.charCodeAt(i)) | 0;
-        }
-        function mulberry32(s) {
-          return function() {
-            s |= 0; s = s + 0x6D2B79F5 | 0;
-            var t = Math.imul(s ^ s >>> 15, 1 | s);
-            t = t + Math.imul(t ^ t >>> 7, 61 | t) ^ t;
-            return ((t ^ t >>> 14) >>> 0) / 4294967296;
-          };
-        }
-        var __rng = mulberry32(__seed);
-        // Noise helper: returns integer in [-range, +range] — stays in closure, NOT on window
-        function __noise(range) { return Math.floor(__rng() * (range * 2 + 1)) - range; }
-
-      // ═══ 5.1 Canvas Fingerprint Protection ═══
-      (function() {
-        var origToDataURL = HTMLCanvasElement.prototype.toDataURL;
-        var origToBlob = HTMLCanvasElement.prototype.toBlob;
-
-        function addCanvasNoise(canvas) {
-          try {
-            var ctx = canvas.getContext('2d');
-            if (!ctx) return;
-            var w = canvas.width, h = canvas.height;
-            if (w === 0 || h === 0 || w > 1024 || h > 1024) return; // skip huge canvases
-            var imageData = ctx.getImageData(0, 0, w, h);
-            var data = imageData.data;
-            // Add subtle noise (±2 per channel) using seeded PRNG
-            for (var i = 0; i < data.length; i += 4) {
-              data[i]     = Math.max(0, Math.min(255, data[i]     + __noise(2)));
-              data[i + 1] = Math.max(0, Math.min(255, data[i + 1] + __noise(2)));
-              data[i + 2] = Math.max(0, Math.min(255, data[i + 2] + __noise(2)));
-              // Alpha unchanged
-            }
-            ctx.putImageData(imageData, 0, 0);
-          } catch(e) { /* cross-origin or other issues — silently skip */ }
-        }
-
-        HTMLCanvasElement.prototype.toDataURL = function() {
-          addCanvasNoise(this);
-          return origToDataURL.apply(this, arguments);
-        };
-
-        HTMLCanvasElement.prototype.toBlob = function() {
-          addCanvasNoise(this);
-          return origToBlob.apply(this, arguments);
-        };
-      })();
-
-      // ═══ 5.2 WebGL Fingerprint Masking ═══
-      (function() {
-        var getParamOrig = WebGLRenderingContext.prototype.getParameter;
-        var debugExt = null;
-
-        WebGLRenderingContext.prototype.getParameter = function(param) {
-          // UNMASKED_VENDOR_WEBGL (0x9245) and UNMASKED_RENDERER_WEBGL (0x9246)
-          // These come from the WEBGL_debug_renderer_info extension. Values come
-          // from the OS persona so they match the User-Agent (a Windows UA with a
-          // macOS GPU string is a cross-checkable automation tell).
-          if (param === 0x9245) return ${webglVendor};
-          if (param === 0x9246) return ${webglRenderer};
-          return getParamOrig.call(this, param);
-        };
-
-        // Also patch WebGL2 if available
-        if (typeof WebGL2RenderingContext !== 'undefined') {
-          var getParam2Orig = WebGL2RenderingContext.prototype.getParameter;
-          WebGL2RenderingContext.prototype.getParameter = function(param) {
-            if (param === 0x9245) return ${webglVendor};
-            if (param === 0x9246) return ${webglRenderer};
-            return getParam2Orig.call(this, param);
-          };
-        }
-
-        // Override getSupportedExtensions to return standard Chrome set
-        var stdExtensions = [
-          'ANGLE_instanced_arrays', 'EXT_blend_minmax', 'EXT_color_buffer_half_float',
-          'EXT_disjoint_timer_query', 'EXT_float_blend', 'EXT_frag_depth',
-          'EXT_shader_texture_lod', 'EXT_texture_compression_bptc',
-          'EXT_texture_compression_rgtc', 'EXT_texture_filter_anisotropic',
-          'EXT_sRGB', 'KHR_parallel_shader_compile', 'OES_element_index_uint',
-          'OES_fbo_render_mipmap', 'OES_standard_derivatives', 'OES_texture_float',
-          'OES_texture_float_linear', 'OES_texture_half_float',
-          'OES_texture_half_float_linear', 'OES_vertex_array_object',
-          'WEBGL_color_buffer_float', 'WEBGL_compressed_texture_s3tc',
-          'WEBGL_compressed_texture_s3tc_srgb', 'WEBGL_debug_renderer_info',
-          'WEBGL_debug_shaders', 'WEBGL_depth_texture', 'WEBGL_draw_buffers',
-          'WEBGL_lose_context', 'WEBGL_multi_draw'
-        ];
-        WebGLRenderingContext.prototype.getSupportedExtensions = function() { return stdExtensions.slice(); };
-        if (typeof WebGL2RenderingContext !== 'undefined') {
-          WebGL2RenderingContext.prototype.getSupportedExtensions = function() { return stdExtensions.slice(); };
-        }
-      })();
-
-      // ═══ 5.2b Screen colour depth (match OS persona) ═══
-      // Windows Chrome reports 24-bit colour, macOS Retina reports 30-bit. Left
-      // unpatched, the host display's real depth leaks through and can contradict
-      // the User-Agent persona.
-      (function() {
-        try {
-          Object.defineProperty(screen, 'colorDepth', { get: function() { return ${colorDepth}; }, configurable: true });
-          Object.defineProperty(screen, 'pixelDepth', { get: function() { return ${colorDepth}; }, configurable: true });
-        } catch(e) {}
-      })();
-
-      // ═══ 5.2c CPU / memory (match OS persona) ═══
-      // The host's real core count and RAM leak through untouched and can
-      // contradict the persona (e.g. 32 cores behind a mainstream integrated
-      // GPU). Pin them to values plausible for the persona's hardware tier.
-      (function() {
-        try {
-          Object.defineProperty(navigator, 'hardwareConcurrency', { get: function() { return ${hardwareConcurrency}; }, configurable: true });
-        } catch(e) {}
-        // Always define deviceMemory: real desktop Chrome exposes it on every
-        // origin, but this Chromium build omits it on some — leaving that gap
-        // is itself a tell, so pin it to the persona value everywhere.
-        try {
-          Object.defineProperty(navigator, 'deviceMemory', { get: function() { return ${deviceMemory}; }, configurable: true });
-        } catch(e) {}
-      })();
-
-      // ═══ 5.3 Font Enumeration Protection ═══
-      (function() {
-        // Font whitelist comes from the OS persona so each platform only
-        // reports fonts it genuinely ships, never the other OS's set.
-        var standardFonts = ${fonts};
-        var standardFontsLower = standardFonts.map(function(f) { return f.toLowerCase(); });
-
-        if (document.fonts && document.fonts.check) {
-          var origCheck = document.fonts.check.bind(document.fonts);
-          document.fonts.check = function(font, text) {
-            // Extract font family from CSS font shorthand — last part after size
-            var parts = font.split(/\\s+/);
-            var family = parts.length > 1 ? parts.slice(1).join(' ') : parts[0];
-            family = family.replace(/['"]/g, '').trim();
-            // Allow standard fonts, block exotic ones
-            if (standardFontsLower.indexOf(family.toLowerCase()) === -1) {
-              return false;
-            }
-            return origCheck(font, text);
-          };
-        }
-      })();
-
-      // ═══ 5.4 Audio Fingerprint Protection ═══
-      (function() {
-        var OrigAudioContext = window.AudioContext || window.webkitAudioContext;
-        var OrigOfflineAudioContext = window.OfflineAudioContext;
-
-        if (OrigAudioContext) {
-          var origCreateOscillator = OrigAudioContext.prototype.createOscillator;
-          var origCreateDynamicsCompressor = OrigAudioContext.prototype.createDynamicsCompressor;
-
-          // Patch getFloatFrequencyData / getFloatTimeDomainData to add noise
-          var origGetFloatFreq = AnalyserNode.prototype.getFloatFrequencyData;
-          AnalyserNode.prototype.getFloatFrequencyData = function(array) {
-            origGetFloatFreq.call(this, array);
-            for (var i = 0; i < array.length; i++) {
-              array[i] += __noise(1) * 0.001;
-            }
-          };
-
-          var origGetFloatTime = AnalyserNode.prototype.getFloatTimeDomainData;
-          AnalyserNode.prototype.getFloatTimeDomainData = function(array) {
-            origGetFloatTime.call(this, array);
-            for (var i = 0; i < array.length; i++) {
-              array[i] += __noise(1) * 0.0001;
-            }
-          };
-        }
-
-        // Patch OfflineAudioContext.startRendering to add subtle noise to rendered buffer
-        if (OrigOfflineAudioContext) {
-          var origStartRendering = OrigOfflineAudioContext.prototype.startRendering;
-          OrigOfflineAudioContext.prototype.startRendering = function() {
-            return origStartRendering.call(this).then(function(buffer) {
-              try {
-                for (var ch = 0; ch < buffer.numberOfChannels; ch++) {
-                  var data = buffer.getChannelData(ch);
-                  for (var i = 0; i < data.length; i++) {
-                    data[i] += __noise(1) * 0.0001;
-                  }
-                }
-              } catch(e) { /* ignore */ }
-              return buffer;
-            });
-          };
-        }
-      })();
-
-      // ═══ 5.5 Timing Protection ═══
-      (function() {
-        // Reduce performance.now() precision to 100μs (like Firefox).
-        // This is the API where modern timing-based fingerprinting
-        // actually happens, and Firefox ships this exact behaviour, so
-        // it is a known legitimate browser pattern.
-        var origPerfNow = performance.now.bind(performance);
-        performance.now = function() {
-          return Math.round(origPerfNow() * 10) / 10; // 100μs precision
-        };
-
-        // Note: we deliberately do NOT jitter Date.now. Real Chrome
-        // returns the same millisecond for back-to-back calls; adding
-        // +/-1ms noise makes every t1=Date.now(); t2=Date.now() differ
-        // consistently, which is itself a "not real Chrome" fingerprint.
-        // performance.now() above is the right place for timing defense.
-      })();
 
       // Hide webdriver flag
       Object.defineProperty(navigator, 'webdriver', { get: () => false });

--- a/src/stealth/tests/manager.test.ts
+++ b/src/stealth/tests/manager.test.ts
@@ -309,50 +309,6 @@ describe('stealth-ua platform adapters', () => {
           "platformVersion": "15.3.0",
           "uaFullVersion": "132.0.6834.160",
         },
-        "fingerprint": {
-          "colorDepth": 30,
-          "deviceMemory": 8,
-          "fonts": [
-            "Arial",
-            "Arial Black",
-            "Comic Sans MS",
-            "Courier New",
-            "Georgia",
-            "Impact",
-            "Tahoma",
-            "Times New Roman",
-            "Trebuchet MS",
-            "Verdana",
-            "Courier",
-            "Helvetica",
-            "Helvetica Neue",
-            "Lucida Console",
-            "Lucida Grande",
-            "Lucida Sans Unicode",
-            "Monaco",
-            "Palatino",
-            "Palatino Linotype",
-            "Times",
-            "Apple Color Emoji",
-            "Apple SD Gothic Neo",
-            "Avenir",
-            "Avenir Next",
-            "Futura",
-            "Geneva",
-            "Gill Sans",
-            "Menlo",
-            "Optima",
-            "San Francisco",
-            "SF Pro",
-            "SF Mono",
-            "System Font",
-            "-apple-system",
-            "BlinkMacSystemFont",
-          ],
-          "hardwareConcurrency": 8,
-          "webglRenderer": "ANGLE (Apple, Apple M1, OpenGL 4.1)",
-          "webglVendor": "Google Inc. (Apple)",
-        },
         "requestHeaders": {
           "platform": ""macOS"",
         },
@@ -404,53 +360,6 @@ describe('stealth-ua platform adapters', () => {
           "platform": "Windows",
           "platformVersion": "15.0.0",
           "uaFullVersion": "132.0.6834.160",
-        },
-        "fingerprint": {
-          "colorDepth": 24,
-          "deviceMemory": 8,
-          "fonts": [
-            "Arial",
-            "Arial Black",
-            "Comic Sans MS",
-            "Courier New",
-            "Georgia",
-            "Impact",
-            "Tahoma",
-            "Times New Roman",
-            "Trebuchet MS",
-            "Verdana",
-            "Bahnschrift",
-            "Calibri",
-            "Cambria",
-            "Cambria Math",
-            "Candara",
-            "Consolas",
-            "Constantia",
-            "Corbel",
-            "Ebrima",
-            "Franklin Gothic Medium",
-            "Gabriola",
-            "Gadugi",
-            "Lucida Console",
-            "Lucida Sans Unicode",
-            "Microsoft Sans Serif",
-            "MS Gothic",
-            "MV Boli",
-            "Palatino Linotype",
-            "Segoe Print",
-            "Segoe Script",
-            "Segoe UI",
-            "Segoe UI Emoji",
-            "Segoe UI Symbol",
-            "Sylfaen",
-            "Symbol",
-            "Webdings",
-            "Wingdings",
-            "Yu Gothic",
-          ],
-          "hardwareConcurrency": 8,
-          "webglRenderer": "ANGLE (Intel, Intel(R) UHD Graphics 630 Direct3D11 vs_5_0 ps_5_0, D3D11)",
-          "webglVendor": "Google Inc. (Intel)",
         },
         "requestHeaders": {
           "platform": ""Windows"",
@@ -645,88 +554,52 @@ describe('registerWith() — Sec-CH-UA client-hints injection', () => {
   });
 });
 
-describe('getStealthScript() — timing protection', () => {
-  it('rounds performance.now to 100μs (Firefox parity)', () => {
-    const script = StealthManager.getStealthScript('seed');
-    expect(script).toContain('performance.now = function');
-    expect(script).toContain('Math.round(origPerfNow() * 10) / 10');
-  });
+describe('getStealthScript() — no fingerprinting tricks (real fingerprint only)', () => {
+  // The stealth layer must ONLY hide automation/Electron, never spoof or block
+  // hardware fingerprinting. If any of these come back, the browser starts lying
+  // about hardware again — which both breaks Cloudflare challenges and makes the
+  // fingerprint internally inconsistent (real GPU on some sites, fake on others).
 
-  it('does NOT patch Date.now — real Chrome returns the same ms for back-to-back calls', () => {
-    // Regression guard: an earlier version added +/-1ms noise to every
-    // Date.now call. That made Tandem trivially distinguishable from real
-    // Chrome (two back-to-back calls in real Chrome always return the same
-    // value; jittered calls almost never do). Keep this test red if anyone
-    // re-introduces the jitter without updating the comment / test.
-    const script = StealthManager.getStealthScript('seed');
-    expect(script).not.toMatch(/Date\.now\s*=\s*function/);
-    expect(script).not.toMatch(/origDateNow/);
-  });
-});
-
-describe('getStealthScript() — OS persona fingerprint consistency', () => {
-  // Regression guard: WebGL renderer and screen colour depth must be driven by
-  // the OS persona, not hardcoded. A Windows UA that reports a macOS "Apple M1"
-  // GPU (or 30-bit colour) is a cross-checkable automation tell.
-  it('injects the Windows profile GPU and colour depth for a Windows persona', () => {
-    const win = createWindowsStealthUaAdapter();
-    const script = StealthManager.getStealthScript('seed', undefined, win);
-    expect(script).toContain('Intel(R) UHD Graphics 630');
-    expect(script).toContain('Google Inc. (Intel)');
-    expect(script).toContain('return 24'); // screen.colorDepth
-    // Must NOT leak the macOS GPU into a Windows persona
+  it('does not spoof WebGL renderer/vendor', () => {
+    const script = StealthManager.getStealthScript();
+    expect(script).not.toContain('UNMASKED_RENDERER');
+    expect(script).not.toContain('WebGLRenderingContext.prototype.getParameter');
     expect(script).not.toContain('Apple M1');
-    expect(script).not.toContain('Google Inc. (Apple)');
-  });
-
-  it('injects the macOS profile GPU and colour depth for a macOS persona', () => {
-    const mac = createDarwinStealthUaAdapter();
-    const script = StealthManager.getStealthScript('seed', undefined, mac);
-    expect(script).toContain('Apple M1');
-    expect(script).toContain('Google Inc. (Apple)');
-    expect(script).toContain('return 30'); // screen.colorDepth
     expect(script).not.toContain('Intel(R) UHD Graphics 630');
   });
 
-  it('keeps the WebGL/colour-depth persona aligned with the User-Agent OS', () => {
-    // The one invariant that matters: whatever OS the UA claims, the GPU and
-    // colour depth agree with it.
-    for (const ua of [createWindowsStealthUaAdapter(), createDarwinStealthUaAdapter()]) {
-      const profile = ua.getProfile('132.0.0.0');
-      const script = StealthManager.getStealthScript('seed', undefined, ua);
-      expect(script).toContain(profile.fingerprint.webglRenderer);
-      expect(script).toContain(profile.fingerprint.webglVendor);
-      expect(script).toContain(`return ${profile.fingerprint.colorDepth}`);
-    }
+  it('does not add canvas noise', () => {
+    const script = StealthManager.getStealthScript();
+    expect(script).not.toContain('getImageData');
+    expect(script).not.toContain('addCanvasNoise');
+    expect(script).not.toContain('toDataURL');
   });
 
-  it('exposes the Windows font signature (Segoe UI) and hides macOS-only fonts', () => {
-    const script = StealthManager.getStealthScript('seed', undefined, createWindowsStealthUaAdapter());
-    expect(script).toContain('Segoe UI');
-    expect(script).toContain('Calibri');
-    expect(script).toContain('Consolas');
-    // A Windows machine does not have these macOS-only fonts
-    expect(script).not.toContain('San Francisco');
-    expect(script).not.toContain('Helvetica Neue');
-    expect(script).not.toContain('-apple-system');
+  it('does not add audio noise', () => {
+    const script = StealthManager.getStealthScript();
+    expect(script).not.toContain('getFloatFrequencyData');
+    expect(script).not.toContain('OfflineAudioContext');
   });
 
-  it('exposes the macOS font signature and hides Windows-only fonts', () => {
-    const script = StealthManager.getStealthScript('seed', undefined, createDarwinStealthUaAdapter());
-    expect(script).toContain('San Francisco');
-    expect(script).toContain('Helvetica Neue');
-    expect(script).not.toContain('Segoe UI');
-    expect(script).not.toContain('Calibri');
+  it('does not spoof screen colour depth, CPU cores, or memory', () => {
+    const script = StealthManager.getStealthScript();
+    expect(script).not.toContain('colorDepth');
+    expect(script).not.toContain('hardwareConcurrency');
+    expect(script).not.toContain('deviceMemory');
   });
 
-  it('pins hardwareConcurrency and deviceMemory so the host core count cannot leak', () => {
-    for (const ua of [createWindowsStealthUaAdapter(), createDarwinStealthUaAdapter()]) {
-      const profile = ua.getProfile('132.0.0.0');
-      const script = StealthManager.getStealthScript('seed', undefined, ua);
-      expect(script).toContain('hardwareConcurrency');
-      expect(script).toContain(`return ${profile.fingerprint.hardwareConcurrency}`);
-      expect(script).toContain('deviceMemory');
-    }
+  it('does not block font enumeration', () => {
+    const script = StealthManager.getStealthScript();
+    expect(script).not.toContain('document.fonts');
+    expect(script).not.toContain('standardFonts');
+  });
+
+  it('does not patch timing (performance.now / Date.now)', () => {
+    // Firefox-like performance.now precision reduction is itself a "not real
+    // Chrome" signal, and Date.now jitter is trivially detectable.
+    const script = StealthManager.getStealthScript();
+    expect(script).not.toContain('performance.now =');
+    expect(script).not.toMatch(/Date\.now\s*=\s*function/);
   });
 });
 
@@ -735,21 +608,21 @@ describe('getStealthScript() — userAgentData GREASE brand consistency', () => 
     // Cloudflare cross-checks navigator.userAgentData.brands against the
     // sec-ch-ua HTTP header. The header handler preserves Chromium's natural
     // GREASE token ("Not(A:Brand" for Chrome 120+). The injected JS must match.
-    const script = StealthManager.getStealthScript('seed');
+    const script = StealthManager.getStealthScript();
     expect(script).toContain('Not(A:Brand');
     expect(script).not.toContain('Not_A Brand');
     expect(script).not.toContain('Not.A/Brand');
   });
 
   it('uses GREASE version "8", not the old "24"', () => {
-    const script = StealthManager.getStealthScript('seed');
+    const script = StealthManager.getStealthScript();
     // The __greaseVersion variable must be '8'
     expect(script).toContain("__greaseVersion = '8'");
     expect(script).not.toMatch(/__greaseVersion\s*=\s*'24'/);
   });
 
   it('fullVersionList GREASE version is pinned to Chrome 120+ "8.0.0.0"', () => {
-    const script = StealthManager.getStealthScript('seed');
+    const script = StealthManager.getStealthScript();
     // Should not hardcode the old wrong "24.0.0.0"
     expect(script).not.toContain('"24.0.0.0"');
     expect(script).not.toContain("'24.0.0.0'");
@@ -757,7 +630,7 @@ describe('getStealthScript() — userAgentData GREASE brand consistency', () => 
   });
 
   it('includes "Google Chrome" in all brand lists', () => {
-    const script = StealthManager.getStealthScript('seed');
+    const script = StealthManager.getStealthScript();
     // Must appear in both the low-entropy brands and the getHighEntropyValues response
     const chromeCount = (script.match(/Google Chrome/g) || []).length;
     // brands (1) + getHighEntropyValues brands (1) + fullVersionList (1) = min 3
@@ -766,7 +639,6 @@ describe('getStealthScript() — userAgentData GREASE brand consistency', () => 
 
   it('uses Windows userAgentData values when given the Windows stealth adapter', () => {
     const script = StealthManager.getStealthScript(
-      'seed',
       '132.0.6834.160',
       createWindowsStealthUaAdapter(),
     );


### PR DESCRIPTION
## What does this PR do?

Reframes the stealth layer to its actual purpose: **make the browser look like a normal Chrome used by a real human, hiding only that an AI/Electron drives it.** It must NOT spoof or block hardware fingerprinting — the real, stable hardware fingerprint is fine and expected.

### Removed from the injected stealth script
- WebGL vendor/renderer masking + `getSupportedExtensions` override
- Canvas fingerprint noise
- Audio fingerprint noise
- `screen.colorDepth` / `pixelDepth` spoofing
- `navigator.hardwareConcurrency` / `deviceMemory` spoofing
- Font-enumeration whitelist
- `performance.now` timing precision reduction
- The seeded PRNG that fed the noise, and the now-unused `seed` parameter

Also removed `StealthUaProfile.fingerprint` and the per-OS `FINGERPRINT` constants.

### Kept (the "look like normal Chrome, hide the AI" layer)
UA + client hints, `navigator.webdriver = false`, `window.process`/`require`/`module` removal, the `window.chrome` runtime/loadTimes/csi/app mock, plugins, languages, `navigator.userAgentData` brands, Permissions API, Notification.

### Why
The hardware-spoofing patches **both broke Cloudflare challenges** (so Tandem already skipped them on challenge-sensitive sites) **and made the fingerprint internally inconsistent** — a fake Intel GPU on ordinary sites but the real AMD GPU on challenge sites, cross-checkable across sites. Removing them yields one real, stable fingerprint everywhere.

This supersedes the *direction* of the earlier #247/#248 persona work: the right fix for the Windows-UA/Apple-GPU inconsistency was to stop faking the GPU, not to fake a consistent one.

The no-touch Cloudflare reroute is **kept as a temporary fallback** (tracked in `TODO.md`) until in-place challenge solving is proven, tested, and stable.

## How was it tested?

- [x] `npm run verify` — compile + lint + **3030 tests passed** + consistency OK. Added a regression guard asserting the full script contains no WebGL/canvas/audio/colour-depth/CPU/font/timing spoofing.
- [x] Manual app check done — live via API after rebuild+restart on bot.sannysoft.com (non-CF): now reports the **real** hardware (AMD Radeon 8060S, 30-bit, 32 cores) — consistent with what challenge sites already saw — while `webdriver=false`, `window.process`/`require` absent, and the UA reads Windows Chrome. The no-touch reroute fallback still passes g2.com (real page rendered).

## Platform impact

- [x] macOS behavior preserved or not affected — the macOS UA persona still exists; only hardware spoofing (which was platform-independent) is removed
- [x] Windows impact checked and documented — verified live on Windows 11
- [x] Linux impact checked or marked not applicable
- [ ] `docs/platform-support.md` updated — no capability status changed
- [x] No new `process.platform` branch outside the platform adapter layer
- [x] No Unix-only shell syntax added to `package.json` scripts

## Notes

- **Security-sensitive (stealth):** this is a deliberate reduction of the injected fingerprint surface. The critical anti-automation signals (webdriver, Electron giveaways, UA/brands) remain hidden; only hardware spoofing is removed.
- **Net −404 lines.** Follow-ups tracked in `TODO.md`: retire the now-dead per-install seed infrastructure, and solve Cloudflare challenges in-place (removing the no-touch isolation + fixing cf_clearance carry-back).
- `refactor:` — no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)