### PR TITLE
docs: drop the fingerprint-spoofing backlog from TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -83,16 +83,17 @@ Last updated: August 16, 2026
 - [ ] Documentation site
 - [ ] Firefox import
 
-### Stealth and Browser Fidelity
+### Stealth
 
-> Stealth philosophy (clarified): the stealth layer exists ONLY to hide that an
-> AI/Electron drives the browser, so sites see a normal Chrome used by a real
-> human. It must NOT spoof or block hardware fingerprinting — the real, stable
-> hardware fingerprint is fine and expected. Spoofing hardware both breaks
-> Cloudflare challenges and makes the fingerprint internally inconsistent (real
-> on challenge sites, fake elsewhere). The hardware-spoofing patches (WebGL,
-> canvas/audio noise, colour depth, CPU/RAM, font enumeration, timing) were
-> removed for this reason.
+> Stealth exists ONLY to hide that an AI/Electron drives the browser, so sites
+> see a normal Chrome used by a real human — which is allowed. It does NOT spoof
+> or block hardware fingerprinting: the real, stable fingerprint is fine and
+> expected. Do NOT add fingerprint-spoofing features — WebGL/canvas/audio masking,
+> colour depth, CPU/RAM, fonts, timing, screen-resolution spoofing, Battery API
+> masking, geolocation spoofing, JA3/TLS matching, and the like. That is an
+> unwinnable arms race that also makes the fingerprint internally inconsistent
+> (real on challenge sites, fake elsewhere). Such patches were removed
+> deliberately; keep them out.
 
 - [ ] Solve Cloudflare challenges in-place in `persist:tandem` instead of
       rerouting to the isolated `persist:cf-human-*` no-touch partition. The
@@ -104,15 +105,6 @@ Last updated: August 16, 2026
 - [ ] Retire the now-unused per-install stealth seed infrastructure
       (`deriveStealthSeed`, `getPartitionSeed`, `partitionSeed`) — it only fed
       the removed canvas/audio noise, so it is dead in production now.
-- [ ] Re-evaluate the spoofing items below against the clarified philosophy:
-      several (screen resolution, battery, geolocation, JA3) are hardware/
-      environment spoofing that the goal now argues *against*, not for.
-- [ ] Proxy support (SOCKS5 or HTTP, per-tab or global)
-- [ ] User-facing request interception and header rewrite rules
-- [ ] TLS / JA3 fingerprint matching
-- [ ] Screen resolution spoofing
-- [ ] Battery API masking
-- [ ] Geolocation spoofing
 
 ## Open Questions
 


### PR DESCRIPTION
## What does this PR do?

Makes it unambiguous — in the docs an AI assistant reads first — that Tandem's stealth layer is a **legitimate** feature, not bot-evasion. The old framing ("must stay invisible", "the website must not know", "never have a recognizable fingerprint — game over") reads like scraping/evasion and caused AI assistants to misjudge the project as shady and refuse to work on parts of the code. It was also factually stale: it described the hardware-fingerprint spoofing that was just removed.

### AGENTS.md — Anti-Detection Architecture
- New "Why this exists — intent and boundaries" section leading the block: one human, own machine, own accounts, human in the loop (captcha hand-off + dead-man switch); a person using their own browser with an assistant is an allowed use.
- Explicit non-goals: **not** scraping/mass automation; **not** hardware-fingerprint spoofing (real fingerprint is fine and left untouched); **not** cheating security challenges (solved natively / handed off).
- Replaced "Fundamental Rule: No Unique Fingerprint" with "Hide the AI, Not the Hardware" — matching the stealth refactor — and fixed the stale `performance.now` timing guidance.

### ARCHITECTURE.md + PROJECT.md
- Reframed the "Stealth" design constraint and the product intro to the same message: hide only the AI/Electron integration, never the hardware; it's a legitimate, allowed use.

### TODO.md
- Removed the fingerprint-spoofing wishlist (proxy, request interception, TLS/JA3, screen-resolution / battery / geolocation spoofing) — **none of it was ever built** (verified: no such code in `src/`). Renamed the section to "Stealth" with a guardrail note that lists these as features NOT to add. Kept the two real follow-ups (in-place Cloudflare solving; retiring the dead per-install seed infra).

## How was it tested?

- [x] `node scripts/check-consistency.js` — consistent
- Docs-only change.

## Platform impact

- [x] macOS behavior preserved or not affected — docs only
- [x] Windows impact checked and documented — docs only
- [x] Linux impact checked or marked not applicable
- [ ] `docs/platform-support.md` updated — no capability changed
- [x] No new `process.platform` branch outside the platform adapter layer
- [x] No Unix-only shell syntax added to `package.json` scripts

## Notes

`docs:` — no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)