### PR TITLE
chore: bump dev version to 1.11.4 and refresh TODO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to Tandem Browser will be documented in this file.
 
+## [v1.11.4] - 2026-08-16
+
+### Changed
+
+- **Stealth simplified to "hide the AI, not the hardware"** — removed all
+  hardware-fingerprint spoofing from the injected stealth scripts (WebGL,
+  canvas/audio noise, screen colour depth, CPU cores, device memory, font
+  enumeration, timing) and the dead per-install seed infrastructure behind it.
+  The layer now only hides that an AI/Electron drives the browser (webdriver,
+  `window.process`/`require`, UA, `window.chrome`); the real, stable hardware
+  fingerprint is left intact. Docs and the in-app Help page were reframed to
+  match, and the fingerprint-spoofing backlog was dropped from `TODO.md`.
+
+### Fixed
+
+- **Address bar** no longer overwrites what the user is typing during
+  navigation, and inline autocomplete no longer re-fills while deleting;
+  history suggestions are cleaned and de-duplicated (Chrome-style).
+- **Cloudflare challenge handling** — a challenged tab is no longer reopened at
+  the challenge-platform script itself, so it lands on the real destination
+  page instead of rendering the raw `main.js`.
+
+### Dependencies
+
+- Resolved the open Dependabot backlog (24 → 0 npm-audit findings), including
+  Electron 40 → 41.10.3 with better-sqlite3 12 → 13.
+
 ## Unreleased
 
 ### Security

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -35,7 +35,7 @@ The security layer exists because when an AI has access to your browser, your th
 Data stays local. Sessions are isolated. Nothing leaves the machine through Tandem Browser without going through a filter first.
 
 **GitHub:** `hydro13/tandem-browser`  
-**Current version:** `1.11.0`
+**Current version:** `1.11.4`
 **Repository status:** Public developer preview  
 **Started:** February 11, 2026
 

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ contributors, not yet a polished mass-user release.
 - Supported platform: Windows 11 x64
 - Secondary platform: Linux
 - Binaries: signed and notarized macOS Apple Silicon builds plus unsigned Windows x64 installer/portable builds on [GitHub Releases](https://github.com/hydro13/tandem-browser/releases), starting with Windows in v1.10.0
-- Current version: `1.11.0`
+- Current version: `1.11.4`
 - Package metadata: [package.json](package.json)
 
 ## Community

--- a/TODO.md
+++ b/TODO.md
@@ -14,12 +14,12 @@ Last updated: August 16, 2026
 
 ## Current Snapshot
 
-- Current app version: `1.11.0`
+- Current app version: `1.11.4`
 - MCP server: 257 tools (full API parity + awareness)
 - The codebase scope is larger than this backlog summary and includes major subsystems such as `sidebar`, `workspaces`, `pinboards`, `sync`, `headless`, and `sessions`.
 - Scheduled browsing already exists in baseline form via `WatchManager` and the `/watch/*` API routes.
 - Session isolation already exists in baseline form via `SessionManager` and the `/sessions/*` API routes.
-- `TODO.md` is the active engineering backlog; `docs/internal/ROADMAP.md` and `docs/internal/STATUS.md` are historical snapshots, not the day-to-day source of truth.
+- `TODO.md` is the active engineering backlog; release history lives in `CHANGELOG.md`.
 
 ## Current Priorities
 
@@ -51,7 +51,7 @@ Last updated: August 16, 2026
 
 ### Codebase Hygiene
 
-- [ ] Finish Cloudflare human mode phases 4-5 so challenge-sensitive tabs pause cleanly for the human and resume conservatively after `cf_clearance`; phase 3 now gates ScriptGuard and resource monitoring on Cloudflare tabs
+- [ ] Cloudflare human-in-the-loop: challenge-sensitive tabs should pause cleanly for the human and resume conservatively after `cf_clearance` (phase 3 already gates ScriptGuard and resource monitoring on Cloudflare tabs). NOTE: this was built on the no-touch reroute, which the **Stealth** section now treats as a temporary fallback pending in-place challenge solving — settle that architecture question first, since it changes where the pause/resume happens (the UX itself carries over either way).
 - [x] Make Wingman `openclaw` mode gateway-first for sends, sign a real OpenClaw device identity for the WebSocket handshake, and persist gateway replies into Tandem chat history so stock Tandem no longer depends on a local OpenClaw tandem-chat skill
 - [x] Add a built-in Tandem local Wingman chat backend so MCP/API agents can read and reply in the panel without requiring OpenClaw on the host, while keeping the OpenClaw gateway backend available when installed
 - [x] Split `src/main.ts` bootstrap and teardown wiring into dedicated `src/bootstrap/` modules so manager composition stops growing in one file

--- a/docs/index.html
+++ b/docs/index.html
@@ -325,7 +325,7 @@ footer a:hover{color:var(--text2)}
 </header>
 
 <div class="hero">
-<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v1.11.0</div>
+<div class="hero-label">Open source &middot; MIT license &middot; developer preview &middot; v1.11.4</div>
 <p class="hero-lead">Tandem Browser is the <strong>open-source, local-first browser for AI agents</strong> — where the AI lives inside your real browser session, sharing your tabs, cookies, and DOM, ready to ask for your help the moment it gets stuck.</p>
 <h1>The browser becomes a <em>programmable workspace</em> where human intent and AI capability meet.</h1>
 <p>Tandem Browser is built around a simple shift: the AI is not a sidebar talking <em>about</em> your browser, it is <em>inside</em> it. Same tabs, same cookies, same logged-in sessions, same page you are looking at right now. Reading the accessibility tree, watching the network, writing live styles, handing back to you when something needs a human. It turns the web that already exists into something agents can actually operate on — no per-site API, no RPA rig, no screenshot loop. The real browser, as a shared human-AI symbiotic runtime.</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tandem-browser",
-  "version": "1.11.0",
+  "version": "1.11.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tandem-browser",
-      "version": "1.11.0",
+      "version": "1.11.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandem-browser",
-  "version": "1.11.0",
+  "version": "1.11.4",
   "description": "Local-first Electron browser with a 257-tool MCP server, MCP/HTTP control surfaces, and built-in security controls",
   "main": "dist/main.js",
   "author": "Tandem Browser contributors",


### PR DESCRIPTION
## What does this PR do?

Two housekeeping items from the TODO freshness check.

### A — TODO freshness
- **Removed a dead reference**: the "Current Snapshot" pointed at `docs/internal/ROADMAP.md` / `STATUS.md` as historical snapshots, but that directory does not exist. Now points to `CHANGELOG.md` for release history.
- **Reworded the "Cloudflare human mode phases 4-5" item**: it was written on top of the no-touch reroute, which the **Stealth** section now treats as a *temporary fallback* pending in-place challenge solving. The item now flags that architecture question as the thing to settle first (the pause/resume UX carries over either way).
- (The "retire the per-install seed infrastructure" item was already removed when that work landed.)

### B — Version bump
Four `fix:` PRs shipped since 1.11.0 (#247, #248, #249, #250) but the version never moved (the auto-bump hook only fires on local `main` commits, not GitHub merges). Per the "each merged `fix:` bumps a patch" rule, the **dev version is now 1.11.4**, propagated through `package.json`, `package-lock.json`, and the consistency-guarded docs (README, PROJECT.md, docs/index.html) via `check-consistency --fix`, plus the TODO snapshot and a consolidated CHANGELOG entry.

**Download / GitHub-release links intentionally stay at `v1.11.0`** — that is the last actual binary release; 1.11.4 is the dev version only, and cutting a binary release is a separate deliberate step (AGENTS.md Release Policy). `check-consistency` correctly guards only the dev-version fields.

## How was it tested?

- [x] `node scripts/check-consistency.js` — all files consistent (v1.11.4, 257 tools)
- Docs/version-only change; no source code touched.

## Platform impact

- [x] macOS behavior preserved or not affected — docs/version only
- [x] Windows impact checked and documented — docs/version only
- [x] Linux impact checked or marked not applicable
- [ ] `docs/platform-support.md` updated — no capability changed
- [x] No new `process.platform` branch outside the platform adapter layer
- [x] No Unix-only shell syntax added to `package.json` scripts

## Notes

`chore:` — the version bump itself; does not trigger a further bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)